### PR TITLE
feat: add --exclude flag for index and serve subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "regex-syntax",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ tgrep is designed to be significantly faster than ripgrep on large repos:
 tgrep index .                          # index current directory
 tgrep index /path/to/repo             # index a specific repo
 tgrep index . --index-path /tmp/idx   # custom index location
+tgrep index . --exclude vendor --exclude third_party  # skip directories
 ```
 
 ### Start the server
@@ -78,6 +79,7 @@ tgrep index . --index-path /tmp/idx   # custom index location
 tgrep serve .                          # start server (auto-builds index if missing)
 tgrep serve . --index-path /tmp/idx    # custom index location
 tgrep serve . --no-watch               # skip file watcher (saves memory)
+tgrep serve . --exclude node_modules   # exclude directories from indexing
 ```
 
 The server builds the index in the background if none exists, and serves
@@ -189,6 +191,7 @@ Prints the count to stdout (scriptable) and details to stderr:
 | `--no-ignore` | Don't respect .gitignore files |
 | `-u` | Unrestricted: `-u` = no-ignore, `-uu` = +hidden |
 | `--no-index` | Skip index, grep all files |
+| `--exclude <DIR>` | Exclude directory from indexing (repeatable) |
 | `--stats` | Print query plan and candidate stats |
 | `--index-path <DIR>` | Custom index directory |
 

--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -4,7 +4,12 @@ use std::path::Path;
 use anyhow::Result;
 use tgrep_core::builder;
 
