### PR TITLE
Switch Linux builds to musl static binaries and bump to v0.1.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
+            use_cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
           - os: macos-latest
@@ -36,15 +37,23 @@ jobs:
         run: |
           rustup target add ${{ matrix.target }}
 
-      - name: Install cross-linker (aarch64-linux)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
+      - name: Install musl-tools (x86_64-linux-musl)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          sudo apt-get install -y musl-tools
+
+      - name: Install cross (aarch64-linux-musl)
+        if: matrix.use_cross
+        run: cargo install cross --locked
 
       - name: Build release binary
+        if: ${{ !matrix.use_cross }}
         run: cargo build --release --locked -p tgrep-cli --bin tgrep --target ${{ matrix.target }}
+
+      - name: Build release binary (cross)
+        if: ${{ matrix.use_cross }}
+        run: cross build --release --locked -p tgrep-cli --bin tgrep --target ${{ matrix.target }}
 
       - name: Package (unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install cross (aarch64-linux-musl)
         if: matrix.use_cross
-        run: cargo install cross --locked
+        run: cargo install cross --locked --version 0.2.5
 
       - name: Build release binary
         if: ${{ !matrix.use_cross }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ for Linux, macOS (Intel & Apple Silicon), and Windows.
 
 ```bash
 # Linux (x86_64)
-gh release download --repo microsoft/tgrep -p '*x86_64-unknown-linux-gnu*' -D /tmp/tgrep-dl
-tar xzf /tmp/tgrep-dl/tgrep-*-x86_64-unknown-linux-gnu.tar.gz -C ~/.local/bin
+gh release download --repo microsoft/tgrep -p '*x86_64-unknown-linux-musl*' -D /tmp/tgrep-dl
+tar xzf /tmp/tgrep-dl/tgrep-*-x86_64-unknown-linux-musl.tar.gz -C ~/.local/bin
 
 # macOS (Apple Silicon)
 gh release download --repo microsoft/tgrep -p '*aarch64-apple-darwin*' -D /tmp/tgrep-dl

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,8 +17,8 @@ detect_target() {
     case "$os" in
         Linux)
             case "$arch" in
-                x86_64)  echo "x86_64-unknown-linux-gnu" ;;
-                aarch64) echo "aarch64-unknown-linux-gnu" ;;
+                x86_64)  echo "x86_64-unknown-linux-musl" ;;
+                aarch64) echo "aarch64-unknown-linux-musl" ;;
                 *)       error "Unsupported architecture: $arch" ;;
             esac
             ;;


### PR DESCRIPTION
## Problem

All 230 test failures in swebench-pro and mfa suites due to **GLIBC version incompatibility** — the tgrep binary built on `ubuntu-latest` links against glibc 2.32+, but the Docker images ship older glibc:

```
GLIBC_2.32 not found (required by tgrep)
GLIBC_2.33 not found (required by tgrep)
GLIBC_2.34 not found (required by tgrep)
```

## Fix

Switch Linux release targets from `gnu` to `musl` to produce **fully static binaries** with zero glibc dependency.

### Changes
- **release.yml**: x86_64/aarch64-unknown-linux-gnu → musl targets; uses musl-tools for x86_64 and cross for aarch64 cross-compilation
- **install.sh**: Updated target detection to match new musl target names
- **README.md**: Updated manual download example
- **Cargo.toml** / **Cargo.lock**: Version bump 0.1.9 → 0.1.10
