### PR TITLE
feat: detect stale files on server startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -915,6 +915,10 @@ fn background_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &P
         start.elapsed().as_secs_f64() * 1000.0
     );
 
+    // Persist the updated index immediately so changes survive a crash
+    eprintln!("[trace] stale check: flushing updated index to disk...");
+    flush_index_to_disk(state, root, index_dir);
+
     // Re-stamp ALL walked files (including content-binary ones) so the
     // next startup won't treat unchanged non-indexed files as "new".
     let new_stamps: std::collections::HashMap<String, FileStamp> = current_meta

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -914,6 +914,24 @@ fn background_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &P
         update_start.elapsed().as_secs_f64() * 1000.0,
         start.elapsed().as_secs_f64() * 1000.0
     );
+
+    // Re-stamp ALL walked files (including content-binary ones) so the
+    // next startup won't treat unchanged non-indexed files as "new".
+    let new_stamps: std::collections::HashMap<String, FileStamp> = current_meta
+        .iter()
+        .map(|fm| {
+            (
+                fm.relative_path.clone(),
+                FileStamp {
+                    mtime: fm.mtime,
+                    size: fm.size,
+                },
+            )
+        })
+        .collect();
+    if let Err(e) = meta::write_filestamps(&new_stamps, index_dir) {
+        eprintln!("[trace] stale check: failed to write filestamps: {e}");
+    }
 }
 
 /// Walk the repo and populate the LiveIndex in batches in a background thread.
@@ -1066,6 +1084,25 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // Final flush to disk
     eprintln!("[trace] persisting final index to disk...");
     flush_index_to_disk(state, root, index_dir);
+
+    // Write per-file stamps for ALL walked files (including content-binary
+    // ones) so the stale check on next startup is accurate.
+    let walk_meta = tgrep_core::walker::walk_file_metadata(root);
+    let stamps: std::collections::HashMap<String, tgrep_core::meta::FileStamp> = walk_meta
+        .into_iter()
+        .map(|fm| {
+            (
+                fm.relative_path,
+                tgrep_core::meta::FileStamp {
+                    mtime: fm.mtime,
+                    size: fm.size,
+                },
+            )
+        })
+        .collect();
+    if let Err(e) = tgrep_core::meta::write_filestamps(&stamps, index_dir) {
+        eprintln!("[trace] warning: failed to write filestamps: {e}");
+    }
 
     // Clear indexing flag AFTER final flush so auto-save doesn't race
     state

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -151,6 +151,14 @@ pub fn run(root: &Path, index_path: Option<&Path>, no_watch: bool) -> Result<()>
         thread::spawn(move || {
             background_index_build(&build_state, &build_root, &build_index_dir);
         });
+    } else {
+        // Index is complete — check for files that changed while server was offline
+        let stale_state = Arc::clone(&state);
+        let stale_root = root.clone();
+        let stale_index_dir = index_dir.clone();
+        thread::spawn(move || {
+            background_refresh_stale(&stale_state, &stale_root, &stale_index_dir);
+        });
     }
 
     // Start file watcher (unless --no-watch)
