### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"
-authors = ["Sheng-Yao Fu"]
+authors = ["Shengyu Fu"]
 
 [workspace.dependencies]
 tgrep-core = { path = "tgrep-core" }


### PR DESCRIPTION
Bumps the workspace version from 0.1.0 to 0.1.1. Both `grep-core` and `grep-cli` inherit the workspace version.