### PR TITLE
Update regex size limits and bump version to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -636,9 +636,9 @@ pub fn build_combined_regex(
         .case_insensitive(case_insensitive)
         .multi_line(multiline)
         .dot_matches_new_line(multiline)
-        .size_limit(10 * (1 << 20)) // 10 MB compiled regex limit
-        .dfa_size_limit(10 * (1 << 20)) // 10 MB DFA cache limit
-        .nest_limit(200)
+        .size_limit(100 * (1 << 20))
+        .dfa_size_limit(1000 * (1 << 20))
+        .nest_limit(250)
         .build()
         .map_err(|e| anyhow::anyhow!("regex error: {e}"))
 }


### PR DESCRIPTION
1. Bump workspace version from 0.1.8 to 0.1.9.
2. Update regex size limits to RegexBuilder in both search.rs and serve.rs:
- size_limit(100 MB) — caps compiled regex size
- dfa_size_limit(1 GB) — caps DFA cache
- nest_limit(250) — prevents stack overflow from deeply nested patterns