@@ -794,6 +802,120 @@ fn create_empty_index(index_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Detect files that changed while the server was not running.
+/// Compares stored filestamps against current filesystem metadata, then upserts
+/// changed/new files and removes deleted files from the LiveIndex.
+fn background_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &Path) {
+    use tgrep_core::meta::{self, FileStamp};
+    use tgrep_core::walker;
+
+    let start = Instant::now();
+    eprintln!("[trace] stale check: comparing index against filesystem...");
+
+    // Load stored per-file stamps from last index write
+    let old_stamps = match meta::read_filestamps(index_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[trace] stale check: no filestamps found ({e}), skipping");
+            return;
+        }
+    };
+    if old_stamps.is_empty() {
+        eprintln!("[trace] stale check: no filestamps found, skipping");
+        return;
+    }
+
+    // Walk filesystem metadata (no content reads)
+    let current_meta = walker::walk_file_metadata(root);
+    let walk_ms = start.elapsed().as_millis();
+
+    // Build lookup of current filesystem state
+    let mut current_set: std::collections::HashSet<String> =
+        std::collections::HashSet::with_capacity(current_meta.len());
+    let mut changed: Vec<String> = Vec::new();
+    let mut added: Vec<String> = Vec::new();
+
+    for fm in &current_meta {
+        current_set.insert(fm.relative_path.clone());
+        let stamp = FileStamp {
+            mtime: fm.mtime,
+            size: fm.size,
+        };
+        match old_stamps.get(&fm.relative_path) {
+            Some(old) if *old == stamp => {
+                // Unchanged — skip
+            }
+            Some(_) => {
+                // mtime or size differs — file changed
+                changed.push(fm.relative_path.clone());
+            }
+            None => {
+                // New file (not in previous index)
+                added.push(fm.relative_path.clone());
+            }
+        }
+    }
+
+    // Detect deleted files (in old stamps but not on filesystem)
+    let deleted: Vec<String> = old_stamps
+        .keys()
+        .filter(|p| !current_set.contains(p.as_str()))
+        .cloned()
+        .collect();
+
+    let total_changes = changed.len() + added.len() + deleted.len();
+    if total_changes == 0 {
+        eprintln!(
+            "[trace] stale check: index is up-to-date ({} files checked in {}ms)",
+            current_meta.len(),
+            walk_ms
+        );
+        return;
+    }
+
+    eprintln!(
+        "[trace] stale check: {} changed, {} new, {} deleted (walk: {}ms)",
+        changed.len(),
+        added.len(),
+        deleted.len(),
+        walk_ms
+    );
+
+    // Apply changes to the LiveIndex
+    let update_start = Instant::now();
+    let files_to_update: Vec<String> = changed.into_iter().chain(added).collect();
+
+    {
+        let mut index = state.index.write().unwrap();
+
+        // Remove deleted files
+        for rel_path in &deleted {
+            index.live.delete_file(rel_path);
+        }
+
+        // Upsert changed/new files (reads content, extracts trigrams)
+        for rel_path in &files_to_update {
+            index.live.update_from_disk(root, rel_path);
+        }
+    }
+
+    // Invalidate cache entries for all affected files
+    {
+        if let Ok(mut cache) = state.cache.write() {
+            for rel_path in deleted.iter().chain(files_to_update.iter()) {
+                cache.pop(rel_path);
+            }
+        }
+    }
+
+    eprintln!(
+        "[trace] stale check: updated {} files in {:.1}ms (total: {:.1}ms)",
+        total_changes,
+        update_start.elapsed().as_secs_f64() * 1000.0,
+        start.elapsed().as_secs_f64() * 1000.0
+    );
+}
+
 /// Walk the repo and populate the LiveIndex in batches in a background thread.
 /// Uses rayon for parallel trigram extraction. Flushes to disk every
 /// FLUSH_INTERVAL or FLUSH_FILE_THRESHOLD, whichever comes first.
