### PR TITLE
ci: add Windows ARM64 release build + bump version to 0.1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"


### PR DESCRIPTION
## Changes

- Add `aarch64-pc-windows-msvc` target to the release workflow matrix, enabling Windows ARM64 builds. Cross-compiles on `windows-latest` via `rustup target add` — no extra linker needed.
- Bump version from `0.1.4` to `0.1.5`.
