### PR TITLE
Add ripgrep-compatible CLI flags for drop-in replacement usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ tgrep "pattern" . -w              # whole word
 tgrep "pattern" . -v              # invert match
 tgrep "pattern" . -m 5            # max 5 matches per file
 tgrep "pattern" . -g "*.rs"       # glob filter
+tgrep "pattern" . -g "*.rs" -g "*.toml"  # multiple globs (OR)
 tgrep "pattern" . -t rust         # type filter
 tgrep "pattern" . -e "also_this"  # multiple patterns
 tgrep "pattern" . -A 3            # 3 lines after match
@@ -107,6 +108,10 @@ tgrep "pattern" . --vimgrep       # vim-compatible output
 tgrep "pattern" . --stats         # show query plan & timing
 tgrep "pattern" . --no-index      # brute-force (skip index)
 tgrep "pattern" . -U              # multiline matching
+tgrep "pattern" . -q              # quiet: exit code only
+tgrep "pattern" . -L              # files that DON'T match
+tgrep "pattern" . --no-filename   # suppress filenames
+tgrep "pattern" . -N              # suppress line numbers
 tgrep --files .                   # list searchable files
 tgrep --files -t rust .           # list Rust files only
 tgrep --type-list                 # show all file types
@@ -143,10 +148,13 @@ Server status for /src/my-monorepo
 | `-f, --file <FILE>` | Read patterns from file (one per line) |
 | `-U, --multiline` | Enable multiline matching |
 | `-n, --line-number` | Show line numbers (default: on) |
+| `-N, --no-line-number` | Suppress line numbers |
 | `-c, --count` | Print match count per file |
 | `-l, --files-with-matches` | Print only filenames |
+| `-L, --files-without-match` | Print files that do NOT match |
+| `-q, --quiet` | Suppress output; exit code only |
 | `-m, --max-count <N>` | Limit matches per file |
-| `-g, --glob <GLOB>` | Filter files by glob pattern |
+| `-g, --glob <GLOB>` | Filter files by glob pattern (repeatable) |
 | `-t, --type <TYPE>` | Filter by file type (`rust`, `py`, `js`, …) |
 | `--type-list` | Print all supported file types |
 | `--files` | List files that would be searched |
@@ -154,6 +162,8 @@ Server status for /src/my-monorepo
 | `-B, --before-context <N>` | Lines of context before match |
 | `-C, --context <N>` | Lines of context before and after |
 | `--heading / --no-heading` | Grouped vs flat output |
