### PR TITLE
Implemented lock-free reader swap so the server serves searches throughout index flushing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -750,42 +750,43 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
                 continue;
             }
 
-            // Brief write lock: swap files and reopen
-            {
-                let mut index = state.index.write().unwrap();
-                index.drop_reader();
-                if let Err(e) = move_staged_files(&staging_dir, index_dir) {
-                    eprintln!("[trace] auto-save move failed: {e}");
-                    let _ = std::fs::remove_dir_all(&staging_dir);
-                    // Try to reopen old reader; LiveIndex is still intact.
-                    if let Err(e2) = index.reopen_reader(index_dir) {
-                        eprintln!("[trace] warning: reader reopen also failed: {e2}");
-                    }
-                    continue;
-                }
-                // Reopen reader, keep LiveIndex as fallback, prune persisted entries.
-                let num_files = paths.len();
-                match index.reopen_reader(index_dir) {
-                    Ok(()) => {
-                        let reader_files = index.reader_file_count();
-                        if reader_files >= num_files {
+            // Lock-free publish: rename staging files into place, build a
+            // new IndexReader, then swap it in via a brief read lock. Search
+            // queries are NOT blocked: they continue to be served by the
+            // previous reader (whose mmap stays valid until the last
+            // in-flight Arc<IndexReader> is dropped) and by the live overlay
+            // throughout the entire publish.
+            let num_files = paths.len();
+            if let Err(e) = move_staged_files(&staging_dir, index_dir) {
+                eprintln!("[trace] auto-save move failed: {e}");
+                let _ = std::fs::remove_dir_all(&staging_dir);
+                continue;
+            }
+            match tgrep_core::reader::IndexReader::open(index_dir) {
+                Ok(new_reader) => {
+                    let reader_files = new_reader.num_files();
+                    if reader_files >= num_files {
+                        // Swap the reader without blocking concurrent searches.
+                        state.index.read().unwrap().swap_reader(new_reader);
+                        // Brief write lock for in-memory overlay prune + dirty reset.
+                        {
+                            let mut index = state.index.write().unwrap();
                             index.prune_persisted_entries();
                             index.live.reset_dirty_count();
-                            last_save = Instant::now();
-                            eprintln!(
-                                "[trace] auto-save complete in {:.1}s ({} files on disk)",
-                                save_start.elapsed().as_secs_f64(),
-                                reader_files,
-                            );
-                        } else {
-                            eprintln!(
-                                "[trace] auto-save reopen incomplete: expected {num_files} files, found {reader_files}; live overlay retained"
-                            );
                         }
+                        last_save = Instant::now();
+                        eprintln!(
+                            "[trace] auto-save complete in {:.1}s ({reader_files} files on disk)",
+                            save_start.elapsed().as_secs_f64(),
+                        );
+                    } else {
+                        eprintln!(
+                            "[trace] auto-save reopen incomplete: expected {num_files} files, found {reader_files}; live overlay retained"
+                        );
                     }
-                    Err(e) => {
-                        eprintln!("[trace] auto-save reopen failed: {e}, live overlay retained");
-                    }
+                }
+                Err(e) => {
+                    eprintln!("[trace] auto-save reopen failed: {e}, live overlay retained");
                 }
             }
             let _ = std::fs::remove_dir_all(&staging_dir);
@@ -1201,18 +1202,23 @@ fn checkpoint_index_to_disk(
             return;
         }
 
-        // Brief write lock: drop mmap handles, move staged files, reopen reader
-        {
-            let mut index = state.index.write().unwrap();
-            index.drop_reader();
-            if let Err(e) = move_staged_files(&staging_dir, &index_dir) {
-                eprintln!("[trace] warning: checkpoint move failed: {e}");
-            }
+        // Lock-free publish: rename staging files into place, then build and
+        // swap in a fresh reader without taking the outer write lock.
+        // Searches continue to be served by the previous reader (its mmap
+        // remains valid while in-flight queries hold an Arc<IndexReader>).
+        if let Err(e) = move_staged_files(&staging_dir, &index_dir) {
+            eprintln!("[trace] warning: checkpoint move failed: {e}");
+        } else {
             // Reopen the reader so future snapshots include checkpointed files.
             // Without this, the reader stays empty and the final flush loses
             // all files that were only in the on-disk reader (seeded files).
-            if let Err(e) = index.reopen_reader(&index_dir) {
-                eprintln!("[trace] warning: checkpoint reader reopen failed: {e}");
+            match tgrep_core::reader::IndexReader::open(&index_dir) {
+                Ok(new_reader) => {
+                    state.index.read().unwrap().swap_reader(new_reader);
+                }
+                Err(e) => {
+                    eprintln!("[trace] warning: checkpoint reader reopen failed: {e}");
+                }
             }
         }
         let _ = std::fs::remove_dir_all(&staging_dir);
@@ -1252,43 +1258,39 @@ fn flush_index_to_disk(state: &ServerState, _root: &Path, index_dir: &Path) {
         return;
     }
 
-    // Brief write lock: drop reader, move staged files, reopen
-    {
-        let mut index = state.index.write().unwrap();
-        index.drop_reader(); // release mmap handles (Windows)
-        if let Err(e) = move_staged_files(&staging_dir, index_dir) {
-            eprintln!("[trace] warning: flush move failed: {e}");
-            let _ = std::fs::remove_dir_all(&staging_dir);
-            // Try to reopen the (old) reader so lookups don't hit None mmaps.
-            // LiveIndex is still intact as a fallback.
-            if let Err(e2) = index.reopen_reader(index_dir) {
-                eprintln!("[trace] warning: reader reopen also failed: {e2}");
-            }
-            return;
-        }
+    // Lock-free publish: rename staging files into place, build new reader,
+    // then swap. Search queries continue to be served throughout.
+    if let Err(e) = move_staged_files(&staging_dir, index_dir) {
+        eprintln!("[trace] warning: flush move failed: {e}");
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        return;
+    }
 
-        // Reopen just the reader — keep LiveIndex as a safety net.
-        // If the reader is valid, prune overlay entries that are now on disk.
-        match index.reopen_reader(index_dir) {
-            Ok(()) => {
-                let reader_files = index.reader_file_count();
-                if reader_files >= num_files {
+    // Open the new reader OUTSIDE any lock — this can take a moment for large
+    // indices and we don't want to block search.
+    match tgrep_core::reader::IndexReader::open(index_dir) {
+        Ok(new_reader) => {
+            let reader_files = new_reader.num_files();
+            if reader_files >= num_files {
+                // Atomic swap — no outer write lock required.
+                state.index.read().unwrap().swap_reader(new_reader);
+                // Brief write lock for in-memory overlay maintenance only.
+                {
+                    let mut index = state.index.write().unwrap();
                     index.prune_persisted_entries();
                     index.live.reset_dirty_count();
-                    eprintln!(
-                        "[trace] flush: reader reopened ({reader_files} files), overlay pruned"
-                    );
-                } else {
-                    eprintln!(
-                        "[trace] warning: reader has {reader_files} files (expected {num_files}), keeping live overlay as fallback"
-                    );
                 }
-            }
-            Err(e) => {
+                eprintln!("[trace] flush: reader reopened ({reader_files} files), overlay pruned");
+            } else {
                 eprintln!(
-                    "[trace] warning: failed to reopen reader after flush: {e}, live overlay retained"
+                    "[trace] warning: reader has {reader_files} files (expected {num_files}), keeping live overlay as fallback"
                 );
             }
+        }
+        Err(e) => {
+            eprintln!(
+                "[trace] warning: failed to reopen reader after flush: {e}, live overlay retained"
+            );
         }
     }
     let _ = std::fs::remove_dir_all(&staging_dir);

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -2,7 +2,17 @@
 ///
 /// Queries return the union of results from both layers, with the overlay
 /// taking precedence for files that have been modified or deleted.
+///
+/// **Concurrency**: the on-disk `IndexReader` is held inside an internal
+/// `RwLock<Arc<IndexReader>>`, which lets the publish path swap the reader
+/// **without** the caller having to hold an exclusive (`&mut`) reference to
+/// the `HybridIndex`. This means `tgrep serve` can safely keep search
+/// queries running with only an outer read lock during a flush — the brief
+/// inner write lock around the `Arc` swap takes microseconds and the old
+/// reader's mmap is released only after the last in-flight query drops its
+/// `Arc<IndexReader>`.
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
 
 use crate::Result;
 use crate::live::{self, LiveIndex};
@@ -11,7 +21,7 @@ use crate::query::{self, QueryPlan};
 use crate::reader::IndexReader;
 
 pub struct HybridIndex {
-    reader: IndexReader,
+    reader: RwLock<Arc<IndexReader>>,
     pub live: LiveIndex,
     pub root: PathBuf,
 }
@@ -20,33 +30,57 @@ impl HybridIndex {
     pub fn open(index_dir: &Path, root: &Path) -> Result<Self> {
         let reader = IndexReader::open(index_dir)?;
         Ok(Self {
-            reader,
+            reader: RwLock::new(Arc::new(reader)),
             live: LiveIndex::new(),
             root: root.to_path_buf(),
         })
     }
 
-    /// Release the mmap reader handles so index files can be overwritten (Windows).
-    pub fn drop_reader(&mut self) {
-        self.reader.close();
+    /// Snapshot the current on-disk reader. Cheap (clones an `Arc`).
+    fn reader(&self) -> Arc<IndexReader> {
+        Arc::clone(&self.reader.read().unwrap())
+    }
+
+    /// Atomically replace the on-disk reader with `new_reader`.
+    ///
+    /// Takes `&self` (not `&mut self`) so that callers can perform the swap
+    /// while holding only an outer read lock on the `HybridIndex`, which in
+    /// turn means concurrent search queries are not blocked during a flush.
+    /// The previous reader's mmap is released when the last in-flight query
+    /// drops its `Arc<IndexReader>` — Rust's `File::open` on Windows uses
+    /// `FILE_SHARE_DELETE` by default, so renaming the underlying files
+    /// before the old mmap is dropped is safe (the old section keeps the
+    /// orphaned file content alive until refs drain).
+    pub fn swap_reader(&self, new_reader: IndexReader) {
+        *self.reader.write().unwrap() = Arc::new(new_reader);
+    }
+
+    /// Replace the reader with an empty one, releasing the current mmap.
+    ///
+    /// Retained for callers that need the old "drop then re-open" sequence;
+    /// new code should prefer `swap_reader` so there is no window during
+    /// which the reader is empty.
+    pub fn drop_reader(&self) {
+        self.swap_reader(IndexReader::empty());
     }
 
     /// Reopen the on-disk reader from updated index files, keeping the live
-    /// overlay intact. Use after `drop_reader` + file replacement so that
-    /// subsequent snapshots still include the on-disk data.
-    pub fn reopen_reader(&mut self, index_dir: &Path) -> Result<()> {
-        self.reader = IndexReader::open(index_dir)?;
+    /// overlay intact. Equivalent to `swap_reader(IndexReader::open(..)?)`.
+    pub fn reopen_reader(&self, index_dir: &Path) -> Result<()> {
+        let new_reader = IndexReader::open(index_dir)?;
+        self.swap_reader(new_reader);
         Ok(())
     }
 
     /// Look up candidate file IDs for a trigram, merging reader + overlay.
     pub fn lookup_trigram(&self, trigram: u32) -> Vec<u32> {
-        let mut reader_ids = self.reader.lookup_trigram(trigram);
+        let reader = self.reader();
+        let mut reader_ids = reader.lookup_trigram(trigram);
         let live_ids = self.live.lookup_trigram(trigram);
 
         // Filter out reader IDs for files that are deleted or overridden in overlay
         reader_ids.retain(|&fid| {
-            if let Some(path) = self.reader.file_path(fid) {
+            if let Some(path) = reader.file_path(fid) {
                 !self.live.is_deleted(path) && !self.live_has_path(path)
             } else {
                 false
@@ -59,11 +93,12 @@ impl HybridIndex {
 
     /// Look up candidate posting entries with masks, merging reader + overlay.
     pub fn lookup_trigram_with_masks(&self, trigram: u32) -> Vec<PostingEntry> {
-        let mut reader_entries = self.reader.lookup_trigram_with_masks(trigram);
+        let reader = self.reader();
+        let mut reader_entries = reader.lookup_trigram_with_masks(trigram);
         let live_entries = self.live.lookup_trigram_with_masks(trigram);
 
         reader_entries.retain(|e| {
-            if let Some(path) = self.reader.file_path(e.file_id) {
+            if let Some(path) = reader.file_path(e.file_id) {
                 !self.live.is_deleted(path) && !self.live_has_path(path)
             } else {
                 false
@@ -75,22 +110,25 @@ impl HybridIndex {
     }
 
     /// Resolve a file ID to a path (works for both reader and overlay IDs).
-    pub fn file_path(&self, file_id: u32) -> Option<&str> {
+    ///
+    /// Returns an owned `String` so the result is safe to use after the
+    /// internal reader is swapped out by a concurrent flush.
+    pub fn file_path(&self, file_id: u32) -> Option<String> {
         if live::LiveIndex::is_overlay_id(file_id) {
-            self.live.file_path(file_id)
+            self.live.file_path(file_id).map(|s| s.to_string())
         } else {
-            self.reader.file_path(file_id)
+            self.reader().file_path(file_id).map(|s| s.to_string())
         }
     }
 
     /// Get all file IDs from both layers (overlay takes precedence).
     pub fn all_file_ids(&self) -> Vec<u32> {
-        let mut ids: Vec<u32> = self
-            .reader
+        let reader = self.reader();
+        let mut ids: Vec<u32> = reader
             .all_file_ids()
             .into_iter()
             .filter(|&fid| {
-                if let Some(path) = self.reader.file_path(fid) {
+                if let Some(path) = reader.file_path(fid) {
                     !self.live.is_deleted(path) && !self.live_has_path(path)
                 } else {
                     false
@@ -124,7 +162,7 @@ impl HybridIndex {
 
     /// Total unique trigrams across both reader and live overlay.
     pub fn num_trigrams(&self) -> usize {
-        let reader_count = self.reader.num_trigrams();
+        let reader_count = self.reader().num_trigrams();
         let live_count = self.live.num_trigrams();
         if reader_count == 0 {
             return live_count;
@@ -151,12 +189,12 @@ impl HybridIndex {
 
     /// Get all paths from the on-disk reader (for skip-set construction).
     pub fn reader_paths(&self) -> std::collections::HashSet<String> {
-        self.reader.all_paths().iter().cloned().collect()
+        self.reader().all_paths().iter().cloned().collect()
     }
 
     /// Number of files in the on-disk reader.
     pub fn reader_file_count(&self) -> usize {
-        self.reader.num_files()
+        self.reader().num_files()
     }
 
     /// Remove overlay entries whose paths already exist in the on-disk reader.
@@ -168,8 +206,9 @@ impl HybridIndex {
     /// (e.g. by the file-watcher) are preserved because they are **not** in
     /// the reader yet.
     pub fn prune_persisted_entries(&mut self) {
+        let reader = self.reader();
         let reader_paths: std::collections::HashSet<&str> =
-            self.reader.all_paths().iter().map(|s| s.as_str()).collect();
+            reader.all_paths().iter().map(|s| s.as_str()).collect();
         let to_remove: Vec<String> = self
             .live
             .overlay_paths()
@@ -186,12 +225,14 @@ impl HybridIndex {
     pub fn full_snapshot(&self) -> (Vec<String>, std::collections::HashMap<u32, Vec<u32>>) {
         use std::collections::HashMap;
 
+        let reader = self.reader();
+
         // Phase 1: Build merged file list (reader files not in overlay + overlay files)
         let mut paths: Vec<String> = Vec::new();
         let mut reader_id_map: HashMap<u32, u32> = HashMap::new();
 
         // Add reader files (skip those superseded by overlay or deleted)
-        for (old_id, path) in self.reader.all_paths().iter().enumerate() {
+        for (old_id, path) in reader.all_paths().iter().enumerate() {
             let old_id = old_id as u32;
             if self.live.is_deleted(path) || self.live.has_path(path) {
                 continue; // superseded or deleted
@@ -214,7 +255,7 @@ impl HybridIndex {
         let mut inverted: HashMap<u32, Vec<u32>> = HashMap::new();
 
         // Reader trigram postings (remapped, excluding superseded files)
-        for (trigram, posting) in self.reader.all_trigram_postings() {
+        for (trigram, posting) in reader.all_trigram_postings() {
             let remapped: Vec<u32> = posting
                 .into_iter()
                 .filter_map(|old_id| reader_id_map.get(&old_id).copied())

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -64,6 +64,18 @@ impl IndexReader {
         })
     }
 
+    /// An empty reader that returns no results. Useful as a placeholder
+    /// when callers need to release the previous mmap before swapping in a
+    /// freshly-built reader.
+    pub fn empty() -> Self {
+        Self {
+            lookup: None,
+            postings: None,
+            file_paths: Vec::new(),
+            num_entries: 0,
+        }
+    }
+
     /// Release mmap handles so the underlying files can be overwritten (Windows).
     pub fn close(&mut self) {
         self.lookup = None;


### PR DESCRIPTION
Changes:

   - tgrep-core/src/hybrid.rs: reader is now RwLock<Arc<IndexReader>>; new swap_reader(&self, IndexReader) lets the publish path swap atomically while callers hold only a read lock. file_path returns 
  Option<String> so the result outlives the inner swap.
   - tgrep-core/src/reader.rs: added IndexReader::empty().
   - tgrep-cli/src/serve.rs: auto_save_loop, checkpoint_index_to_disk, and flush_index_to_disk now do rename → IndexReader::open → swap_reader without ever taking the outer write lock. The old mmap stays 
  alive via in-flight Arcs; safe on Windows due to default FILE_SHARE_DELETE.

  Result for your question: Both before and during a flush the server reports indexing: false (auto-save flushes) or true only during the initial background build, and in all cases search requests are served
  without being blocked by the flush.

  Verified: cargo build, cargo clippy --workspace --all-targets -- -D warnings, cargo test --workspace all green (65 tests pass).