### PR TITLE
fix: set ENABLE_PRS_DELAYSIGN=0 to fix ADO signing watcher timeout

### DIFF
--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -44,7 +44,7 @@ parameters:
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]  # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   system.debug: ${{ parameters.debug }}
-  ENABLE_PRS_DELAYSIGN: 1
+  ENABLE_PRS_DELAYSIGN: 0  # Disable PRS delay signing; sign directly in container (0=direct, 1=requires host watcher agent)
   TGREP_TAG: ${{ parameters.ReleaseTag }}
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'  # Docker image https://aka.ms/obpipelines/containers
 


### PR DESCRIPTION
## Problem

The `sign-and-release.yml` pipeline was failing at the sign step with:
```
Watcher did not create .started signal file
```

## Root Cause

`ENABLE_PRS_DELAYSIGN: 1` enables PRS delay signing mode, which requires a host watcher agent to create a `.started` signal file before signing can proceed. This watcher agent is only available when the pipeline source repo is an **ADO internal repo**.

Our pipeline's source repo is **microsoft/tgrep** (external GitHub repo), so the host watcher agent never starts, causing the signing step to time out.

## Fix

Set `ENABLE_PRS_DELAYSIGN: 0` to sign directly in the container (no host watcher needed).

Reference: `dp-ado-test-tgrep-build.yml` uses `ENABLE_PRS_DELAYSIGN: 0` and signs successfully.