### PR TITLE
feat: add count-files subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ Server status for /src/my-monorepo
   Indexing:   complete
 ```
 
+### Count files
+
+```bash
+tgrep count-files .              # count text files (no server needed)
+tgrep count-files /path/to/repo  # scan a specific repo
+```
+
+Prints the count to stdout (scriptable) and details to stderr:
+
+```
+284957
+284957 text files (47516 binary skipped, 0 errors) in 1200ms
+```
+
 ## CLI Flags
 
 | Flag | Description |

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -10,6 +10,7 @@ mod output;
 mod search;
 mod serve;
 mod status;
+mod walkcount;
 
 use std::path::PathBuf;
 use std::process;
@@ -235,6 +236,13 @@ enum Command {
         #[arg(default_value = ".")]
         path: PathBuf,
     },
+
+    /// Count text files in a directory (fast walker, no indexing).
+    CountFiles {
+        /// Root directory to scan.
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
 }
 
 impl Cli {
@@ -308,6 +316,7 @@ fn main() {
             ref path,
         }) => run_search(&cli, pattern.clone(), path),
         Some(Command::Status { path }) => status::run(&path, cli.index_path.as_deref()),
+        Some(Command::CountFiles { path }) => walkcount::run(&path, cli.hidden, cli.no_ignore),
         None => {
             if cli.list_files {
                 let opts = cli.build_search_opts(String::new());

--- a/tgrep-cli/src/walkcount.rs
+++ b/tgrep-cli/src/walkcount.rs
@@ -1,0 +1,34 @@
+/// `tgrep count-files` — count text files using the fast parallel walker.
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::Result;
+use tgrep_core::walker::{self, WalkOptions};
+
+pub fn run(root: &Path, include_hidden: bool, no_ignore: bool) -> Result<()> {
+    let root = std::fs::canonicalize(root)?;
+    let start = Instant::now();
+
+    let walk = walker::walk_dir(
+        &root,
+        &WalkOptions {
+            include_hidden,
+            no_ignore,
+            ..Default::default()
+        },
+    );
+
+    let elapsed = start.elapsed();
+    let total = walk.files.len();
+
+    println!("{total}");
+    eprintln!(
+        "{} text files ({} binary skipped, {} errors) in {:.0}ms",
+        total,
+        walk.skipped_binary,
+        walk.skipped_error,
+        elapsed.as_secs_f64() * 1000.0
+    );
+
+    Ok(())
+}

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -537,3 +537,46 @@ fn with_filename_and_no_filename_last_wins() {
     assert!(!stdout.contains("hello.rs"));
     assert!(stdout.contains("fn main()"));
 }
+
+// ─── count-files ────────────────────────────────────────────────────
+
+#[test]
+fn count_files_reports_correct_count() {
+    let dir = setup_fixture();
+    let output = tgrep()
+        .args(["count-files", &fixture_path(&dir)])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Fixture has 4 text files: hello.rs, lib.rs, config.toml, notes.txt
+    assert_eq!(stdout.trim(), "4");
+}
+
+#[test]
+fn count_files_stderr_has_details() {
+    let dir = setup_fixture();
+    let output = tgrep()
+        .args(["count-files", &fixture_path(&dir)])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("4 text files"));
+    assert!(stderr.contains("binary skipped"));
+}
+
+#[test]
+fn count_files_skips_binary() {
+    let dir = setup_fixture();
+    // Add a binary file (by extension)
+    fs::write(dir.path().join("testdata").join("image.png"), b"\x89PNG\r\n").unwrap();
+    let output = tgrep()
+        .args(["count-files", &fixture_path(&dir)])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Still 4 text files — png is skipped
+    assert_eq!(stdout.trim(), "4");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("1 binary skipped"));
+}

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -569,7 +569,11 @@ fn count_files_stderr_has_details() {
 fn count_files_skips_binary() {
     let dir = setup_fixture();
     // Add a binary file (by extension)
-    fs::write(dir.path().join("testdata").join("image.png"), b"\x89PNG\r\n").unwrap();
+    fs::write(
+        dir.path().join("testdata").join("image.png"),
+        b"\x89PNG\r\n",
+    )
+    .unwrap();
     let output = tgrep()
         .args(["count-files", &fixture_path(&dir)])
         .output()


### PR DESCRIPTION
Add `tgrep count-files` subcommand that runs the fast parallel walker and reports the number of text files.

## Usage

```bash
$ tgrep count-files /src/myrepo
284957
284957 text files (47516 binary skipped, 0 errors) in 1200ms
```

- **stdout**: clean count (for scripting, e.g. `if [ $(tgrep count-files .) -gt 50000 ]`)
- **stderr**: details (binary skipped, errors, timing)

Respects `--hidden` and `--no-ignore` flags.
