### PR TITLE
fix(pipeline): use git show to read ado-cargo-config.toml (bypass partial clone)

### DIFF
--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -137,11 +137,10 @@ extends:
               # redirect crates.io, to avoid breaking external contributor builds).
               # ---------------------------------------------------------------
               - powershell: |
-                  $src = "$(Build.SourcesDirectory)\.github\workflows\ado-cargo-config.toml"
                   $dstDir = "$(Build.SourcesDirectory)\.cargo"
                   New-Item -ItemType Directory -Force -Path $dstDir | Out-Null
-                  Copy-Item -Path $src -Destination "$dstDir\config.toml" -Force
-                  Write-Host "Copied: $src -> $dstDir\config.toml"
+                  git -C "$(Build.SourcesDirectory)" show HEAD:.github/workflows/ado-cargo-config.toml | Out-File -FilePath "$dstDir\config.toml" -Encoding utf8NoBOM
+                  Write-Host "Written: $dstDir\config.toml"
                 displayName: 'Copy ADO cargo config (crates.io redirect + BinSkim flags)'
 
               # ---------------------------------------------------------------
@@ -267,12 +266,10 @@ extends:
                 displayName: 'Verify Rust version'
 
               - powershell: |
-                  $src = "$(Build.SourcesDirectory)\.github\workflows\ado-cargo-config.toml"
                   $dstDir = "$(Build.SourcesDirectory)\.cargo"
                   New-Item -ItemType Directory -Force -Path $dstDir | Out-Null
-                  Copy-Item -Path $src -Destination "$dstDir\config.toml" -Force
-                  Write-Host "Copied: $src -> $dstDir\config.toml"
-                  Get-Content "$dstDir\config.toml"
+                  git -C "$(Build.SourcesDirectory)" show HEAD:.github/workflows/ado-cargo-config.toml | Out-File -FilePath "$dstDir\config.toml" -Encoding utf8NoBOM
+                  Write-Host "Written: $dstDir\config.toml"
                 displayName: 'Copy ADO cargo config (crates.io redirect + BinSkim flags)'
 
               - task: CargoAuthenticate@0

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -139,7 +139,9 @@ extends:
               - powershell: |
                   $dstDir = "$(Build.SourcesDirectory)\.cargo"
                   New-Item -ItemType Directory -Force -Path $dstDir | Out-Null
-                  git -C "$(Build.SourcesDirectory)" show HEAD:.github/workflows/ado-cargo-config.toml | Out-File -FilePath "$dstDir\config.toml" -Encoding utf8NoBOM
+                  $content = git -C "$(Build.SourcesDirectory)" show HEAD:.github/workflows/ado-cargo-config.toml
+                  if ($LASTEXITCODE -ne 0) { throw "git show failed with exit code $LASTEXITCODE" }
+                  [System.IO.File]::WriteAllText("$dstDir\config.toml", ($content -join "`n") + "`n", [System.Text.UTF8Encoding]::new($false))
                   Write-Host "Written: $dstDir\config.toml"
                 displayName: 'Copy ADO cargo config (crates.io redirect + BinSkim flags)'
 
@@ -268,7 +270,9 @@ extends:
               - powershell: |
                   $dstDir = "$(Build.SourcesDirectory)\.cargo"
                   New-Item -ItemType Directory -Force -Path $dstDir | Out-Null
-                  git -C "$(Build.SourcesDirectory)" show HEAD:.github/workflows/ado-cargo-config.toml | Out-File -FilePath "$dstDir\config.toml" -Encoding utf8NoBOM
+                  $content = git -C "$(Build.SourcesDirectory)" show HEAD:.github/workflows/ado-cargo-config.toml
+                  if ($LASTEXITCODE -ne 0) { throw "git show failed with exit code $LASTEXITCODE" }
+                  [System.IO.File]::WriteAllText("$dstDir\config.toml", ($content -join "`n") + "`n", [System.Text.UTF8Encoding]::new($false))
                   Write-Host "Written: $dstDir\config.toml"
                 displayName: 'Copy ADO cargo config (crates.io redirect + BinSkim flags)'
 


### PR DESCRIPTION
## Problem

ADO build 13878026 failed with:
```
Copy-Item : Cannot find path 'C:\__w\1\s\.github\workflows\ado-cargo-config.toml' because it does not exist.
```

## Root Cause

OneBranch pipeline uses **partial clone** (`--filter=blob:none`). After `git sparse-checkout disable`, the working tree appears clean but file blobs are not fetched. `Copy-Item` fails because the file content was never downloaded.

## Fix

Replace `Copy-Item` with `git show HEAD:<path>` which reads the blob directly from git object store (fetching it on demand if needed), bypassing the partial clone issue.

Also removes the leftover `Get-Content` line in the arm64 job.