### PR TITLE
fix: Chromium benchmarks to avoid CI timeout

### DIFF
--- a/.github/workflows/benchmark-chromium-win.yml
+++ b/.github/workflows/benchmark-chromium-win.yml
@@ -14,13 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install ripgrep
+        run: cargo install ripgrep --locked
+
       - name: Build release
         run: cargo build --release
 
       - name: Run benchmark
         shell: pwsh
         run: |
-          .\scripts\benchmark.ps1 -QueriesFile scripts\benchmark-queries-chromium.json -SkipBuild -SkipRipgrep -BenchDir $env:RUNNER_TEMP\tgrep-bench -ResultsPath benchmark-results.md
+          .\scripts\benchmark.ps1 -QueriesFile scripts\benchmark-queries-chromium.json -SkipBuild -BenchDir $env:RUNNER_TEMP\tgrep-bench -ResultsPath benchmark-results.md
 
       - name: Print results
         shell: pwsh

--- a/.github/workflows/benchmark-chromium-win.yml
+++ b/.github/workflows/benchmark-chromium-win.yml
@@ -14,16 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ripgrep
-        run: cargo install ripgrep --locked
-
       - name: Build release
         run: cargo build --release
 
       - name: Run benchmark
         shell: pwsh
         run: |
-          .\scripts\benchmark.ps1 -QueriesFile scripts\benchmark-queries-chromium.json -SkipBuild -BenchDir $env:RUNNER_TEMP\tgrep-bench -ResultsPath benchmark-results.md
+          .\scripts\benchmark.ps1 -QueriesFile scripts\benchmark-queries-chromium.json -SkipBuild -SkipRipgrep -BenchDir $env:RUNNER_TEMP\tgrep-bench -ResultsPath benchmark-results.md
 
       - name: Print results
         shell: pwsh

--- a/.github/workflows/benchmark-chromium-win.yml
+++ b/.github/workflows/benchmark-chromium-win.yml
@@ -10,7 +10,7 @@ jobs:
   benchmark:
     name: Benchmark Chromium (Windows)
     timeout-minutes: 180
-    runs-on: windows-latest
+    runs-on: windows-latest-16-core
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/benchmark-chromium.yml
+++ b/.github/workflows/benchmark-chromium.yml
@@ -12,19 +12,14 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # ubuntu-latest excluded: 7 GB RAM is insufficient for indexing 440k+ files
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Build release
         run: cargo build --release