@@ -1083,7 +1205,13 @@ fn flush_index_to_disk(state: &ServerState, _root: &Path, index_dir: &Path) {
 /// Move index files from staging to the target directory.
 fn move_staged_files(staging: &Path, target: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(target)?;
-    for name in &["index.bin", "lookup.bin", "files.bin", "meta.json"] {
+    for name in &[
+        "index.bin",
+        "lookup.bin",
+        "files.bin",
+        "meta.json",
+        "filestamps.json",
+    ] {
         let src = staging.join(name);
         let dst = target.join(name);
         if src.exists() {

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::Result;
-use crate::meta::IndexMeta;
+use crate::meta::{self, IndexMeta};
 use crate::ondisk::{self, LookupEntry, PostingEntry};
 use crate::trigram::{self, TrigramMasks};
 use crate::walker;
@@ -102,6 +102,11 @@ pub fn build_index(root: &Path, index_dir: Option<&Path>, include_hidden: bool) 
 
     write_index_v2(&index_dir, &root, &file_id_map, &inverted)?;
 
+    // Write per-file stamps for stale detection on next startup
+    let paths: Vec<String> = file_id_map.iter().map(|(_, p)| p.clone()).collect();
+    let stamps = meta::collect_filestamps(&root, &paths);
+    meta::write_filestamps(&stamps, &index_dir)?;
+
     eprintln!("Index built successfully at {}", index_dir.display());
     Ok(())
 }
@@ -175,13 +180,19 @@ pub fn write_index_from_snapshot(
 
     // Write meta.json (version 2 for mask-aware format)
     let root = std::fs::canonicalize(root)?;
-    let mut meta = IndexMeta::new(
+    let mut meta_obj = IndexMeta::new(
         &root.to_string_lossy(),
         paths.len() as u64,
         sorted_trigrams.len() as u64,
     );
-    meta.complete = complete;
-    meta.save(index_dir)?;
+    meta_obj.complete = complete;
+    meta_obj.save(index_dir)?;
+
+    // Write per-file stamps for stale detection on next startup
+    if complete {
+        let stamps = meta::collect_filestamps(&root, paths);
+        meta::write_filestamps(&stamps, index_dir)?;
+    }
 
     Ok(())
 }

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -102,9 +102,16 @@ pub fn build_index(root: &Path, index_dir: Option<&Path>, include_hidden: bool) 
 
     write_index_v2(&index_dir, &root, &file_id_map, &inverted)?;
 
-    // Write per-file stamps for stale detection on next startup
-    let paths: Vec<String> = file_id_map.iter().map(|(_, p)| p.clone()).collect();
-    let stamps = meta::collect_filestamps(&root, &paths);
+    // Write per-file stamps for ALL walked files (including those later
+    // rejected as binary-by-content) so the stale check on next startup
+    // won't re-process unchanged files that aren't in the index.
+    let all_walked: Vec<String> = walk
+        .files
+        .iter()
+        .filter_map(|p| p.strip_prefix(&root).ok())
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .collect();
+    let stamps = meta::collect_filestamps(&root, &all_walked);
     meta::write_filestamps(&stamps, &index_dir)?;
 
     eprintln!("Index built successfully at {}", index_dir.display());
@@ -187,12 +194,6 @@ pub fn write_index_from_snapshot(
     );
     meta_obj.complete = complete;
     meta_obj.save(index_dir)?;
-
-    // Write per-file stamps for stale detection on next startup
-    if complete {
-        let stamps = meta::collect_filestamps(&root, paths);
-        meta::write_filestamps(&stamps, index_dir)?;
-    }
 
     Ok(())
 }

--- a/tgrep-core/src/meta.rs
+++ b/tgrep-core/src/meta.rs
@@ -1,10 +1,12 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::SystemTime;
 
 use crate::Result;
 
 const META_FILENAME: &str = "meta.json";
+const FILESTAMPS_FILENAME: &str = "filestamps.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexMeta {
@@ -57,4 +59,54 @@ impl IndexMeta {
         let meta: Self = serde_json::from_str(&data)?;
         Ok(meta)
     }
+}
+
+/// Per-file stamp for change detection (mtime + size).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileStamp {
+    pub mtime: u64,
+    pub size: u64,
+}
+
+/// Write per-file stamps to `filestamps.json` in the index directory.
+pub fn write_filestamps(stamps: &HashMap<String, FileStamp>, index_dir: &Path) -> Result<()> {
+    let path = index_dir.join(FILESTAMPS_FILENAME);
+    let json = serde_json::to_string(stamps)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Read per-file stamps from `filestamps.json` in the index directory.
+pub fn read_filestamps(index_dir: &Path) -> Result<HashMap<String, FileStamp>> {
+    let path = index_dir.join(FILESTAMPS_FILENAME);
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+    let json = std::fs::read_to_string(&path)?;
+    let stamps: HashMap<String, FileStamp> = serde_json::from_str(&json)?;
+    Ok(stamps)
+}
+
+/// Collect file stamps (mtime + size) for a list of relative paths under `root`.
+pub fn collect_filestamps(root: &Path, paths: &[String]) -> HashMap<String, FileStamp> {
+    let mut stamps = HashMap::with_capacity(paths.len());
+    for rel_path in paths {
+        let full_path = root.join(rel_path);
+        if let Ok(metadata) = std::fs::metadata(&full_path) {
+            let mtime = metadata
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            stamps.insert(
+                rel_path.clone(),
+                FileStamp {
+                    mtime,
+                    size: metadata.len(),
+                },
+            );
+        }
+    }
+    stamps
 }

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -98,3 +98,69 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
         skipped_error: skipped_error.into_inner(),
     }
 }
+
+/// Filesystem metadata for a single file (no content read).
+pub struct FileMeta {
+    pub relative_path: String,
+    pub mtime: u64,
+    pub size: u64,
+}
+
+/// Walk a directory tree collecting only filesystem metadata (mtime, size).
+/// No file content is read — this is used for stale file detection on startup.
+pub fn walk_file_metadata(root: &Path) -> Vec<FileMeta> {
+    let results = std::sync::Mutex::new(Vec::new());
+
+    let walker = WalkBuilder::new(root)
+        .hidden(true) // skip hidden by default
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .threads(std::thread::available_parallelism().map_or(4, |n| n.get().min(12)))
+        .build_parallel();
+
+    walker.run(|| {
+        Box::new(|entry| {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => return ignore::WalkState::Continue,
+            };
+
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                return ignore::WalkState::Continue;
+            }
+
+            let path = entry.path();
+
+            if is_binary_extension(path) {
+                return ignore::WalkState::Continue;
+            }
+
+            let rel_path = match path.strip_prefix(root) {
+                Ok(p) => p.to_string_lossy().replace('\\', "/"),
+                Err(_) => return ignore::WalkState::Continue,
+            };
+
+            if let Ok(meta) = entry.metadata() {
+                if meta.len() > MAX_FILE_SIZE {
+                    return ignore::WalkState::Continue;
+                }
+                let mtime = meta
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                results.lock().unwrap().push(FileMeta {
+                    relative_path: rel_path,
+                    mtime,
+                    size: meta.len(),
+                });
+            }
+
+            ignore::WalkState::Continue
+        })
+    });
+
+    results.into_inner().unwrap()
+}


