### PR TITLE
ci: add Azure Trusted Signing for Windows binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -51,6 +52,30 @@ jobs:
           cp target/${{ matrix.target }}/release/tgrep "$staging/"
           cp README.md "$staging/"
           tar czf tgrep-${{ github.ref_name }}-${{ matrix.target }}.tar.gz -C "$staging" .
+
+      - name: Azure login (Windows signing)
+        if: runner.os == 'Windows'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign binary (Windows)
+        if: runner.os == 'Windows'
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ vars.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ vars.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.TRUSTED_SIGNING_CERTIFICATE_PROFILE }}
+          files-folder: target/${{ matrix.target }}/release
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Package (windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary

Sign the Windows `tgrep.exe` release binary with Azure Trusted Signing (Authenticode) before packaging.

## Changes

- Added `id-token: write` permission for OIDC authentication with Azure
- Added `azure/login@v2` step for federated credential auth (Windows only)
- Added `azure/trusted-signing-action@v0` step to Authenticode-sign `tgrep.exe` with SHA-256 digest and RFC3161 timestamp (Windows only, runs before packaging)

## Required Configuration

The following must be set in the repo before this workflow will succeed:

| Type | Name | Description |
|---|---|---|
| Secret | `AZURE_CLIENT_ID` | App registration client ID |
| Secret | `AZURE_TENANT_ID` | Azure AD tenant ID |
| Secret | `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
| Secret | `AZURE_CLIENT_SECRET` | App registration secret |
| Variable | `TRUSTED_SIGNING_ENDPOINT` | e.g. `https://eus.codesigning.azure.net/` |
| Variable | `TRUSTED_SIGNING_ACCOUNT` | Trusted Signing account name |
| Variable | `TRUSTED_SIGNING_CERTIFICATE_PROFILE` | Certificate profile name |