+| `-H, --with-filename` | Show filenames (default: on) |
+| `--no-filename` | Suppress filenames in output |
 | `--json` | JSON output (one object per line) |
 | `--vimgrep` | Vim-compatible `file:line:col:content` |
 | `--color auto/always/never` | Color mode control |

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -73,6 +73,10 @@ struct Cli {
     #[arg(short = 'l', long = "files-with-matches", global = true)]
     files_only: bool,
 
+    /// Print files that do NOT match the pattern.
+    #[arg(short = 'L', long = "files-without-match", global = true)]
+    files_without_match: bool,
+
     /// Print match count per file.
     #[arg(short = 'c', long = "count", global = true)]
     count: bool,
@@ -88,6 +92,10 @@ struct Cli {
     /// List files that would be searched (no search performed).
     #[arg(long = "files", global = true)]
     list_files: bool,
+
+    /// Suppress all output; exit code only (0 = match found, 1 = no match).
+    #[arg(short = 'q', long = "quiet", global = true)]
+    quiet: bool,
 
     // ── Filtering ────────────────────────────────────
     /// Filter files by glob pattern (can be specified multiple times).
@@ -118,6 +126,18 @@ struct Cli {
     /// Print the file name for each match (default behavior, ripgrep compatibility).
     #[arg(short = 'H', long = "with-filename", global = true)]
     with_filename: bool,
+
+    /// Suppress filenames in output.
+    #[arg(long = "no-filename", global = true)]
+    no_filename: bool,
+
+    /// Show line numbers (default behavior, ripgrep compatibility).
+    #[arg(short = 'n', long = "line-number", global = true)]
+    line_number: bool,
+
+    /// Suppress line numbers in output.
+    #[arg(short = 'N', long = "no-line-number", global = true)]
+    no_line_number: bool,
 
     // ── Output formatting ────────────────────────────
     /// Group matches by file with heading.
@@ -238,6 +258,7 @@ impl Cli {
             smart_case: self.smart_case,
             fixed_string: self.fixed_strings,
             files_only: self.files_only,
+            files_without_match: self.files_without_match,
             count: self.count,
             word_boundary: self.word_regexp,
             max_count: self.max_count,
@@ -259,6 +280,9 @@ impl Cli {
             multiline: self.multiline,
             no_ignore,
             hidden,
+            quiet: self.quiet,
+            no_filename: self.no_filename,
+            no_line_number: self.no_line_number,
         }
     }
 }

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -90,9 +90,9 @@ struct Cli {
     list_files: bool,
 
     // ── Filtering ────────────────────────────────────
-    /// Filter files by glob pattern.
-    #[arg(short = 'g', long = "glob", global = true)]
-    glob: Option<String>,
+    /// Filter files by glob pattern (can be specified multiple times).
+    #[arg(short = 'g', long = "glob", global = true, action = clap::ArgAction::Append)]
+    glob: Vec<String>,
 
     /// Filter files by type (e.g., rust, py, js). Use --type-list to see all.
     #[arg(short = 't', long = "type", global = true)]
@@ -114,6 +114,10 @@ struct Cli {
     /// Lines of context before and after each match.
     #[arg(short = 'C', long = "context", global = true)]
     context: Option<usize>,
+
+    /// Print the file name for each match (default behavior, ripgrep compatibility).
+    #[arg(short = 'H', long = "with-filename", global = true)]
+    with_filename: bool,
 
     // ── Output formatting ────────────────────────────
     /// Group matches by file with heading.

--- a/tgrep-cli/src/output.rs
+++ b/tgrep-cli/src/output.rs
@@ -54,6 +54,8 @@ pub struct OutputConfig {
     pub heading: Option<bool>,
     pub null: bool,
     pub trim: bool,
+    pub no_filename: bool,
+    pub no_line_number: bool,
 }
 
 impl OutputConfig {
@@ -68,6 +70,8 @@ impl OutputConfig {
         color: ColorMode,
         null: bool,
         trim: bool,
+        no_filename: bool,
+        no_line_number: bool,
     ) -> Self {
         let format = if json {
             OutputFormat::Json
@@ -87,6 +91,8 @@ impl OutputConfig {
             heading,
             null,
             trim,
+            no_filename,
+            no_line_number,
         }
     }
 }
@@ -151,16 +157,29 @@ impl OutputWriter {
                 writeln!(self.stdout, "{json}")?;
             }
             _ => {
-                self.ensure_heading(&ctx.file)?;
+                if !self.config.no_filename {
+                    self.ensure_heading(&ctx.file)?;
+                }
                 let content = self.maybe_trim(&ctx.content);
-                if self.use_heading {
-                    if self.use_color {
+                if self.use_heading && !self.config.no_filename {
+                    if self.config.no_line_number {
+                        writeln!(self.stdout, "{content}")?;
+                    } else if self.use_color {
                         writeln!(self.stdout, "\x1b[32m{}\x1b[0m-{content}", ctx.line_number)?;
                     } else {
                         writeln!(self.stdout, "{}-{content}", ctx.line_number)?;
                     }
                 } else {
-                    writeln!(self.stdout, "{}-{}-{content}", ctx.file, ctx.line_number)?;
+                    let show_file = !self.config.no_filename;
+                    let show_line = !self.config.no_line_number;
+                    match (show_file, show_line) {
+                        (true, true) => {
+                            writeln!(self.stdout, "{}-{}-{content}", ctx.file, ctx.line_number)?
+                        }
+                        (true, false) => writeln!(self.stdout, "{}-{content}", ctx.file)?,
+                        (false, true) => writeln!(self.stdout, "{}-{content}", ctx.line_number)?,
+                        (false, false) => writeln!(self.stdout, "{content}")?,
+                    }
                 }
             }
         }
@@ -172,15 +191,28 @@ impl OutputWriter {
         let content = self.maybe_trim(&m.content);
         match self.config.format {
             OutputFormat::Heading | OutputFormat::Flat => {
-                self.ensure_heading(&m.file)?;
-                if self.use_heading {
-                    if self.use_color {
+                if !self.config.no_filename {
+                    self.ensure_heading(&m.file)?;
+                }
+                if self.use_heading && !self.config.no_filename {
+                    if self.config.no_line_number {
+                        writeln!(self.stdout, "{content}")?;
+                    } else if self.use_color {
                         writeln!(self.stdout, "\x1b[32m{}\x1b[0m:{content}", m.line_number)?;
                     } else {
                         writeln!(self.stdout, "{}:{content}", m.line_number)?;
                     }
                 } else {
-                    writeln!(self.stdout, "{}:{}:{content}", m.file, m.line_number)?;
+                    let show_file = !self.config.no_filename;
+                    let show_line = !self.config.no_line_number;
+                    match (show_file, show_line) {
+                        (true, true) => {
+                            writeln!(self.stdout, "{}:{}:{content}", m.file, m.line_number)?
+                        }
+                        (true, false) => writeln!(self.stdout, "{}:{content}", m.file)?,
+                        (false, true) => writeln!(self.stdout, "{}:{content}", m.line_number)?,
+                        (false, false) => writeln!(self.stdout, "{content}")?,
+                    }
                 }
             }
             OutputFormat::Vimgrep => {
@@ -215,7 +247,11 @@ impl OutputWriter {
     }
 
     pub fn write_count(&mut self, file: &str, count: usize) -> io::Result<()> {
-        writeln!(self.stdout, "{file}:{count}")?;
+        if self.config.no_filename {
+            writeln!(self.stdout, "{count}")?;
+        } else {
+            writeln!(self.stdout, "{file}:{count}")?;
+        }
         Ok(())
     }
 

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -26,6 +26,7 @@ pub struct SearchOptions {
     pub smart_case: bool,
     pub fixed_string: bool,
     pub files_only: bool,
+    pub files_without_match: bool,
     pub count: bool,
     pub word_boundary: bool,
     pub max_count: Option<usize>,
@@ -47,6 +48,9 @@ pub struct SearchOptions {
     pub multiline: bool,
     pub no_ignore: bool,
     pub hidden: bool,
+    pub quiet: bool,
+    pub no_filename: bool,
+    pub no_line_number: bool,
 }
 
 impl SearchOptions {
@@ -81,6 +85,8 @@ impl SearchOptions {
             self.color,
             self.null,
             self.trim,
+            self.no_filename,
+            self.no_line_number,
         )
     }
 
@@ -143,8 +149,10 @@ pub fn run(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) -> Resu
 
     let ci = opts.effective_case_insensitive();
 
-    // Try to delegate to a running server
+    // Try to delegate to a running server (skip for files_without_match
+    // since the server only returns matching files).
     if !opts.no_index
+        && !opts.files_without_match
         && let Ok(info) = ServerInfo::load(&index_dir)
     {
         if let Ok(had_matches) = search_via_server(&info, opts, ci) {
@@ -215,6 +223,11 @@ fn search_via_server(info: &ServerInfo, opts: &SearchOptions, ci: bool) -> Resul
 
     let mut writer = OutputWriter::new(opts.make_output_config());
     let had_matches = !matches.is_empty();
+
+    if opts.quiet {
+        writer.flush()?;
+        return Ok(had_matches);
+    }
 
     if opts.files_only {
         let mut seen = std::collections::HashSet::new();
@@ -301,7 +314,7 @@ fn search_local_index(
 
     let is_match_all = plan.is_match_all();
 
-    let candidates = if is_match_all {
+    let candidates = if is_match_all || opts.files_without_match {
         reader.all_file_ids()
     } else {
         query::execute_plan(&plan, &|tri| reader.lookup_trigram(tri))
@@ -337,7 +350,18 @@ fn search_local_index(
 
         let matched = search_file_content(&content, &re, &rel_path, opts, &mut writer)?;
         if matched {
+            if !opts.files_without_match {
+                had_matches = true;
+            }
+            if opts.quiet {
+                break;
+            }
+        } else if opts.files_without_match {
+            writer.write_file(&rel_path)?;
             had_matches = true;
+            if opts.quiet {
+                break;
+            }
         }
     }
 
@@ -410,7 +434,18 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
 
         let matched = search_file_content(&content, &re, &rel_path, opts, &mut writer)?;
         if matched {
+            if !opts.files_without_match {
+                had_matches = true;
+            }
+            if opts.quiet {
+                break;
+            }
+        } else if opts.files_without_match {
+            writer.write_file(&rel_path)?;
             had_matches = true;
+            if opts.quiet {
+                break;
+            }
         }
     }
 
@@ -452,6 +487,9 @@ fn search_file_content(
         };
         if include {
             match_indices.push(i);
+            if opts.quiet || opts.files_without_match {
+                break;
+            }
             if let Some(max) = opts.max_count
                 && match_indices.len() >= max
             {
@@ -462,6 +500,11 @@ fn search_file_content(
 
     if match_indices.is_empty() {
         return Ok(false);
+    }
+
+    // For quiet/files_without_match, we only need the boolean result.
+    if opts.quiet || opts.files_without_match {
+        return Ok(true);
     }
 
     if opts.files_only {

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -33,7 +33,7 @@ pub struct SearchOptions {
     pub vimgrep: bool,
     pub stats: bool,
     pub no_index: bool,
-    pub glob: Option<String>,
+    pub glob: Vec<String>,
     pub file_type: Option<String>,
     pub invert_match: bool,
     pub only_matching: bool,
@@ -126,9 +126,7 @@ pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
         {
             continue;
         }
-        if let Some(ref glob) = opts.glob
-            && !glob_matches(glob, &rel_path)
-        {
+        if !passes_glob_filters(&opts.glob, &rel_path) {
             continue;
         }
         writer.write_file(&rel_path)?;
@@ -178,7 +176,7 @@ fn search_via_server(info: &ServerInfo, opts: &SearchOptions, ci: bool) -> Resul
             "files_only": opts.files_only,
             "word_boundary": opts.word_boundary,
             "max_count": opts.max_count,
-            "glob": opts.glob,
+            "glob": opts.glob,  // sent as JSON array
             "file_type": opts.file_type,
             "invert_match": opts.invert_match,
             "only_matching": opts.only_matching,
@@ -588,18 +586,25 @@ fn build_combined_regex(
         .map_err(|e| anyhow::anyhow!("regex error: {e}"))
 }
 
-fn passes_filters(rel_path: &str, glob: &Option<String>, file_type: &Option<String>) -> bool {
+fn passes_filters(rel_path: &str, globs: &[String], file_type: &Option<String>) -> bool {
     if let Some(type_name) = file_type
         && !filetypes::matches_type(rel_path, type_name)
     {
         return false;
     }
-    if let Some(glob_pat) = glob
-        && !glob_matches(glob_pat, rel_path)
-    {
+    if !passes_glob_filters(globs, rel_path) {
         return false;
     }
     true
+}
+
+/// Check if a path passes all glob filters. If no globs are specified, all
+/// paths pass. When multiple globs are given, the path must match at least one.
+fn passes_glob_filters(globs: &[String], path: &str) -> bool {
+    if globs.is_empty() {
+        return true;
+    }
+    globs.iter().any(|g| glob_matches(g, path))
 }
 
 fn glob_matches(pattern: &str, path: &str) -> bool {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -263,10 +263,15 @@ fn handle_search(
         .get("max_count")
         .and_then(|m| m.as_u64())
         .map(|m| m as usize);
-    let glob_filter = params
+    let glob_filters: Vec<String> = params
         .get("glob")
-        .and_then(|g| g.as_str())
-        .map(|s| s.to_string());
+        .and_then(|g| g.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
     let file_type = params
         .get("file_type")
         .and_then(|t| t.as_str())
@@ -365,8 +370,8 @@ fn handle_search(
                 {
                     return None;
                 }
-                if let Some(ref glob) = glob_filter
-                    && !simple_glob_match(glob, &rel_path)
+                if !glob_filters.is_empty()
+                    && !glob_filters.iter().any(|g| simple_glob_match(g, &rel_path))
                 {
                     return None;
                 }


### PR DESCRIPTION
## Summary

Adds several ripgrep-compatible flags so that tgrep can be used as a drop-in replacement for ripgrep in scripts and tool integrations.

## Changes

### Fix: `--glob` supports multiple uses (commit aa4cc24)
- Changed `--glob`/`-g` from `Option<String>` to `Vec<String>` so it can be specified multiple times (e.g. `-g '*.rs' -g '*.toml'`)
- When multiple globs are given, a file matches if it matches **any** pattern (OR logic)
- Updated server-side glob handling to accept an array of patterns

### Feat: ripgrep-compatible output flags (commit 192e913)

| Flag | Description |
|------|-------------|
| `-H` / `--with-filename` | Accepted as no-op (filenames always shown by default) |
| `--no-filename` | Suppress filenames in output |
| `-n` / `--line-number` | Accepted as no-op (line numbers always shown by default) |
| `-N` / `--no-line-number` | Suppress line numbers in output |
| `-L` / `--files-without-match` | Print files that do NOT match the pattern |
| `-q` / `--quiet` | Suppress all output; exit code only (0 = match, 1 = no match) |

## Testing
- All 16 existing tests pass
- Manually verified each new flag