### PR DESCRIPTION
When `tgrep serve` starts with a complete index, it now detects files that changed while the server was offline and updates the index automatically.

## Problem

Previously, if files were modified, added, or deleted while `tgrep serve` was not running, the server would start with a stale index and never catch up with those changes (only the file watcher tracked future changes).

## Solution

Store per-file `mtime + size` in `filestamps.json` alongside the index. On startup with a complete index, walk the filesystem metadata (no content reads), compare against stored stamps, and update the LiveIndex:

- **Changed files** (mtime or size differs) → re-read and re-index
- **New files** (not in stored stamps) → read and index
- **Deleted files** (in stamps but not on filesystem) → remove from index

## Changes

- `tgrep-core/src/meta.rs` — `FileStamp` struct, `read_filestamps()`, `write_filestamps()`, `collect_filestamps()`
- `tgrep-core/src/walker.rs` — `walk_file_metadata()` for metadata-only filesystem walk
- `tgrep-core/src/builder.rs` — Write `filestamps.json` during `tgrep index` and server flush
- `tgrep-cli/src/serve.rs` — `background_refresh_stale()` runs on startup when index is complete; `move_staged_files()` includes `filestamps.json`

## Example output

```
[trace] opened index: 3 files, 31 trigrams in 0.9ms
[trace] stale check: comparing index against filesystem...
[trace] stale check: 1 changed, 1 new, 1 deleted (walk: 5ms)
[trace] stale check: updated 3 files in 19.5ms (total: 29.1ms)
```
