### PR TITLE
ci: use standard runners for chromium benchmarks

### DIFF
--- a/.github/workflows/benchmark-chromium-win.yml
+++ b/.github/workflows/benchmark-chromium-win.yml
@@ -10,7 +10,7 @@ jobs:
   benchmark:
     name: Benchmark Chromium (Windows)
     timeout-minutes: 180
-    runs-on: windows-latest-16-core
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/benchmark-chromium.yml
+++ b/.github/workflows/benchmark-chromium.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 180
     strategy:
       matrix:
-        os: [ubuntu-latest-16-core, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Changes

- `benchmark-chromium.yml`: `ubuntu-latest-16-core` → `ubuntu-latest`
- `benchmark-chromium-win.yml`: `windows-latest-16-core` → `windows-latest`
