### PR TITLE
fix: add regex safeguards and escape benchmark query

### DIFF
--- a/scripts/benchmark-queries-gecko.json
+++ b/scripts/benchmark-queries-gecko.json
@@ -106,7 +106,7 @@
     "virtual\\s+.*\\s*=\\s*0",
     "static_assert",
     "constexpr",
-    "[[nodiscard]]",
+    "\\[\\[nodiscard\\]\\]",
     "std::move",
     "std::unique_ptr",
     "UniquePtr",

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -597,7 +597,7 @@ fn match_content(line: &str, re: &regex::Regex, only_matching: bool) -> String {
     }
 }
 
-fn build_combined_regex(
+pub fn build_combined_regex(
     patterns: &[String],
     case_insensitive: bool,
     fixed_string: bool,
@@ -636,6 +636,9 @@ fn build_combined_regex(
         .case_insensitive(case_insensitive)
         .multi_line(multiline)
         .dot_matches_new_line(multiline)
+        .size_limit(10 * (1 << 20)) // 10 MB compiled regex limit
+        .dfa_size_limit(10 * (1 << 20)) // 10 MB DFA cache limit
+        .nest_limit(200)
         .build()
         .map_err(|e| anyhow::anyhow!("regex error: {e}"))
 }

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -17,7 +17,6 @@ use lru::LruCache;
 use anyhow::Result;
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use rayon::prelude::*;
-use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 
 use tgrep_core::builder;
@@ -358,42 +357,15 @@ fn handle_search(
     let mut all_patterns = vec![pattern.to_string()];
     all_patterns.extend(extra_patterns);
 
-    let combined = if all_patterns.len() == 1 {
-        let mut p = if fixed_string {
-            regex::escape(&all_patterns[0])
-        } else {
-            all_patterns[0].clone()
-        };
-        if word_boundary {
-            p = format!(r"\b(?:{p})\b");
-        }
-        p
-    } else {
-        let parts: Vec<String> = all_patterns
-            .iter()
-            .map(|p| {
-                let mut p = if fixed_string {
-                    regex::escape(p)
-                } else {
-                    p.clone()
-                };
-                if word_boundary {
-                    p = format!(r"\b(?:{p})\b");
-                }
-                p
-            })
-            .collect();
-        format!("(?:{})", parts.join("|"))
-    };
-
-    let re = match RegexBuilder::new(&combined)
-        .case_insensitive(case_insensitive)
-        .multi_line(multiline)
-        .dot_matches_new_line(multiline)
-        .build()
-    {
+    let re = match crate::search::build_combined_regex(
+        &all_patterns,
+        case_insensitive,
+        fixed_string,
+        word_boundary,
+        multiline,
+    ) {
         Ok(r) => r,
-        Err(e) => return json_rpc_error(id, -32602, &format!("regex error: {e}")),
+        Err(e) => return json_rpc_error(id, -32602, &format!("{e}")),
     };
 
     // Build query plan from primary pattern for index filtering


### PR DESCRIPTION
## Summary

Fixes the gecko benchmark CI failure and adds regex safeguards to prevent similar hangs.

## Changes

1. **Escape `[[nodiscard]]` in benchmark queries** — unescaped brackets caused tgrep to hang during DFA construction
2. **Add regex size limits** to `RegexBuilder` in both `search.rs` and `serve.rs`:
   - `size_limit(10 MB)` — caps compiled regex size
   - `dfa_size_limit(10 MB)` — caps DFA cache
   - `nest_limit(200)` — prevents stack overflow from deeply nested patterns

Patterns exceeding these limits now return a clean error instead of hanging.
