### PR TITLE
fix: suppress spurious reindex events during initial build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -693,6 +693,13 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path) -> Option<Recommende
 }
 
 fn handle_fs_event(state: &ServerState, root: &Path, event: &Event) {
+    // Skip file events while the initial background index build is in progress —
+    // the indexer will pick up all files itself, and the watcher would just
+    // cause duplicate reindex work.
+    if state.indexing.load(std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+
     let dominated_kinds = matches!(
         event.kind,
         EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)


### PR DESCRIPTION
## Summary

Suppresses spurious `reindex: modified` log messages during the initial background index build.

## Problem

The file watcher starts concurrently with the background indexer. As the indexer reads files, the OS fires modify events that the watcher picks up, causing duplicate reindex work and noisy log output.

## Fix

Added a check at the top of `handle_fs_event` to skip all watcher events while `state.indexing` is true. The `auto_save_loop` already had this guard but the watcher handler did not.
