### PR TITLE
feat: prevent multiple servers on the same index directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +795,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "fs2",
  "lru",
  "notify",
  "predicates",
@@ -907,6 +918,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +941,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -24,6 +24,7 @@ notify = "7"
 rayon = "1"
 regex = "1"
 lru = "0.16.3"
+fs2 = "0.4.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2,6 +2,7 @@
 ///
 /// Keeps the trigram index in memory (HybridIndex), watches for filesystem
 /// changes, and serves search/status queries over TCP.
+use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::num::NonZeroUsize;
@@ -10,6 +11,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use fs2::FileExt;
 use lru::LruCache;
 
 use anyhow::Result;
@@ -53,6 +55,33 @@ impl ServerInfo {
     }
 }
 
+/// Attempt to acquire an exclusive lock on `serve.lock` inside the index
+/// directory. Returns the held `File` (must be kept alive for the duration of
+/// the server) or an error with a user-friendly message when another server is
+/// already running.
+fn try_acquire_server_lock(index_dir: &Path) -> Result<File> {
+    std::fs::create_dir_all(index_dir)?;
+    let lock_path = index_dir.join("serve.lock");
+    let file = File::create(&lock_path)?;
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(file),
+        Err(_) => {
+            // Another server holds the lock — provide a helpful message.
+            let detail = if let Ok(info) = ServerInfo::load(index_dir) {
+                format!(" (pid {}, port {})", info.pid, info.port,)
+            } else {
+                String::new()
+            };
+            anyhow::bail!(
+                "another tgrep server is already running for index directory `{}`{}. \
+                 Stop the existing server before starting a new one.",
+                index_dir.display(),
+                detail,
+            );
+        }
+    }
+}
+
 struct ServerState {
     index: RwLock<HybridIndex>,
     cache: RwLock<LruCache<String, Arc<String>>>,
@@ -88,6 +117,10 @@ pub fn run(
     let index_dir = index_path
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| builder::default_index_dir(&root));
+
+    // Ensure only one server runs per index directory.
+    // The lock file is held for the lifetime of the server and released on exit.
+    let _lock_file = try_acquire_server_lock(&index_dir)?;
 
     let has_index = index_dir.join("lookup.bin").exists();
 

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -675,3 +675,59 @@ fn index_exclude_multiple_dirs() {
     assert!(!stdout.contains("vendor"));
     assert!(!stdout.contains("third_party"));
 }
+
+// ─── serve lock ─────────────────────────────────────────────────────
+
+#[test]
+fn serve_rejects_second_server_on_same_index() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("hello.txt"), "hello world").unwrap();
+
+    let index_dir = dir.path().join("idx");
+
+    // Start first server in background using std::process::Command
+    let tgrep_bin = assert_cmd::cargo::cargo_bin("tgrep");
+    let mut server1 = std::process::Command::new(&tgrep_bin)
+        .args([
+            "serve",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--no-watch",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Wait for server1 to be ready (serve.json written)
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !index_dir.join("serve.json").exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "server1 did not start in time"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    // Try to start second server on the same index — should fail
+    tgrep()
+        .args([
+            "serve",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--no-watch",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "another tgrep server is already running",
+        ));
+
+    // Clean up: kill server1
+    server1.kill().ok();
+    server1.wait().ok();
+}


### PR DESCRIPTION
## Summary

Prevents multiple `tgrep serve` instances from running on the same index directory, which could cause index corruption and `serve.json` overwrites.

## Changes

- **serve.rs**: Added `try_acquire_server_lock()` using fs2 crate for cross-platform exclusive file locking on `serve.lock`
- **Cargo.toml**: Added fs2 dependency
- **Integration test**: Verifies second server exits with clear error message

## Behavior

When a second server attempts to start on the same index directory:

```
Error: another tgrep server is already running for index directory .tgrep (pid 12345, port 49152). Stop the existing server before starting a new one.
```

The lock is held for the server lifetime and automatically released on exit (normal, crash, or kill).