-
-      - name: Free disk space (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
-          df -h
 
       - name: Run benchmark
         run: |

--- a/.github/workflows/benchmark-chromium.yml
+++ b/.github/workflows/benchmark-chromium.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ripgrep
-        run: cargo install ripgrep --locked
-
       - name: Build release
         run: cargo build --release
 
@@ -32,7 +29,7 @@ jobs:
       - name: Run benchmark
         run: |
           chmod +x scripts/benchmark.sh
-          ./scripts/benchmark.sh --queries scripts/benchmark-queries-chromium.json --skip-build --bench-dir /tmp/tgrep-bench --results benchmark-results.md
+          ./scripts/benchmark.sh --queries scripts/benchmark-queries-chromium.json --skip-build --skip-rg --bench-dir /tmp/tgrep-bench --results benchmark-results.md
 
       - name: Print results
         run: cat benchmark-results.md

--- a/.github/workflows/benchmark-chromium.yml
+++ b/.github/workflows/benchmark-chromium.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest-16-core, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark-chromium.yml
+++ b/.github/workflows/benchmark-chromium.yml
@@ -12,19 +12,27 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        # ubuntu-latest excluded: 7 GB RAM is insufficient for indexing 440k+ files
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install ripgrep
+        run: cargo install ripgrep --locked
+
       - name: Build release
         run: cargo build --release
+
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          df -h
 
       - name: Run benchmark
         run: |
           chmod +x scripts/benchmark.sh
-          ./scripts/benchmark.sh --queries scripts/benchmark-queries-chromium.json --skip-build --skip-rg --bench-dir /tmp/tgrep-bench --results benchmark-results.md
+          ./scripts/benchmark.sh --queries scripts/benchmark-queries-chromium.json --skip-build --bench-dir /tmp/tgrep-bench --results benchmark-results.md
 
       - name: Print results
         run: cat benchmark-results.md

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,72 @@
+# Benchmarks
+
+All benchmarks measure **search time only** — the trigram index is built before timing starts.
+tgrep runs in client/server mode: `tgrep serve` runs in the background, and the `tgrep` client connects via TCP.
+
+---
+
+## torvalds/linux (93K files)
+
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/23984630704)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/23984627799)
+
+- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (93,023 files)
+- **Queries**: 102 (mix of literals, multi-word, and regex)
+- **Index build time**: ~61s (Linux/macOS), ~110s (Windows)
+- **Index size**: ~969 MB
+
+### Windows AMD64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 531,054 | 5,206.4 |
+| tgrep (client → serve) | 130,938 | 1,283.7 |
+
+**tgrep is ~4x faster**
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 93,843 | 920.0 |
+| tgrep (client → serve) | 63,896 | 626.4 |
+
+**tgrep is ~1.5x faster**
+
+### Linux x86_64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 103,194 | 1,011.7 |
+| tgrep (client → serve) | 128,157 | 1,256.4 |
+
+**tgrep is ~0.8x (ripgrep faster on small repos with Linux I/O cache)**
+
+---
+
+## chromium/chromium (492K files)
+
+[Benchmark Run (macOS)](https://github.com/microsoft/tgrep/actions/runs/23994708937)
+
+- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (491,632 files)
+- **Queries**: 121 (mix of literals, multi-word, and regex)
+- **Index build time**: ~498s (~8 min)
+- **Index size**: 2,467 MB (~2.4 GB)
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 5,653,497 | 46,723.1 |
+| tgrep (client → serve) | 162,404 | 1,342.2 |
+
+**tgrep is ~35x faster**
+
+---
+
+## Key takeaways
+
+- tgrep's advantage grows with repo size — the trigram index eliminates scanning files that can't match
+- On the 492K-file Chromium repo, ripgrep spends ~47s per query scanning every file; tgrep averages ~1.3s
+- On smaller repos (93K files), the gap narrows because OS page cache helps ripgrep's brute-force approach
+- Index build is a one-time cost; the server watches for file changes and updates incrementally

--- a/README.md
+++ b/README.md
@@ -17,38 +17,7 @@ tgrep serve .            # start server (watches for file changes)
 tgrep "fn main" .        # instant — auto-connects to running server
 ```
 
-# Benchmark: 102-query search across 93K files (torvalds/linux)
-
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/23984630704)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/23984627799)
-
-### Windows AMD64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 531,054 | 5,206.4 |
-| tgrep (client → serve) | 130,938 | 1,283.7 |
-
-### macOS Apple Silicon (Darwin arm64)
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 93,843 | 920.0 |
-| tgrep (client → serve) | 63,896 | 626.4 |
-
-### Linux x86_64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 103,194 | 1,011.7 |
-| tgrep (client → serve) | 128,157 | 1,256.4 |
-
-- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (93,023 files)
-- **Queries**: 102 (mix of literals, multi-word, and regex)
-- **Index build time**: ~61s (Linux/macOS), ~110s (Windows)
-- **Index size**: ~969 MB
-- **Scope**: search only (index built before timing)
-- **tgrep mode**: client/server — `tgrep serve` runs in background, `tgrep` client connects via TCP
+See [full benchmark results](BENCHMARKS.md) — up to **35x faster** than ripgrep on large repos.
 
 ## Architecture
 

--- a/scripts/benchmark.ps1
+++ b/scripts/benchmark.ps1
@@ -33,7 +33,8 @@ param(
     [string]$BenchDir = (Join-Path $env:TEMP 'tgrep-bench'),
     [string]$TgrepBin = '',
     [string]$ResultsPath = '',
-    [switch]$SkipBuild
+    [switch]$SkipBuild,
+    [switch]$SkipRipgrep
 )
 
 $ErrorActionPreference = 'Stop'
@@ -181,7 +182,9 @@ try {
 # ── Benchmark: ripgrep ──
 $rgCmd = Get-Command rg -ErrorAction SilentlyContinue
 $rgMs = -1
-if ($rgCmd) {
+if ($SkipRipgrep) {
+    Write-Host 'ripgrep benchmark skipped (-SkipRipgrep)' -ForegroundColor Yellow
+} elseif ($rgCmd) {
     Write-Host "`n==> Benchmarking ripgrep..." -ForegroundColor Cyan
     $ErrorActionPreference = 'Continue'
     $rgSw = [System.Diagnostics.Stopwatch]::StartNew()

--- a/scripts/benchmark.ps1
+++ b/scripts/benchmark.ps1
@@ -3,6 +3,8 @@
     Benchmark tgrep vs ripgrep on Windows.
 .DESCRIPTION
     Runs a search benchmark comparing tgrep (client/server) against ripgrep.
+    Uses `tgrep serve` for memory-efficient background indexing, then polls
+    `tgrep status` until the index is complete before running queries.
     Queries and the default repo URL are loaded from a JSON file.
 .PARAMETER QueriesFile
     Path to a JSON file containing "repo_url" and "queries" array.
@@ -33,8 +35,7 @@ param(
     [string]$BenchDir = (Join-Path $env:TEMP 'tgrep-bench'),
     [string]$TgrepBin = '',
     [string]$ResultsPath = '',
-    [switch]$SkipBuild,
-    [switch]$SkipRipgrep
+    [switch]$SkipBuild
 )
 
 $ErrorActionPreference = 'Stop'
@@ -75,7 +76,9 @@ $IndexPath = Join-Path $BenchDir 'tgrep-index'
 if ($RepoPath) {
     $BenchRepoDir = $RepoPath
 } else {
-    $BenchRepoDir = Join-Path $BenchDir 'linux'
+    # Derive clone directory name from repo URL (e.g. linux, chromium)
+    $CloneName = [System.IO.Path]::GetFileNameWithoutExtension($RepoUrl.TrimEnd('/'))
+    $BenchRepoDir = Join-Path $BenchDir $CloneName
 }
 
 # ── Build ──
@@ -113,23 +116,12 @@ if (-not (Test-Path $BenchRepoDir)) {
 # ── Count files ──
 $FileCount = (git -C $BenchRepoDir ls-files | Measure-Object -Line).Lines
 
-# ── Build index ──
-Write-Host '==> Building tgrep index...' -ForegroundColor Cyan
-$indexSw = [System.Diagnostics.Stopwatch]::StartNew()
-& $TgrepBin index $BenchRepoDir --index-path $IndexPath
-if ($LASTEXITCODE -ne 0) { throw 'tgrep index failed' }
-$indexSw.Stop()
-$indexMs = $indexSw.ElapsedMilliseconds
-Write-Host "Index built in ${indexMs}ms" -ForegroundColor Green
-
-$QueryCount = $Queries.Count
-Write-Host "==> Running $QueryCount queries against $FileCount files" -ForegroundColor Cyan
-
-# ── Start tgrep serve ──
-Write-Host '==> Starting tgrep serve...' -ForegroundColor Cyan
+# ── Start tgrep serve (builds index in background) ──
+Write-Host '==> Starting tgrep serve (index will build in background)...' -ForegroundColor Cyan
 
 $LockFile = Join-Path $IndexPath 'serve.json'
 if (Test-Path $LockFile) { Remove-Item $LockFile -Force }
+New-Item -ItemType Directory -Path $IndexPath -Force | Out-Null
 
 $serveOut = Join-Path $BenchDir 'serve-stdout.log'
 $serveErr = Join-Path $BenchDir 'serve-stderr.log'
@@ -157,6 +149,27 @@ if (-not $ready) {
     throw 'tgrep serve failed to start'
 }
 
+# ── Wait for background indexing to complete ──
+Write-Host '==> Waiting for index build to complete...' -ForegroundColor Cyan
+$indexSw = [System.Diagnostics.Stopwatch]::StartNew()
+while ($true) {
+    $statusOutput = & $TgrepBin status $BenchRepoDir --index-path $IndexPath 2>$null
+    if ($statusOutput -match 'Indexing:\s+complete') {
+        break
+    }
+    $progress = $statusOutput | Select-String 'Indexing:' | Select-Object -First 1
+    if ($progress) {
+        Write-Host "  $($progress.Line)"
+    }
+    Start-Sleep -Seconds 10
+}
+$indexSw.Stop()
+$indexMs = $indexSw.ElapsedMilliseconds
+Write-Host "Index built in ${indexMs}ms" -ForegroundColor Green
+
+$QueryCount = $Queries.Count
+Write-Host "==> Running $QueryCount queries against $FileCount files" -ForegroundColor Cyan
+
 # ── Benchmark: tgrep (client → serve) ──
 $savedEAP = $ErrorActionPreference
 $ErrorActionPreference = 'Continue'
@@ -182,9 +195,7 @@ try {
 # ── Benchmark: ripgrep ──
 $rgCmd = Get-Command rg -ErrorAction SilentlyContinue
 $rgMs = -1
-if ($SkipRipgrep) {
-    Write-Host 'ripgrep benchmark skipped (-SkipRipgrep)' -ForegroundColor Yellow
-} elseif ($rgCmd) {
+if ($rgCmd) {
     Write-Host "`n==> Benchmarking ripgrep..." -ForegroundColor Cyan
     $ErrorActionPreference = 'Continue'
     $rgSw = [System.Diagnostics.Stopwatch]::StartNew()

--- a/scripts/benchmark.ps1
+++ b/scripts/benchmark.ps1
@@ -183,17 +183,42 @@ try {
 # ── Benchmark: ripgrep ──
 $rgCmd = Get-Command rg -ErrorAction SilentlyContinue
 $rgMs = -1
+$rgTimeouts = 0
+$rgTimeoutMs = 10000
+$rgTimeoutSec = $rgTimeoutMs / 1000
 if ($rgCmd) {
-    Write-Host "`n==> Benchmarking ripgrep..." -ForegroundColor Cyan
-    $ErrorActionPreference = 'Continue'
+    Write-Host "`n==> Benchmarking ripgrep (${rgTimeoutSec}s timeout per query)..." -ForegroundColor Cyan
+    $rgOutTmp = Join-Path $BenchDir 'rg-stdout.tmp'
+    $rgErrTmp = Join-Path $BenchDir 'rg-stderr.tmp'
+    New-Item -ItemType Directory -Path $BenchDir -Force | Out-Null
     $rgSw = [System.Diagnostics.Stopwatch]::StartNew()
+    $qIdx = 0
     foreach ($q in $Queries) {
-        & rg -n $q $BenchRepoDir *>$null
+        $qIdx++
+        Write-Host "  [$qIdx/$QueryCount] $q"
+        $safeQ = $q -replace '"', '\"'
+        $safePath = $BenchRepoDir -replace '"', '\"'
+        $rgProc = Start-Process -FilePath $rgCmd.Source `
+            -ArgumentList "-n -- `"$safeQ`" `"$safePath`"" `
+            -PassThru -WindowStyle Hidden `
+            -RedirectStandardOutput $rgOutTmp `
+            -RedirectStandardError $rgErrTmp
+        $finished = $rgProc.WaitForExit($rgTimeoutMs)
+        if (-not $finished) {
+            try { $rgProc.Kill() } catch {}
+            try { $rgProc.WaitForExit(2000) | Out-Null } catch {}
+            $rgTimeouts++
+            Write-Host "    timed out (${rgTimeoutSec}s)" -ForegroundColor Yellow
+        }
     }
     $rgSw.Stop()
-    $ErrorActionPreference = $savedEAP
+    Remove-Item -Path $rgOutTmp -ErrorAction SilentlyContinue
+    Remove-Item -Path $rgErrTmp -ErrorAction SilentlyContinue
     $rgMs = $rgSw.ElapsedMilliseconds
     Write-Host "ripgrep: ${rgMs}ms total" -ForegroundColor Green
+    if ($rgTimeouts -gt 0) {
+        Write-Host "ripgrep: $rgTimeouts/$QueryCount queries timed out (${rgTimeoutSec}s limit)" -ForegroundColor Yellow
+    }
 } else {
     Write-Host 'ripgrep (rg) not found in PATH, skipping' -ForegroundColor Yellow
 }
@@ -233,13 +258,13 @@ $sb = [System.Text.StringBuilder]::new()
 [void]$sb.AppendLine('- **Scope**: search only (index built before timing)')
 [void]$sb.AppendLine('- **tgrep mode**: client/server — `tgrep serve` runs in background, `tgrep` client connects via TCP')
 [void]$sb.AppendLine()
-[void]$sb.AppendLine('| Tool | Total (ms) | Avg per query (ms) |')
-[void]$sb.AppendLine('| --- | ---: | ---: |')
+[void]$sb.AppendLine("| Tool | Total (ms) | Avg per query (ms) | Timeouts (${rgTimeoutSec}s) |")
+[void]$sb.AppendLine('| --- | ---: | ---: | ---: |')
 if ($rgMs -ge 0) {
     $rgAvg = [math]::Round($rgMs / $QueryCount, 1)
-    [void]$sb.AppendLine(('| ripgrep | {0} | {1} |' -f $rgMs, $rgAvg))
+    [void]$sb.AppendLine(('| ripgrep | {0} | {1} | {2} |' -f $rgMs, $rgAvg, $rgTimeouts))
 }
-[void]$sb.AppendLine(('| tgrep (client -> serve) | {0} | {1} |' -f $tgrepMs, $tgrepAvg))
+[void]$sb.AppendLine(('| tgrep (client -> serve) | {0} | {1} | - |' -f $tgrepMs, $tgrepAvg))
 
 $results = $sb.ToString()
 

--- a/scripts/benchmark.ps1
+++ b/scripts/benchmark.ps1
@@ -3,8 +3,6 @@
     Benchmark tgrep vs ripgrep on Windows.
 .DESCRIPTION
     Runs a search benchmark comparing tgrep (client/server) against ripgrep.
-    Uses `tgrep serve` for memory-efficient background indexing, then polls
-    `tgrep status` until the index is complete before running queries.
     Queries and the default repo URL are loaded from a JSON file.
 .PARAMETER QueriesFile
     Path to a JSON file containing "repo_url" and "queries" array.
@@ -116,12 +114,23 @@ if (-not (Test-Path $BenchRepoDir)) {
 # ── Count files ──
 $FileCount = (git -C $BenchRepoDir ls-files | Measure-Object -Line).Lines
 
-# ── Start tgrep serve (builds index in background) ──
-Write-Host '==> Starting tgrep serve (index will build in background)...' -ForegroundColor Cyan
+# ── Build index ──
+Write-Host '==> Building tgrep index...' -ForegroundColor Cyan
+$indexSw = [System.Diagnostics.Stopwatch]::StartNew()
+& $TgrepBin index $BenchRepoDir --index-path $IndexPath
+if ($LASTEXITCODE -ne 0) { throw 'tgrep index failed' }
+$indexSw.Stop()
+$indexMs = $indexSw.ElapsedMilliseconds
+Write-Host "Index built in ${indexMs}ms" -ForegroundColor Green
+
+$QueryCount = $Queries.Count
+Write-Host "==> Running $QueryCount queries against $FileCount files" -ForegroundColor Cyan
+
+# ── Start tgrep serve ──
+Write-Host '==> Starting tgrep serve...' -ForegroundColor Cyan
 
 $LockFile = Join-Path $IndexPath 'serve.json'
 if (Test-Path $LockFile) { Remove-Item $LockFile -Force }
-New-Item -ItemType Directory -Path $IndexPath -Force | Out-Null
 
 $serveOut = Join-Path $BenchDir 'serve-stdout.log'
 $serveErr = Join-Path $BenchDir 'serve-stderr.log'
@@ -148,27 +157,6 @@ if (-not $ready) {
     if (-not $serveProc.HasExited) { $serveProc.Kill() }
     throw 'tgrep serve failed to start'
 }
-
-# ── Wait for background indexing to complete ──
-Write-Host '==> Waiting for index build to complete...' -ForegroundColor Cyan
-$indexSw = [System.Diagnostics.Stopwatch]::StartNew()
-while ($true) {
-    $statusOutput = & $TgrepBin status $BenchRepoDir --index-path $IndexPath 2>$null
-    if ($statusOutput -match 'Indexing:\s+complete') {
-        break
-    }
-    $progress = $statusOutput | Select-String 'Indexing:' | Select-Object -First 1
-    if ($progress) {
-        Write-Host "  $($progress.Line)"
-    }
-    Start-Sleep -Seconds 10
-}
-$indexSw.Stop()
-$indexMs = $indexSw.ElapsedMilliseconds
-Write-Host "Index built in ${indexMs}ms" -ForegroundColor Green
-
-$QueryCount = $Queries.Count
-Write-Host "==> Running $QueryCount queries against $FileCount files" -ForegroundColor Cyan
 
 # ── Benchmark: tgrep (client → serve) ──
 $savedEAP = $ErrorActionPreference

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -19,6 +19,7 @@ BENCH_DIR="/tmp/tgrep-bench"
 TGREP_BIN=""
 RESULTS_PATH=""
 SKIP_BUILD=false
+SKIP_RG=false
 
 # ── Parse args ──
 while [[ $# -gt 0 ]]; do
@@ -30,6 +31,7 @@ while [[ $# -gt 0 ]]; do
     --tgrep-bin)   TGREP_BIN="$2"; shift 2 ;;
     --results)     RESULTS_PATH="$2"; shift 2 ;;
     --skip-build)  SKIP_BUILD=true; shift ;;
+    --skip-rg)     SKIP_RG=true; shift ;;
     -h|--help)
       echo "Usage: $(basename "$0") [OPTIONS]"
       echo ""
@@ -42,6 +44,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --tgrep-bin PATH   Path to tgrep binary (default: target/release/tgrep)"
       echo "  --results   PATH   Output path for results markdown"
       echo "  --skip-build       Skip building tgrep from source"
+      echo "  --skip-rg          Skip the ripgrep comparison"
       exit 0
       ;;
     *) echo "Unknown option: $1 (use --help for usage)" >&2; exit 1 ;;
@@ -220,7 +223,9 @@ cleanup_serve
 
 # ── Benchmark: ripgrep ──
 RG_MS=-1
-if command -v rg >/dev/null 2>&1; then
+if [ "$SKIP_RG" = true ]; then
+  echo "ripgrep benchmark skipped (--skip-rg)"
+elif command -v rg >/dev/null 2>&1; then
   echo ""
   echo "==> Benchmarking ripgrep..."
   RG_START=$(now_ns)

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 #
-# Benchmark tgrep vs ripgrep vs grep on Linux/macOS.
+# Benchmark tgrep vs ripgrep on Linux/macOS.
+#
+# Uses `tgrep serve` for memory-efficient background indexing, then polls
+# `tgrep status` until the index is complete before running queries.
 #
 # Usage:
 #   ./scripts/benchmark.sh                                    # full run
@@ -19,7 +22,6 @@ BENCH_DIR="/tmp/tgrep-bench"
 TGREP_BIN=""
 RESULTS_PATH=""
 SKIP_BUILD=false
-SKIP_RG=false
 
 # ── Parse args ──
 while [[ $# -gt 0 ]]; do
@@ -31,7 +33,6 @@ while [[ $# -gt 0 ]]; do
     --tgrep-bin)   TGREP_BIN="$2"; shift 2 ;;
     --results)     RESULTS_PATH="$2"; shift 2 ;;
     --skip-build)  SKIP_BUILD=true; shift ;;
-    --skip-rg)     SKIP_RG=true; shift ;;
     -h|--help)
       echo "Usage: $(basename "$0") [OPTIONS]"
       echo ""
@@ -44,7 +45,6 @@ while [[ $# -gt 0 ]]; do
       echo "  --tgrep-bin PATH   Path to tgrep binary (default: target/release/tgrep)"
       echo "  --results   PATH   Output path for results markdown"
       echo "  --skip-build       Skip building tgrep from source"
-      echo "  --skip-rg          Skip the ripgrep comparison"
       exit 0
       ;;
     *) echo "Unknown option: $1 (use --help for usage)" >&2; exit 1 ;;
@@ -74,8 +74,11 @@ if [ -z "$REPO_URL" ]; then
   exit 1
 fi
 
-# Read queries into a bash array
-mapfile -t QUERIES < <(python3 -c "
+# Read queries into a shell array (compatible with bash 3 / macOS)
+QUERIES=()
+while IFS= read -r line; do
+  QUERIES+=("$line")
+done < <(python3 -c "
 import json, sys
 data = json.load(open(sys.argv[1]))
 for q in data['queries']:
@@ -99,7 +102,9 @@ INDEX_PATH="$BENCH_DIR/tgrep-index"
 if [ -n "$REPO_PATH" ]; then
   BENCH_REPO_DIR="$REPO_PATH"
 else
-  BENCH_REPO_DIR="$BENCH_DIR/linux"
+  # Derive clone directory name from repo URL (e.g. linux, chromium)
+  CLONE_NAME=$(basename "$REPO_URL" .git)
+  BENCH_REPO_DIR="$BENCH_DIR/$CLONE_NAME"
 fi
 
 # GNU date supports %N for nanoseconds; macOS/BSD does not
@@ -144,22 +149,12 @@ fi
 # ── Count files ──
 FILE_COUNT=$(git -C "$BENCH_REPO_DIR" ls-files | wc -l | tr -d ' ')
 
-# ── Build index ──
-echo "==> Building tgrep index..."
-INDEX_START=$(now_ns)
-"$TGREP_BIN" index "$BENCH_REPO_DIR" --index-path "$INDEX_PATH"
-INDEX_END=$(now_ns)
-INDEX_MS=$(( (INDEX_END - INDEX_START) / 1000000 ))
-echo "Index built in ${INDEX_MS}ms"
-
-QUERY_COUNT=${#QUERIES[@]}
-echo "==> Running $QUERY_COUNT queries against $FILE_COUNT files"
-
-# ── Start tgrep serve ──
-echo "==> Starting tgrep serve..."
+# ── Start tgrep serve (builds index in background) ──
+echo "==> Starting tgrep serve (index will build in background)..."
 
 LOCKFILE="$INDEX_PATH/serve.json"
 rm -f "$LOCKFILE"
+mkdir -p "$INDEX_PATH"
 
 "$TGREP_BIN" serve "$BENCH_REPO_DIR" --index-path "$INDEX_PATH" --no-watch > /dev/null 2>&1 &
 SERVE_PID=$!
@@ -187,6 +182,28 @@ if [ "$READY" = false ]; then
   echo "ERROR: tgrep serve failed to start within 60s" >&2
   exit 1
 fi
+
+# ── Wait for background indexing to complete ──
+echo "==> Waiting for index build to complete..."
+INDEX_START=$(now_ns)
+while true; do
+  STATUS_OUTPUT=$("$TGREP_BIN" status "$BENCH_REPO_DIR" --index-path "$INDEX_PATH" 2>/dev/null || true)
+  if echo "$STATUS_OUTPUT" | grep -q "Indexing:   complete"; then
+    break
+  fi
+  # Print progress
+  PROGRESS=$(echo "$STATUS_OUTPUT" | grep "Indexing:" | head -1 || true)
+  if [ -n "$PROGRESS" ]; then
+    echo "  $PROGRESS"
+  fi
+  sleep 10
+done
+INDEX_END=$(now_ns)
+INDEX_MS=$(( (INDEX_END - INDEX_START) / 1000000 ))
+echo "Index built in ${INDEX_MS}ms"
+
+QUERY_COUNT=${#QUERIES[@]}
+echo "==> Running $QUERY_COUNT queries against $FILE_COUNT files"
 
 # ── Benchmark: tgrep (client → serve) ──
 echo ""
@@ -223,9 +240,7 @@ cleanup_serve
 
 # ── Benchmark: ripgrep ──
 RG_MS=-1
-if [ "$SKIP_RG" = true ]; then
-  echo "ripgrep benchmark skipped (--skip-rg)"
-elif command -v rg >/dev/null 2>&1; then
+if command -v rg >/dev/null 2>&1; then
   echo ""
   echo "==> Benchmarking ripgrep..."
   RG_START=$(now_ns)

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -225,16 +225,41 @@ cleanup_serve
 
 # ── Benchmark: ripgrep ──
 RG_MS=-1
+RG_TIMEOUTS=0
+RG_TIMEOUT_SEC=10
 if command -v rg >/dev/null 2>&1; then
+  # Detect timeout command (macOS needs gtimeout from coreutils)
+  TIMEOUT_CMD=""
+  if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="gtimeout"
+  fi
+
   echo ""
-  echo "==> Benchmarking ripgrep..."
+  echo "==> Benchmarking ripgrep (${RG_TIMEOUT_SEC}s timeout per query)..."
   RG_START=$(now_ns)
+  QIDX=0
   for pattern in "${QUERIES[@]}"; do
-    rg -n "$pattern" "$BENCH_REPO_DIR" > /dev/null 2>&1 || true
+    QIDX=$((QIDX + 1))
+    echo "  [$QIDX/$QUERY_COUNT] $pattern"
+    if [ -n "$TIMEOUT_CMD" ]; then
+      $TIMEOUT_CMD "$RG_TIMEOUT_SEC" rg -n "$pattern" "$BENCH_REPO_DIR" > /dev/null 2>&1
+      rc=$?
+      if [ $rc -eq 124 ]; then
+        echo "    ⚠ timed out (${RG_TIMEOUT_SEC}s)"
+        RG_TIMEOUTS=$((RG_TIMEOUTS + 1))
+      fi
+    else
+      rg -n "$pattern" "$BENCH_REPO_DIR" > /dev/null 2>&1 || true
+    fi
   done
   RG_END=$(now_ns)
   RG_MS=$(( (RG_END - RG_START) / 1000000 ))
   echo "ripgrep: ${RG_MS}ms total"
+  if [ $RG_TIMEOUTS -gt 0 ]; then
+    echo "ripgrep: $RG_TIMEOUTS/$QUERY_COUNT queries timed out (${RG_TIMEOUT_SEC}s limit)"
+  fi
 else
   echo "ripgrep (rg) not found in PATH, skipping"
 fi
@@ -278,15 +303,15 @@ cat > "$RESULTS_PATH" <<EOF
 - **Scope**: search only (index built before timing)
 - **tgrep mode**: client/server — \`tgrep serve\` runs in background, \`tgrep\` client connects via TCP
 
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
+| Tool | Total (ms) | Avg per query (ms) | Timeouts (${RG_TIMEOUT_SEC}s) |
+| --- | ---: | ---: | ---: |
 EOF
 
 if [ "$RG_MS" -ge 0 ]; then
   RG_AVG=$(awk "BEGIN { printf \"%.1f\", $RG_MS / $QUERY_COUNT }")
-  echo "| ripgrep | $RG_MS | $RG_AVG |" >> "$RESULTS_PATH"
+  echo "| ripgrep | $RG_MS | $RG_AVG | $RG_TIMEOUTS |" >> "$RESULTS_PATH"
 fi
-echo "| tgrep (client → serve) | $TGREP_MS | $TGREP_AVG |" >> "$RESULTS_PATH"
+echo "| tgrep (client → serve) | $TGREP_MS | $TGREP_AVG | - |" >> "$RESULTS_PATH"
 
 echo ""
 cat "$RESULTS_PATH"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -2,9 +2,6 @@
 #
 # Benchmark tgrep vs ripgrep on Linux/macOS.
 #
-# Uses `tgrep serve` for memory-efficient background indexing, then polls
-# `tgrep status` until the index is complete before running queries.
-#
 # Usage:
 #   ./scripts/benchmark.sh                                    # full run
 #   ./scripts/benchmark.sh --repo-path /src/myrepo --skip-build
@@ -149,12 +146,22 @@ fi
 # ── Count files ──
 FILE_COUNT=$(git -C "$BENCH_REPO_DIR" ls-files | wc -l | tr -d ' ')
 
-# ── Start tgrep serve (builds index in background) ──
-echo "==> Starting tgrep serve (index will build in background)..."
+# ── Build index ──
+echo "==> Building tgrep index..."
+INDEX_START=$(now_ns)
+"$TGREP_BIN" index "$BENCH_REPO_DIR" --index-path "$INDEX_PATH"
+INDEX_END=$(now_ns)
+INDEX_MS=$(( (INDEX_END - INDEX_START) / 1000000 ))
+echo "Index built in ${INDEX_MS}ms"
+
+QUERY_COUNT=${#QUERIES[@]}
+echo "==> Running $QUERY_COUNT queries against $FILE_COUNT files"
+
+# ── Start tgrep serve ──
+echo "==> Starting tgrep serve..."
 
 LOCKFILE="$INDEX_PATH/serve.json"
 rm -f "$LOCKFILE"
-mkdir -p "$INDEX_PATH"
 
 "$TGREP_BIN" serve "$BENCH_REPO_DIR" --index-path "$INDEX_PATH" --no-watch > /dev/null 2>&1 &
 SERVE_PID=$!
@@ -182,28 +189,6 @@ if [ "$READY" = false ]; then
   echo "ERROR: tgrep serve failed to start within 60s" >&2
   exit 1
 fi
-
-# ── Wait for background indexing to complete ──
-echo "==> Waiting for index build to complete..."
-INDEX_START=$(now_ns)
-while true; do
-  STATUS_OUTPUT=$("$TGREP_BIN" status "$BENCH_REPO_DIR" --index-path "$INDEX_PATH" 2>/dev/null || true)
-  if echo "$STATUS_OUTPUT" | grep -q "Indexing:   complete"; then
-    break
-  fi
-  # Print progress
-  PROGRESS=$(echo "$STATUS_OUTPUT" | grep "Indexing:" | head -1 || true)
-  if [ -n "$PROGRESS" ]; then
-    echo "  $PROGRESS"
-  fi
-  sleep 10
-done
-INDEX_END=$(now_ns)
-INDEX_MS=$(( (INDEX_END - INDEX_START) / 1000000 ))
-echo "Index built in ${INDEX_MS}ms"
-
-QUERY_COUNT=${#QUERIES[@]}
-echo "==> Running $QUERY_COUNT queries against $FILE_COUNT files"
 
 # ── Benchmark: tgrep (client → serve) ──
 echo ""


### PR DESCRIPTION
Improves the Chromium benchmark scripts and CI workflows.

## Changes

- **16-core runners**: Use `ubuntu-latest-16-core` and `windows-latest-16-core` (64GB RAM) to avoid OOM during indexing of 400k+ Chromium files
- **Ripgrep 10s timeout**: Each ripgrep query has a 10-second per-query timeout. Timed-out queries are counted and reported in results (new Timeouts column in the markdown table)
- **Benchmark scripts**: Use `tgrep index` for building, `tgrep serve` for queries, with progress output for ripgrep queries
- **Benchmark docs**: Move detailed benchmark results from README to dedicated BENCHMARKS.md

## Results table example

| Tool | Total (ms) | Avg per query (ms) | Timeouts (10s) |
| --- | ---: | ---: | ---: |
| ripgrep | 52000 | 1733.3 | 2 |
| tgrep (client -> serve) | 1234 | 41.1 | - |