-pub fn run(root: &Path, index_path: Option<&Path>, include_hidden: bool) -> Result<()> {
-    builder::build_index(root, index_path, include_hidden)?;
+pub fn run(
+    root: &Path,
+    index_path: Option<&Path>,
+    include_hidden: bool,
+    exclude_dirs: &[String],
+) -> Result<()> {
+    builder::build_index(root, index_path, include_hidden, exclude_dirs)?;
     Ok(())
 }

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -207,6 +207,10 @@ enum Command {
         /// Force a full rebuild.
         #[arg(long)]
         force: bool,
+
+        /// Exclude directories from indexing (can be specified multiple times).
+        #[arg(long = "exclude", action = clap::ArgAction::Append)]
+        exclude: Vec<String>,
     },
 
     /// Start the persistent search server.
@@ -218,6 +222,10 @@ enum Command {
         /// Disable the file system watcher (saves memory on large repos).
         #[arg(long)]
         no_watch: bool,
+
+        /// Exclude directories from indexing (can be specified multiple times).
+        #[arg(long = "exclude", action = clap::ArgAction::Append)]
+        exclude: Vec<String>,
     },
 
     /// Search for a pattern.
@@ -305,12 +313,14 @@ fn main() {
     }
 
     let result = match cli.command {
-        Some(Command::Index { path, .. }) => {
-            index::run(&path, cli.index_path.as_deref(), cli.hidden)
+        Some(Command::Index { path, exclude, .. }) => {
+            index::run(&path, cli.index_path.as_deref(), cli.hidden, &exclude)
         }
-        Some(Command::Serve { path, no_watch }) => {
-            serve::run(&path, cli.index_path.as_deref(), no_watch)
-        }
+        Some(Command::Serve {
+            path,
+            no_watch,
+            exclude,
+        }) => serve::run(&path, cli.index_path.as_deref(), no_watch, &exclude),
         Some(Command::Search {
             ref pattern,
             ref path,

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -64,6 +64,8 @@ struct ServerState {
     index_progress: std::sync::atomic::AtomicU64,
     /// Total files discovered for indexing.
     index_total: std::sync::atomic::AtomicU64,
+    /// Directories to exclude from indexing.
+    exclude_dirs: Vec<String>,
 }
 
 struct SearchOpts {
@@ -75,7 +77,12 @@ struct SearchOpts {
     after_context: usize,
 }
 
-pub fn run(root: &Path, index_path: Option<&Path>, no_watch: bool) -> Result<()> {
+pub fn run(
+    root: &Path,
+    index_path: Option<&Path>,
+    no_watch: bool,
+    exclude_dirs: &[String],
+) -> Result<()> {
     let serve_start = Instant::now();
     let root = std::fs::canonicalize(root)?;
     let index_dir = index_path
@@ -123,6 +130,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, no_watch: bool) -> Result<()>
         indexing: std::sync::atomic::AtomicBool::new(needs_build),
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
+        exclude_dirs: exclude_dirs.to_vec(),
     });
 
     // Bind TCP listener on a random port
@@ -602,7 +610,8 @@ fn handle_reload(id: Option<serde_json::Value>, state: &ServerState) -> String {
     let index_dir = builder::default_index_dir(&state.root);
 
     // Rebuild from disk
-    if let Err(e) = builder::build_index(&state.root, Some(&index_dir), false) {
+    if let Err(e) = builder::build_index(&state.root, Some(&index_dir), false, &state.exclude_dirs)
+    {
         return json_rpc_error(id, -32000, &format!("rebuild failed: {e}"));
     }
 
@@ -826,7 +835,7 @@ fn background_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &P
     }
 
     // Walk filesystem metadata (no content reads)
-    let current_meta = walker::walk_file_metadata(root);
+    let current_meta = walker::walk_file_metadata(root, &state.exclude_dirs);
     let walk_ms = start.elapsed().as_millis();
 
     // Build lookup of current filesystem state
@@ -972,6 +981,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         root,
         &WalkOptions {
             include_hidden: false,
+            exclude_dirs: state.exclude_dirs.clone(),
             ..Default::default()
         },
     );
@@ -1091,7 +1101,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
 
     // Write per-file stamps for ALL walked files (including content-binary
     // ones) so the stale check on next startup is accurate.
-    let walk_meta = tgrep_core::walker::walk_file_metadata(root);
+    let walk_meta = tgrep_core::walker::walk_file_metadata(root, &state.exclude_dirs);
     let stamps: std::collections::HashMap<String, tgrep_core::meta::FileStamp> = walk_meta
         .into_iter()
         .map(|fm| {

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -584,3 +584,96 @@ fn count_files_skips_binary() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("1 binary skipped"));
 }
+
+// ─── --exclude (index) ─────────────────────────────────────────────
+
+/// Create a fixture with subdirectories to test --exclude during indexing.
+fn setup_exclude_fixture() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("vendor")).unwrap();
+    fs::create_dir_all(root.join("third_party")).unwrap();
+    fs::write(root.join("src/main.rs"), "fn main() { hello(); }").unwrap();
+    fs::write(root.join("vendor/dep.rs"), "fn hello() { dep(); }").unwrap();
+    fs::write(root.join("third_party/lib.rs"), "fn hello() { lib(); }").unwrap();
+    fs::write(root.join("README.md"), "# hello project").unwrap();
+    dir
+}
+
+#[test]
+fn index_exclude_single_dir() {
+    let dir = setup_exclude_fixture();
+    let root = dir.path().join("testdata");
+    let index_dir = dir.path().join("idx");
+
+    // Build index excluding vendor
+    tgrep()
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--exclude",
+            "vendor",
+        ])
+        .assert()
+        .success();
+
+    // Search the index for "hello" — should find src/main.rs and third_party/lib.rs
+    // but not vendor/dep.rs
+    let output = tgrep()
+        .args([
+            "hello",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "-l",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("src/main.rs") || stdout.contains("src\\main.rs"));
+    assert!(
+        stdout.contains("third_party/lib.rs") || stdout.contains("third_party\\lib.rs")
+    );
+    assert!(!stdout.contains("vendor"));
+}
+
+#[test]
+fn index_exclude_multiple_dirs() {
+    let dir = setup_exclude_fixture();
+    let root = dir.path().join("testdata");
+    let index_dir = dir.path().join("idx");
+
+    // Build index excluding both vendor and third_party
+    tgrep()
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--exclude",
+            "vendor",
+            "--exclude",
+            "third_party",
+        ])
+        .assert()
+        .success();
+
+    // Search the index for "hello" — should only find src/main.rs and README.md
+    let output = tgrep()
+        .args([
+            "hello",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "-l",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("src/main.rs") || stdout.contains("src\\main.rs"));
+    assert!(!stdout.contains("vendor"));
+    assert!(!stdout.contains("third_party"));
+}

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -634,9 +634,7 @@ fn index_exclude_single_dir() {
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("src/main.rs") || stdout.contains("src\\main.rs"));
-    assert!(
-        stdout.contains("third_party/lib.rs") || stdout.contains("third_party\\lib.rs")
-    );
+    assert!(stdout.contains("third_party/lib.rs") || stdout.contains("third_party\\lib.rs"));
     assert!(!stdout.contains("vendor"));
 }
 

