### PR TITLE
fix: increase ripgrep benchmark timeout and fix exit code handling

### DIFF
--- a/scripts/benchmark.ps1
+++ b/scripts/benchmark.ps1
@@ -184,7 +184,7 @@ try {
 $rgCmd = Get-Command rg -ErrorAction SilentlyContinue
 $rgMs = -1
 $rgTimeouts = 0
-$rgTimeoutMs = 10000
+$rgTimeoutMs = 120000
 $rgTimeoutSec = $rgTimeoutMs / 1000
 if ($rgCmd) {
     Write-Host "`n==> Benchmarking ripgrep (${rgTimeoutSec}s timeout per query)..." -ForegroundColor Cyan

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -226,7 +226,7 @@ cleanup_serve
 # ── Benchmark: ripgrep ──
 RG_MS=-1
 RG_TIMEOUTS=0
-RG_TIMEOUT_SEC=10
+RG_TIMEOUT_SEC=120
 if command -v rg >/dev/null 2>&1; then
   # Detect timeout command (macOS needs gtimeout from coreutils)
   TIMEOUT_CMD=""
@@ -244,8 +244,8 @@ if command -v rg >/dev/null 2>&1; then
     QIDX=$((QIDX + 1))
     echo "  [$QIDX/$QUERY_COUNT] $pattern"
     if [ -n "$TIMEOUT_CMD" ]; then
-      $TIMEOUT_CMD "$RG_TIMEOUT_SEC" rg -n "$pattern" "$BENCH_REPO_DIR" > /dev/null 2>&1
-      rc=$?
+      rc=0
+      $TIMEOUT_CMD "$RG_TIMEOUT_SEC" rg -n "$pattern" "$BENCH_REPO_DIR" > /dev/null 2>&1 || rc=$?
       if [ $rc -eq 124 ]; then
         echo "    ⚠ timed out (${RG_TIMEOUT_SEC}s)"
         RG_TIMEOUTS=$((RG_TIMEOUTS + 1))


### PR DESCRIPTION
## Changes

- Increase ripgrep per-query timeout from 10s to 120s (large repos on standard runners need more time)
- Fix `set -e` abort in benchmark.sh: capture timeout exit code with `|| rc=$?` instead of bare command that kills the script on non-zero exit

Updated both `benchmark.sh` and `benchmark.ps1`.
