### PR TITLE
fix: remove checkout:self to fix OneBranch signing (FileWatcher .pid deletion)

### DIFF
--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -44,7 +44,6 @@ parameters:
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]  # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   system.debug: ${{ parameters.debug }}
-  ENABLE_PRS_DELAYSIGN: 0  # Disable PRS delay signing; sign directly in container (0=direct, 1=requires host watcher agent)
   TGREP_TAG: ${{ parameters.ReleaseTag }}
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'  # Docker image https://aka.ms/obpipelines/containers
 
@@ -59,7 +58,8 @@ extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates  # https://aka.ms/obpipelines/templates
   parameters:
     featureFlags:
-      WindowsHostVersion: '1ESWindows2022'
+      WindowsHostVersion:
+        Version: 2022
     git:
       submodules: false
     cloudvault:  # https://aka.ms/obpipelines/cloudvault
@@ -100,17 +100,7 @@ extends:
 
             steps:
               # ---------------------------------------------------------------
-              # Step 1: Checkout tgrep source code
-              # OneBranch checks out the repo containing this YAML (microsoft/tgrep)
-              # into $(Build.SourcesDirectory)\s (OneBranch single-repo convention).
-              # ---------------------------------------------------------------
-              - checkout: self
-                fetchDepth: 1
-                fetchTags: false
-                displayName: 'Checkout microsoft/tgrep'
-
-              # ---------------------------------------------------------------
-              # Step 2: Install Rust toolchain via RustInstaller@1
+              # Step 1: Install Rust toolchain via RustInstaller@1
               # Uses the official Microsoft Rust installer task (MSRustup).
               # toolchainFeed: dedicated Rust NuGet feed (contains rust.msrustup-* packages).
               # Reference: rust.msrustup/.pipelines/build.yml, ripgrep-prebuilt pipeline

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -44,6 +44,7 @@ parameters:
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]  # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   system.debug: ${{ parameters.debug }}
+  ENABLE_PRS_DELAYSIGN: 0  # Disable PRS delay signing; sign directly in container (0=direct, 1=requires host watcher agent)
   TGREP_TAG: ${{ parameters.ReleaseTag }}
   WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'  # Docker image https://aka.ms/obpipelines/containers
 
@@ -58,8 +59,7 @@ extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates  # https://aka.ms/obpipelines/templates
   parameters:
     featureFlags:
-      WindowsHostVersion:
-        Version: 2022
+      WindowsHostVersion: '1ESWindows2022'
     git:
       submodules: false
     cloudvault:  # https://aka.ms/obpipelines/cloudvault
@@ -100,7 +100,12 @@ extends:
 
             steps:
               # ---------------------------------------------------------------
-              # Step 1: Install Rust toolchain via RustInstaller@1
+              # Step 1: Checkout tgrep source code
+              # OneBranch checks out the repo containing this YAML (microsoft/tgrep)
+              # into $(Build.SourcesDirectory)\s (OneBranch single-repo convention).
+              # ---------------------------------------------------------------
+              # ---------------------------------------------------------------
+              # Step 2: Install Rust toolchain via RustInstaller@1
               # Uses the official Microsoft Rust installer task (MSRustup).
               # toolchainFeed: dedicated Rust NuGet feed (contains rust.msrustup-* packages).
               # Reference: rust.msrustup/.pipelines/build.yml, ripgrep-prebuilt pipeline
@@ -251,11 +256,6 @@ extends:
               ob_sdl_binskim_break: true  # https://aka.ms/obpipelines/sdl
 
             steps:
-              - checkout: self
-                fetchDepth: 1
-                fetchTags: false
-                displayName: 'Checkout microsoft/tgrep'
-
               - task: RustInstaller@1
                 displayName: 'Install Rust toolchain (with arm64 target)'
                 inputs:


### PR DESCRIPTION
## Problem

The `checkout: self` step in the user yaml runs **after** OneBranch's `🔒 Setup Signing` step. This causes the `.pid` file (created by Setup Signing in the repo root) to be deleted when the checkout step moves/recreates the repo folder. FileWatcher detects the `.pid` file deletion and terminates, breaking the signing process.

## Root Cause

From [OneBranch Signing FileWatcher FAQ](https://eng.ms/docs/products/onebranch/faqs/signingfaq/filewatcher):
> "One particular accidental delete is if the build job includes the -checkout build step to reassign the source of the repo to another folder. That build task will move the folder that is the root of the repo, which causes the .pid file that is in the root of the repo to be deleted."
> "The solution is to remove the -checkout step."

## Evidence

Reference projects that sign successfully from GitHub repos:
- `vscode-powershell` (GitHub → OneBranch signing ✅): **no** `checkout: self`
- `vscode-cosmosdb` (GitHub → OneBranch signing ✅): **no** `checkout: self`

OneBranch handles the checkout automatically - no need to specify it explicitly.

## Fix

Remove the explicit `checkout: self` step (4 lines). OneBranch will checkout the repo automatically before user steps run.