--- a/tgrep-core/Cargo.toml
+++ b/tgrep-core/Cargo.toml
@@ -18,3 +18,6 @@ regex = "1"
 regex-syntax = "0.8"
 rayon = "1"
 ignore = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -13,7 +13,12 @@ use crate::walker;
 const INDEX_DIR_NAME: &str = ".tgrep";
 
 /// Build a trigram index for all text files under `root`.
-pub fn build_index(root: &Path, index_dir: Option<&Path>, include_hidden: bool) -> Result<()> {
+pub fn build_index(
+    root: &Path,
+    index_dir: Option<&Path>,
+    include_hidden: bool,
+    exclude_dirs: &[String],
+) -> Result<()> {
     let root = std::fs::canonicalize(root)?;
     let index_dir = match index_dir {
         Some(d) => d.to_path_buf(),
@@ -26,6 +31,7 @@ pub fn build_index(root: &Path, index_dir: Option<&Path>, include_hidden: bool) 
         &root,
         &walker::WalkOptions {
             include_hidden,
+            exclude_dirs: exclude_dirs.to_vec(),
             ..Default::default()
         },
     );

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -26,6 +26,8 @@ pub struct WalkOptions {
     pub include_hidden: bool,
     pub no_ignore: bool,
     pub search_binary: bool,
+    /// Directory names to exclude from walking (e.g., "vendor", "third_party").
+    pub exclude_dirs: Vec<String>,
 }
 
 /// Check if a file extension indicates a binary format.
@@ -48,6 +50,8 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
     let files = std::sync::Mutex::new(Vec::new());
     let skipped_binary = std::sync::atomic::AtomicUsize::new(0);
     let skipped_error = std::sync::atomic::AtomicUsize::new(0);
+    let exclude_dirs: std::sync::Arc<Vec<String>> = std::sync::Arc::new(opts.exclude_dirs.clone());
+    let search_binary = opts.search_binary;
 
     let walker = WalkBuilder::new(root)
         .hidden(!opts.include_hidden)
@@ -58,7 +62,11 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
         .build_parallel();
 
     walker.run(|| {
-        Box::new(|entry| {
+        let exclude = exclude_dirs.clone();
+        let files = &files;
+        let skipped_binary = &skipped_binary;
+        let skipped_error = &skipped_error;
+        Box::new(move |entry| {
             let entry = match entry {
                 Ok(e) => e,
                 Err(_) => {
@@ -67,13 +75,25 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
                 }
             };
 
+            // Skip excluded directories and their subtrees
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                if !exclude.is_empty() {
+                    if let Some(name) = entry.file_name().to_str() {
+                        if exclude.iter().any(|d| d == name) {
+                            return ignore::WalkState::Skip;
+                        }
+                    }
+                }
+                return ignore::WalkState::Continue;
+            }
+
             if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                 return ignore::WalkState::Continue;
             }
 
             let path = entry.path();
 
-            if !opts.search_binary {
+            if !search_binary {
                 if is_binary_extension(path) {
                     skipped_binary.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     return ignore::WalkState::Continue;
@@ -108,8 +128,9 @@ pub struct FileMeta {
 
 /// Walk a directory tree collecting only filesystem metadata (mtime, size).
 /// No file content is read — this is used for stale file detection on startup.
-pub fn walk_file_metadata(root: &Path) -> Vec<FileMeta> {
+pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String]) -> Vec<FileMeta> {
     let results = std::sync::Mutex::new(Vec::new());
+    let exclude: std::sync::Arc<Vec<String>> = std::sync::Arc::new(exclude_dirs.to_vec());
 
     let walker = WalkBuilder::new(root)
         .hidden(true) // skip hidden by default
@@ -120,11 +141,24 @@ pub fn walk_file_metadata(root: &Path) -> Vec<FileMeta> {
         .build_parallel();
 
     walker.run(|| {
-        Box::new(|entry| {
+        let exclude = exclude.clone();
+        let results = &results;
+        Box::new(move |entry| {
             let entry = match entry {
                 Ok(e) => e,
                 Err(_) => return ignore::WalkState::Continue,
             };
+
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                if !exclude.is_empty() {
+                    if let Some(name) = entry.file_name().to_str() {
+                        if exclude.iter().any(|d| d == name) {
+                            return ignore::WalkState::Skip;
+                        }
+                    }
+                }
+                return ignore::WalkState::Continue;
+            }
 
             if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                 return ignore::WalkState::Continue;

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -198,3 +198,138 @@ pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String]) -> Vec<FileMeta>
 
     results.into_inner().unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Create a temp directory with a structure for exclude testing:
+    ///   testdata/
+    ///     src/
+    ///       main.rs
+    ///     vendor/
+    ///       dep.rs
+    ///     third_party/
+    ///       lib.rs
+    ///     README.md
+    fn setup_fixture() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().join("testdata");
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("vendor")).unwrap();
+        fs::create_dir_all(root.join("third_party")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+        fs::write(root.join("vendor/dep.rs"), "pub fn dep() {}").unwrap();
+        fs::write(root.join("third_party/lib.rs"), "pub fn lib() {}").unwrap();
+        fs::write(root.join("README.md"), "# hello").unwrap();
+        dir
+    }
+
+    fn sorted_filenames(result: &WalkResult, root: &Path) -> Vec<String> {
+        let mut names: Vec<String> = result
+            .files
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn walk_dir_no_excludes_returns_all_files() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+        let result = walk_dir(&root, &WalkOptions::default());
+        let names = sorted_filenames(&result, &root);
+        assert_eq!(names, vec!["README.md", "src/main.rs", "third_party/lib.rs", "vendor/dep.rs"]);
+    }
+
+    #[test]
+    fn walk_dir_exclude_single_dir() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+        let result = walk_dir(
+            &root,
+            &WalkOptions {
+                exclude_dirs: vec!["vendor".to_string()],
+                ..Default::default()
+            },
+        );
+        let names = sorted_filenames(&result, &root);
+        assert!(names.contains(&"src/main.rs".to_string()));
+        assert!(names.contains(&"third_party/lib.rs".to_string()));
+        assert!(!names.contains(&"vendor/dep.rs".to_string()));
+    }
+
+    #[test]
+    fn walk_dir_exclude_multiple_dirs() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+        let result = walk_dir(
+            &root,
+            &WalkOptions {
+                exclude_dirs: vec!["vendor".to_string(), "third_party".to_string()],
+                ..Default::default()
+            },
+        );
+        let names = sorted_filenames(&result, &root);
+        assert_eq!(names, vec!["README.md", "src/main.rs"]);
+    }
+
+    #[test]
+    fn walk_dir_exclude_nonexistent_dir_is_noop() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+        let all = walk_dir(&root, &WalkOptions::default());
+        let with_bogus = walk_dir(
+            &root,
+            &WalkOptions {
+                exclude_dirs: vec!["nonexistent".to_string()],
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            sorted_filenames(&all, &root),
+            sorted_filenames(&with_bogus, &root),
+        );
+    }
+
+    #[test]
+    fn walk_dir_exclude_skips_nested_files() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+        // Add a nested file inside vendor
+        fs::create_dir_all(root.join("vendor/sub")).unwrap();
+        fs::write(root.join("vendor/sub/nested.rs"), "fn nested() {}").unwrap();
+
+        let result = walk_dir(
+            &root,
+            &WalkOptions {
+                exclude_dirs: vec!["vendor".to_string()],
+                ..Default::default()
+            },
+        );
+        let names = sorted_filenames(&result, &root);
+        assert!(!names.iter().any(|n| n.starts_with("vendor/")));
+    }
+
+    #[test]
+    fn walk_file_metadata_excludes_dirs() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+
+        let all = walk_file_metadata(&root, &[]);
+        let excluded = walk_file_metadata(&root, &["vendor".to_string()]);
+
+        assert!(all.iter().any(|f| f.relative_path.starts_with("vendor/")));
+        assert!(!excluded.iter().any(|f| f.relative_path.starts_with("vendor/")));
+        assert!(excluded.iter().any(|f| f.relative_path == "src/main.rs"));
+    }
+}

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -77,12 +77,11 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
 
             // Skip excluded directories and their subtrees
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                if !exclude.is_empty() {
-                    if let Some(name) = entry.file_name().to_str() {
-                        if exclude.iter().any(|d| d == name) {
-                            return ignore::WalkState::Skip;
-                        }
-                    }
+                if let Some(name) = entry.file_name().to_str()
+                    && !exclude.is_empty()
+                    && exclude.iter().any(|d| d == name)
+                {
+                    return ignore::WalkState::Skip;
                 }
                 return ignore::WalkState::Continue;
             }
@@ -150,12 +149,11 @@ pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String]) -> Vec<FileMeta>
             };
 
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                if !exclude.is_empty() {
-                    if let Some(name) = entry.file_name().to_str() {
-                        if exclude.iter().any(|d| d == name) {
-                            return ignore::WalkState::Skip;
-                        }
-                    }
+                if let Some(name) = entry.file_name().to_str()
+                    && !exclude.is_empty()
+                    && exclude.iter().any(|d| d == name)
+                {
+                    return ignore::WalkState::Skip;
                 }
                 return ignore::WalkState::Continue;
             }
@@ -248,7 +246,15 @@ mod tests {
         let root = dir.path().join("testdata");
         let result = walk_dir(&root, &WalkOptions::default());
         let names = sorted_filenames(&result, &root);
-        assert_eq!(names, vec!["README.md", "src/main.rs", "third_party/lib.rs", "vendor/dep.rs"]);
+        assert_eq!(
+            names,
+            vec![
+                "README.md",
+                "src/main.rs",
+                "third_party/lib.rs",
+                "vendor/dep.rs"
+            ]
+        );
     }
 
     #[test]
@@ -329,7 +335,11 @@ mod tests {
         let excluded = walk_file_metadata(&root, &["vendor".to_string()]);
 
         assert!(all.iter().any(|f| f.relative_path.starts_with("vendor/")));
-        assert!(!excluded.iter().any(|f| f.relative_path.starts_with("vendor/")));
+        assert!(
+            !excluded
+                .iter()
+                .any(|f| f.relative_path.starts_with("vendor/"))
+        );
         assert!(excluded.iter().any(|f| f.relative_path == "src/main.rs"));
     }
 }


### PR DESCRIPTION
## Summary

Add `--exclude` flag to `index` and `serve` subcommands, allowing directories to be excluded from indexing by name. Also bumps version to 0.1.6.

## Usage

```bash
tgrep index --exclude vendor --exclude third_party
tgrep serve --exclude node_modules --exclude .cache
```

The flag can be specified multiple times. Excluded directories are pruned entirely via `WalkState::Skip` in the parallel walker — their subtrees are never traversed.

## Changes

- **`tgrep-core/src/walker.rs`**: Added `exclude_dirs` field to `WalkOptions`; both `walk_dir` and `walk_file_metadata` now skip excluded directory subtrees
- **`tgrep-core/src/builder.rs`**: `build_index` accepts and passes through `exclude_dirs`
- **`tgrep-cli/src/main.rs`**: Added `--exclude` arg to `Index` and `Serve` subcommands
- **`tgrep-cli/src/serve.rs`**: `ServerState` stores `exclude_dirs`; threaded through to background build, stale check, and reload
- **`tgrep-cli/src/index.rs`**: Updated to pass `exclude_dirs`
- **`README.md`**: Documented `--exclude` in usage examples and CLI flags table
- **`Cargo.toml`**: Version bump to 0.1.6
