### PR TITLE
fix(index): validate path length and detect truncated files.bin

### DIFF
--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -187,7 +187,7 @@ pub fn write_index_from_snapshot(
     let mut files_file =
         std::io::BufWriter::new(std::fs::File::create(index_dir.join("files.bin"))?);
     for (id, path) in paths.iter().enumerate() {
-        files_file.write_all(&ondisk::encode_file_entry(id as u32, path))?;
+        files_file.write_all(&ondisk::encode_file_entry(id as u32, path)?)?;
     }
     files_file.flush()?;
 
@@ -252,7 +252,7 @@ fn write_index_v2(
     let mut files_file =
         std::io::BufWriter::new(std::fs::File::create(index_dir.join("files.bin"))?);
     for (id, path) in file_id_map {
-        files_file.write_all(&ondisk::encode_file_entry(*id, path))?;
+        files_file.write_all(&ondisk::encode_file_entry(*id, path)?)?;
     }
     files_file.flush()?;
 

--- a/tgrep-core/src/ondisk.rs
+++ b/tgrep-core/src/ondisk.rs
@@ -88,11 +88,21 @@ pub(crate) const MAX_PATH_LEN: usize = u16::MAX as usize;
 pub(crate) fn encode_file_entry(file_id: u32, path: &str) -> crate::Result<Vec<u8>> {
     let path_bytes = path.as_bytes();
     if path_bytes.len() > MAX_PATH_LEN {
+        // Avoid embedding a 64KiB+ path into the error message (memory
+        // pressure and log spam, and potentially echoes untrusted content).
+        // Include only the length and a short prefix for diagnostics.
+        const PREVIEW: usize = 80;
+        let preview_end = path
+            .char_indices()
+            .take_while(|(i, _)| *i < PREVIEW)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
         return Err(crate::Error::IndexCorrupted(format!(
-            "path too long for index ({} bytes, max {}): {}",
+            "path too long for index ({} bytes, max {}): \"{}…\"",
             path_bytes.len(),
             MAX_PATH_LEN,
-            path
+            &path[..preview_end],
         )));
     }
     let path_len = path_bytes.len() as u16;

--- a/tgrep-core/src/ondisk.rs
+++ b/tgrep-core/src/ondisk.rs
@@ -74,33 +74,66 @@ impl LookupEntry {
     }
 }
 
+/// Maximum supported path length (in bytes) for entries in `files.bin`.
+///
+/// Limited by the `u16` length prefix in the on-disk format.
+pub(crate) const MAX_PATH_LEN: usize = u16::MAX as usize;
+
 /// Encode a file entry for `files.bin`.
-pub(crate) fn encode_file_entry(file_id: u32, path: &str) -> Vec<u8> {
+///
+/// Returns `Error::IndexCorrupted` if the path exceeds [`MAX_PATH_LEN`] bytes,
+/// since the on-disk format uses a `u16` length prefix and a silent truncation
+/// here would corrupt the entire trailing portion of `files.bin` (the decoder
+/// reads variable-length records sequentially).
+pub(crate) fn encode_file_entry(file_id: u32, path: &str) -> crate::Result<Vec<u8>> {
     let path_bytes = path.as_bytes();
+    if path_bytes.len() > MAX_PATH_LEN {
+        return Err(crate::Error::IndexCorrupted(format!(
+            "path too long for index ({} bytes, max {}): {}",
+            path_bytes.len(),
+            MAX_PATH_LEN,
+            path
+        )));
+    }
     let path_len = path_bytes.len() as u16;
     let mut buf = Vec::with_capacity(4 + 2 + path_bytes.len());
     buf.extend_from_slice(&file_id.to_le_bytes());
     buf.extend_from_slice(&path_len.to_le_bytes());
     buf.extend_from_slice(path_bytes);
-    buf
+    Ok(buf)
 }
 
 /// Decode file entries from `files.bin` data.
-pub(crate) fn decode_file_entries(data: &[u8]) -> Vec<(u32, String)> {
+///
+/// Returns `Error::IndexCorrupted` if `data` is truncated mid-record (i.e.
+/// not enough bytes for a declared path or a partial header), so that callers
+/// don't silently load a partial file table that would cause queries to drop
+/// matches.
+pub(crate) fn decode_file_entries(data: &[u8]) -> crate::Result<Vec<(u32, String)>> {
     let mut entries = Vec::new();
     let mut pos = 0;
-    while pos + 6 <= data.len() {
+    while pos < data.len() {
+        if pos + 6 > data.len() {
+            return Err(crate::Error::IndexCorrupted(format!(
+                "files.bin truncated: {} trailing bytes < 6-byte header",
+                data.len() - pos
+            )));
+        }
         let file_id = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap());
         let path_len = u16::from_le_bytes(data[pos + 4..pos + 6].try_into().unwrap()) as usize;
         pos += 6;
         if pos + path_len > data.len() {
-            break;
+            return Err(crate::Error::IndexCorrupted(format!(
+                "files.bin truncated: declared path_len {} exceeds remaining {} bytes",
+                path_len,
+                data.len() - pos
+            )));
         }
         let path = String::from_utf8_lossy(&data[pos..pos + path_len]).into_owned();
         entries.push((file_id, path));
         pos += path_len;
     }
-    entries
+    Ok(entries)
 }
 
 #[cfg(test)]
@@ -123,14 +156,63 @@ mod tests {
 
     #[test]
     fn test_file_entry_roundtrip() {
-        let encoded = encode_file_entry(7, "src/main.rs");
+        let encoded = encode_file_entry(7, "src/main.rs").unwrap();
         let mut all = Vec::new();
         all.extend_from_slice(&encoded);
-        all.extend_from_slice(&encode_file_entry(12, "README.md"));
-        let entries = decode_file_entries(&all);
+        all.extend_from_slice(&encode_file_entry(12, "README.md").unwrap());
+        let entries = decode_file_entries(&all).unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0], (7, "src/main.rs".to_string()));
         assert_eq!(entries[1], (12, "README.md".to_string()));
+    }
+
+    #[test]
+    fn test_encode_file_entry_rejects_oversized_path() {
+        // A path longer than u16::MAX bytes must error rather than silently
+        // truncate the on-disk `path_len` field.
+        let huge = "a".repeat(MAX_PATH_LEN + 1);
+        let err = encode_file_entry(0, &huge).unwrap_err();
+        match err {
+            crate::Error::IndexCorrupted(_) => {}
+            other => panic!("expected IndexCorrupted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_encode_file_entry_accepts_max_path() {
+        let max = "a".repeat(MAX_PATH_LEN);
+        let buf = encode_file_entry(0, &max).expect("max-length path should encode");
+        let entries = decode_file_entries(&buf).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, 0);
+        assert_eq!(entries[0].1.len(), MAX_PATH_LEN);
+    }
+
+    #[test]
+    fn test_decode_file_entries_rejects_truncated_header() {
+        // Two well-formed entries followed by 3 stray bytes (incomplete header).
+        let mut all = encode_file_entry(1, "a.rs").unwrap();
+        all.extend_from_slice(&encode_file_entry(2, "b.rs").unwrap());
+        all.extend_from_slice(&[0u8, 0, 0]);
+        let err = decode_file_entries(&all).unwrap_err();
+        assert!(matches!(err, crate::Error::IndexCorrupted(_)));
+    }
+
+    #[test]
+    fn test_decode_file_entries_rejects_truncated_path() {
+        // Header claims 100-byte path but only 5 bytes follow.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&7u32.to_le_bytes());
+        buf.extend_from_slice(&100u16.to_le_bytes());
+        buf.extend_from_slice(b"hello");
+        let err = decode_file_entries(&buf).unwrap_err();
+        assert!(matches!(err, crate::Error::IndexCorrupted(_)));
+    }
+
+    #[test]
+    fn test_decode_file_entries_empty_ok() {
+        let entries = decode_file_entries(&[]).unwrap();
+        assert!(entries.is_empty());
     }
 
     #[test]

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -39,7 +39,11 @@ impl IndexReader {
             // entry size would cause silent truncation of the trailing entry
             // (and binary search would still see it via integer division).
             // Reject up-front so the failure is loud and obvious.
-            if !(lookup_meta.len() as usize).is_multiple_of(LOOKUP_ENTRY_SIZE) {
+            //
+            // Do the modulo in u64 (file sizes are u64) so a >4GiB file on
+            // 32-bit targets isn't truncated by an `as usize` cast before
+            // the validation runs.
+            if lookup_meta.len() % (LOOKUP_ENTRY_SIZE as u64) != 0 {
                 return Err(crate::Error::IndexCorrupted(format!(
                     "lookup.bin size {} is not a multiple of {}",
                     lookup_meta.len(),
@@ -61,10 +65,31 @@ impl IndexReader {
         // resulting in queries that returned empty file paths for high IDs.
         let files_data = std::fs::read(&files_path)?;
         let file_entries = ondisk::decode_file_entries(&files_data)?;
-        // Size the table to fit the largest declared id, not just the entry
-        // count, so that any future sparse-id writers don't drop entries.
-        let max_id = file_entries.iter().map(|(id, _)| *id as usize).max();
-        let mut file_paths = vec![String::new(); max_id.map(|m| m + 1).unwrap_or(0)];
+
+        // Validate that file IDs are dense (0..N) with no duplicates.
+        // Without this, a corrupted files.bin declaring an id like
+        // u32::MAX would cause `vec![String::new(); max_id + 1]` to attempt
+        // a multi-GiB allocation and likely OOM/crash. Current writers
+        // always assign dense IDs starting at 0, so this is a strict
+        // tightening of the format invariant rather than a behavior change.
+        let n = file_entries.len();
+        let mut seen = vec![false; n];
+        for (id, _) in &file_entries {
+            let idx = *id as usize;
+            if idx >= n {
+                return Err(crate::Error::IndexCorrupted(format!(
+                    "files.bin contains out-of-range file_id {id} (entry count = {n}); \
+                     IDs must be dense in 0..{n}"
+                )));
+            }
+            if seen[idx] {
+                return Err(crate::Error::IndexCorrupted(format!(
+                    "files.bin contains duplicate file_id {id}"
+                )));
+            }
+            seen[idx] = true;
+        }
+        let mut file_paths = vec![String::new(); n];
         for (id, path) in file_entries {
             file_paths[id as usize] = path;
         }
@@ -187,5 +212,107 @@ impl IndexReader {
             }
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    /// Write a minimal trio of index files so `IndexReader::open` runs the
+    /// validation paths we want to exercise.
+    fn write_index(
+        dir: &Path,
+        lookup_bytes: &[u8],
+        postings_bytes: &[u8],
+        files_bytes: &[u8],
+    ) {
+        std::fs::create_dir_all(dir).unwrap();
+        let mut f = std::fs::File::create(dir.join("lookup.bin")).unwrap();
+        f.write_all(lookup_bytes).unwrap();
+        let mut f = std::fs::File::create(dir.join("index.bin")).unwrap();
+        f.write_all(postings_bytes).unwrap();
+        let mut f = std::fs::File::create(dir.join("files.bin")).unwrap();
+        f.write_all(files_bytes).unwrap();
+    }
+
+    fn open_err(dir: &Path) -> crate::Error {
+        match IndexReader::open(dir) {
+            Ok(_) => panic!("expected IndexReader::open to fail"),
+            Err(e) => e,
+        }
+    }
+
+    #[test]
+    fn open_rejects_lookup_with_non_multiple_size() {
+        let tmp = TempDir::new().unwrap();
+        // 1 byte short of a single LOOKUP_ENTRY_SIZE-sized record.
+        let lookup = vec![0u8; LOOKUP_ENTRY_SIZE - 1];
+        // postings non-empty so we get past the `len() == 0` short-circuit.
+        let postings = vec![0u8; POSTING_ENTRY_SIZE];
+        write_index(tmp.path(), &lookup, &postings, &[]);
+        match open_err(tmp.path()) {
+            crate::Error::IndexCorrupted(msg) => {
+                assert!(
+                    msg.contains("lookup.bin"),
+                    "expected lookup.bin diagnostic, got: {msg}"
+                );
+            }
+            other => panic!("expected IndexCorrupted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_accepts_empty_index() {
+        // Both lookup.bin and postings.bin are zero-length: legitimate case
+        // for a freshly-created server with no files indexed yet.
+        let tmp = TempDir::new().unwrap();
+        write_index(tmp.path(), &[], &[], &[]);
+        let reader = IndexReader::open(tmp.path()).expect("empty index should open");
+        assert_eq!(reader.num_entries, 0);
+        assert!(reader.file_paths.is_empty());
+    }
+
+    #[test]
+    fn open_rejects_files_with_out_of_range_id() {
+        let tmp = TempDir::new().unwrap();
+        // Single record whose declared file_id (5) is past entry count (1).
+        // Without the dense-id check this would attempt to allocate a
+        // `Vec<String>` of size 6 for a single entry — and a u32::MAX id
+        // would attempt a multi-GiB allocation.
+        let entry = ondisk::encode_file_entry(5, "a.rs").unwrap();
+        write_index(tmp.path(), &[], &[], &entry);
+        match open_err(tmp.path()) {
+            crate::Error::IndexCorrupted(msg) => assert!(msg.contains("out-of-range")),
+            other => panic!("expected IndexCorrupted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_rejects_files_with_duplicate_id() {
+        let tmp = TempDir::new().unwrap();
+        let mut buf = ondisk::encode_file_entry(0, "a.rs").unwrap();
+        buf.extend_from_slice(&ondisk::encode_file_entry(0, "b.rs").unwrap());
+        write_index(tmp.path(), &[], &[], &buf);
+        match open_err(tmp.path()) {
+            crate::Error::IndexCorrupted(msg) => assert!(msg.contains("duplicate")),
+            other => panic!("expected IndexCorrupted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_accepts_dense_files_table() {
+        let tmp = TempDir::new().unwrap();
+        let mut buf = ondisk::encode_file_entry(0, "a.rs").unwrap();
+        buf.extend_from_slice(&ondisk::encode_file_entry(1, "b.rs").unwrap());
+        buf.extend_from_slice(&ondisk::encode_file_entry(2, "c.rs").unwrap());
+        write_index(tmp.path(), &[], &[], &buf);
+        let reader = IndexReader::open(tmp.path()).expect("dense IDs should be accepted");
+        assert_eq!(reader.file_paths.len(), 3);
+        assert_eq!(reader.file_paths[0], "a.rs");
+        assert_eq!(reader.file_paths[1], "b.rs");
+        assert_eq!(reader.file_paths[2], "c.rs");
     }
 }

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -35,6 +35,17 @@ impl IndexReader {
         {
             (None, None, 0)
         } else {
+            // A corrupted lookup.bin whose size is not a multiple of the fixed
+            // entry size would cause silent truncation of the trailing entry
+            // (and binary search would still see it via integer division).
+            // Reject up-front so the failure is loud and obvious.
+            if !(lookup_meta.len() as usize).is_multiple_of(LOOKUP_ENTRY_SIZE) {
+                return Err(crate::Error::IndexCorrupted(format!(
+                    "lookup.bin size {} is not a multiple of {}",
+                    lookup_meta.len(),
+                    LOOKUP_ENTRY_SIZE
+                )));
+            }
             let lookup_file = File::open(&lookup_path)?;
             let postings_file = File::open(&postings_path)?;
             // SAFETY: Files are opened read-only and the Mmap lifetime is tied to
@@ -46,14 +57,16 @@ impl IndexReader {
             (Some(lk), Some(pk), n)
         };
 
-        // Load file paths
+        // Load file paths. A truncated files.bin used to be silently accepted,
+        // resulting in queries that returned empty file paths for high IDs.
         let files_data = std::fs::read(&files_path)?;
-        let file_entries = ondisk::decode_file_entries(&files_data);
-        let mut file_paths = vec![String::new(); file_entries.len()];
+        let file_entries = ondisk::decode_file_entries(&files_data)?;
+        // Size the table to fit the largest declared id, not just the entry
+        // count, so that any future sparse-id writers don't drop entries.
+        let max_id = file_entries.iter().map(|(id, _)| *id as usize).max();
+        let mut file_paths = vec![String::new(); max_id.map(|m| m + 1).unwrap_or(0)];
         for (id, path) in file_entries {
-            if (id as usize) < file_paths.len() {
-                file_paths[id as usize] = path;
-            }
+            file_paths[id as usize] = path;
         }
 
         Ok(Self {


### PR DESCRIPTION
Three related on-disk-format robustness fixes for the trigram index:

1. encode_file_entry: reject paths longer than u16::MAX bytes instead of silently truncating the path_len field, which would corrupt every subsequent record in files.bin (variable-length records are read sequentially). Now returns Result and surfaces an IndexCorrupted error.

2. decode_file_entries: return Result<_, IndexCorrupted> when files.bin is truncated mid-record. Previously the decoder silently stopped at the truncation point, leaving the IndexReader with a partial file table whose missing high IDs caused queries to drop matches with no error.

3. IndexReader::open: reject lookup.bin whose size is not a multiple of LOOKUP_ENTRY_SIZE (would otherwise be silently rounded down by integer division), and size the file_paths table by the largest declared id rather than the entry count so that no entry can be silently dropped.

Adds focused unit tests for each new error path and the round-trip max-length boundary.