### PR TITLE
fix: disable /CETCOMPAT for ARM64 Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
         if: matrix.use_cross
         run: cargo install cross --locked --version 0.2.5
 
+      - name: Disable /CETCOMPAT for ARM64 Windows
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        shell: pwsh
+        run: echo "RUSTFLAGS=-Clink-args=/CETCOMPAT:NO" >> $env:GITHUB_ENV
+
       - name: Build release binary
         if: ${{ !matrix.use_cross }}
         run: cargo build --release --locked -p tgrep-cli --bin tgrep --target ${{ matrix.target }}


### PR DESCRIPTION
The MSVC linker rejects `/CETCOMPAT` on ARM64 targets (`LNK1246`), causing the `aarch64-pc-windows-msvc` release build to fail.

This adds a workflow step that sets `RUSTFLAGS=-Clink-args=/CETCOMPAT:NO` for the ARM64 Windows matrix entry, disabling the incompatible flag.

Failed run: https://github.com/microsoft/tgrep/actions/runs/24496733215