### PR TITLE
Fix: windows mmap and search correctness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -30,3 +30,4 @@ fs2 = "0.4.3"
 assert_cmd = "2"
 tempfile = "3"
 predicates = "3"
+serde_json = { workspace = true }

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -30,4 +30,3 @@ fs2 = "0.4.3"
 assert_cmd = "2"
 tempfile = "3"
 predicates = "3"
-serde_json = { workspace = true }

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -317,9 +317,7 @@ fn search_local_index(
     let candidates = if is_match_all || opts.files_without_match {
         reader.all_file_ids()
     } else {
-        query::execute_plan_with_masks(&plan, &|tri| {
-            reader.lookup_trigram_with_masks(tri)
-        })
+        query::execute_plan_with_masks(&plan, &|tri| reader.lookup_trigram_with_masks(tri))
     };
 
     if opts.stats {

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -649,15 +649,33 @@ fn passes_filters(rel_path: &str, globs: &[String], file_type: &Option<String>) 
 }
 
 /// Check if a path passes all glob filters. If no globs are specified, all
-/// paths pass. When multiple globs are given, the path must match at least one.
+/// paths pass. Patterns prefixed with `!` act as exclusions — if the path
+/// matches any exclusion it is rejected. Otherwise, if inclusion patterns
+/// are present the path must match at least one.
 fn passes_glob_filters(globs: &[String], path: &str) -> bool {
     if globs.is_empty() {
         return true;
     }
-    globs.iter().any(|g| glob_matches(g, path))
+    let mut has_include = false;
+    let mut included = false;
+    for g in globs {
+        if let Some(neg) = g.strip_prefix('!') {
+            if glob_matches(neg, path) {
+                return false; // excluded
+            }
+        } else {
+            has_include = true;
+            if !included && glob_matches(g, path) {
+                included = true;
+            }
+        }
+    }
+    !has_include || included
 }
 
 fn glob_matches(pattern: &str, path: &str) -> bool {
+    // Normalize backslashes so Windows-style globs match forward-slash index paths
+    let pattern = pattern.replace('\\', "/");
     let pattern = pattern.replace('.', r"\.");
     let pattern = pattern.replace("**", "§§");
     let pattern = pattern.replace('*', "[^/]*");

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -317,12 +317,7 @@ fn search_local_index(
     let candidates = if is_match_all || opts.files_without_match {
         reader.all_file_ids()
     } else {
-        let effective_pattern = if ci {
-            opts.pattern.to_lowercase()
-        } else {
-            opts.pattern.clone()
-        };
-        query::execute_plan_with_masks(&plan, &effective_pattern, &|tri| {
+        query::execute_plan_with_masks(&plan, &|tri| {
             reader.lookup_trigram_with_masks(tri)
         })
     };
@@ -676,7 +671,7 @@ fn glob_matches(pattern: &str, path: &str) -> bool {
 
 fn plan_summary(plan: &QueryPlan) -> String {
     match plan {
-        QueryPlan::And(tris) => format!("AND({} trigrams)", tris.len()),
+        QueryPlan::And(queries) => format!("AND({} trigrams)", queries.len()),
         QueryPlan::Or(plans) => {
             let subs: Vec<String> = plans.iter().map(plan_summary).collect();
             format!("OR({})", subs.join(", "))

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -443,8 +443,9 @@ fn handle_search(
         let index = state.index.read().unwrap();
 
         let candidates = index.execute_query_with_masks(&plan);
+        let raw_candidate_count = candidates.len();
 
-        candidates
+        let filtered: Vec<(String, PathBuf)> = candidates
             .iter()
             .filter_map(|&fid| {
                 let rel_path = index.file_path(fid)?.to_string();
@@ -461,7 +462,29 @@ fn handle_search(
                 let full_path = index.full_path(fid)?;
                 Some((rel_path, full_path))
             })
-            .collect()
+            .collect();
+
+        // Diagnostic: detect when raw candidates are lost in filtering
+        if raw_candidate_count > 0 && filtered.is_empty() {
+            let sample_fids: Vec<u32> = candidates.iter().copied().take(5).collect();
+            let sample_paths: Vec<Option<String>> =
+                sample_fids.iter().map(|&fid| index.file_path(fid)).collect();
+            eprintln!(
+                "[trace] WARNING: {} raw candidates filtered to 0! sample_fids={:?} sample_paths={:?}",
+                raw_candidate_count, sample_fids, sample_paths,
+            );
+        }
+        if raw_candidate_count != filtered.len() && raw_candidate_count > 0 {
+            eprintln!(
+                "[trace] search filter: raw={} filtered={} (type={:?} globs={})",
+                raw_candidate_count,
+                filtered.len(),
+                file_type,
+                glob_filters.len(),
+            );
+        }
+
+        filtered
     }; // index lock released here
     let index_ms = t_index.elapsed().as_secs_f64() * 1000.0;
 
@@ -1000,6 +1023,10 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
                             "[trace] auto-save: degenerate reader ({reader_files} files, \
                              0 trigrams), keeping live overlay"
                         );
+                    } else if let Err(msg) = new_reader.validate_lookup() {
+                        eprintln!(
+                            "[trace] auto-save: validation failed: {msg}, keeping live overlay"
+                        );
                     } else if reader_files >= num_files {
                         // Swap the reader without blocking concurrent searches.
                         state.index.read().unwrap().swap_reader(new_reader);
@@ -1532,6 +1559,30 @@ fn flush_index_to_disk(
                         eprintln!(
                             "[trace] warning: degenerate reader persists after \
                              {READER_OPEN_RETRIES} attempts, keeping live overlay as fallback"
+                        );
+                        break 'open false;
+                    }
+
+                    // Validate + warm the lookup mmap before swapping the
+                    // reader in. This catches corruption (unsorted lookup
+                    // table, out-of-bounds posting offsets) and, as a
+                    // side-effect, pages in every byte of lookup.bin so that
+                    // subsequent binary searches never hit cold mmap pages
+                    // — preventing the zero-candidate failure observed on
+                    // Windows after flush.
+                    if let Err(msg) = new_reader.validate_lookup() {
+                        eprintln!(
+                            "[trace] warning: reader validation failed \
+                             (attempt {}/{READER_OPEN_RETRIES}): {msg}",
+                            attempt + 1
+                        );
+                        if attempt + 1 < READER_OPEN_RETRIES {
+                            thread::sleep(READER_OPEN_BACKOFF * (attempt + 1));
+                            continue;
+                        }
+                        eprintln!(
+                            "[trace] warning: reader validation failed after \
+                             {READER_OPEN_RETRIES} attempts, keeping live overlay"
                         );
                         break 'open false;
                     }

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -472,9 +472,7 @@ fn handle_search(
                     type_filtered_count += 1;
                     return None;
                 }
-                if !glob_filters.is_empty()
-                    && !glob_filter_matches(&glob_filters, &rel_path)
-                {
+                if !glob_filters.is_empty() && !glob_filter_matches(&glob_filters, &rel_path) {
                     glob_filtered_count += 1;
                     if first_glob_rejected.is_none() {
                         first_glob_rejected = Some(rel_path);

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -454,6 +454,7 @@ fn handle_search(
         let mut no_path_count: usize = 0;
         let mut type_filtered_count: usize = 0;
         let mut glob_filtered_count: usize = 0;
+        let mut first_glob_rejected: Option<String> = None;
 
         let filtered: Vec<(String, PathBuf)> = candidates
             .iter()
@@ -475,6 +476,9 @@ fn handle_search(
                     && !glob_filters.iter().any(|g| simple_glob_match(g, &rel_path))
                 {
                     glob_filtered_count += 1;
+                    if first_glob_rejected.is_none() {
+                        first_glob_rejected = Some(rel_path);
+                    }
                     return None;
                 }
                 let full_path = index.resolve_full_path(fid, &reader_snapshot)?;
@@ -487,8 +491,8 @@ fn handle_search(
             eprintln!(
                 "[trace] filter: raw={raw_count} no_path={no_path_count} \
                  type_filtered={type_filtered_count} glob_filtered={glob_filtered_count} \
-                 file_type={file_type:?} globs={glob_count}",
-                glob_count = glob_filters.len(),
+                 file_type={file_type:?} glob_values={glob_filters:?} \
+                 sample_rejected={first_glob_rejected:?}",
             );
         }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -468,9 +468,10 @@ fn handle_search(
         // potential index-level bug).  Glob/type filtering reducing results to 0
         // is normal for path-scoped searches and should not be logged.
         if raw_candidate_count == 0 && !pattern.is_empty() {
+            let pattern_preview: String = pattern.chars().take(40).collect();
             eprintln!(
                 "[trace] search: 0 raw candidates for pattern={:?} (globs={} type={:?})",
-                &pattern[..pattern.len().min(40)],
+                pattern_preview,
                 glob_filters.len(),
                 file_type,
             );

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -993,7 +993,14 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
             match tgrep_core::reader::IndexReader::open(index_dir) {
                 Ok(new_reader) => {
                     let reader_files = new_reader.num_files();
-                    if reader_files >= num_files {
+                    let reader_trigrams = new_reader.num_trigrams();
+
+                    if new_reader.is_degenerate() {
+                        eprintln!(
+                            "[trace] auto-save: degenerate reader ({reader_files} files, \
+                             0 trigrams), keeping live overlay"
+                        );
+                    } else if reader_files >= num_files {
                         // Swap the reader without blocking concurrent searches.
                         state.index.read().unwrap().swap_reader(new_reader);
                         // Brief write lock for in-memory overlay prune + dirty reset.
@@ -1004,7 +1011,8 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
                         }
                         last_save = Instant::now();
                         eprintln!(
-                            "[trace] auto-save complete in {:.1}s ({reader_files} files on disk)",
+                            "[trace] auto-save complete in {:.1}s ({reader_files} files, \
+                             {reader_trigrams} trigrams on disk)",
                             save_start.elapsed().as_secs_f64(),
                         );
                     } else {
@@ -1496,33 +1504,78 @@ fn flush_index_to_disk(
     // these steps). The server-wide `state.index` RwLock is NOT taken, so
     // search queries continue to be served by the previous reader (whose
     // `Arc<IndexReader>` they hold) throughout this call.
-    let pruned = match tgrep_core::reader::IndexReader::open(index_dir) {
-        Ok(new_reader) => {
-            let reader_files = new_reader.num_files();
-            if reader_files >= num_files {
-                // Atomic swap — no outer write lock required.
-                state.index.read().unwrap().swap_reader(new_reader);
-                // Brief write lock for in-memory overlay maintenance only.
-                {
-                    let mut index = state.index.write().unwrap();
-                    index.prune_persisted_entries();
-                    index.live.reset_dirty_count();
+    //
+    // On Windows, NTFS metadata for a recently-renamed file can transiently
+    // appear stale (zero-length), causing IndexReader::open to create a
+    // degenerate reader with files but no trigrams. We retry a few times
+    // with a short backoff to ride out the transient.
+    let pruned = 'open: {
+        const READER_OPEN_RETRIES: u32 = 5;
+        const READER_OPEN_BACKOFF: Duration = Duration::from_millis(200);
+
+        for attempt in 0..READER_OPEN_RETRIES {
+            match tgrep_core::reader::IndexReader::open(index_dir) {
+                Ok(new_reader) => {
+                    let reader_files = new_reader.num_files();
+                    let reader_trigrams = new_reader.num_trigrams();
+
+                    if new_reader.is_degenerate() {
+                        eprintln!(
+                            "[trace] warning: reader has {reader_files} files but 0 trigrams \
+                             (attempt {}/{READER_OPEN_RETRIES}, likely stale NTFS metadata)",
+                            attempt + 1
+                        );
+                        if attempt + 1 < READER_OPEN_RETRIES {
+                            thread::sleep(READER_OPEN_BACKOFF * (attempt + 1));
+                            continue;
+                        }
+                        eprintln!(
+                            "[trace] warning: degenerate reader persists after \
+                             {READER_OPEN_RETRIES} attempts, keeping live overlay as fallback"
+                        );
+                        break 'open false;
+                    }
+
+                    if reader_files >= num_files {
+                        // Atomic swap — no outer write lock required.
+                        state.index.read().unwrap().swap_reader(new_reader);
+                        // Brief write lock for in-memory overlay maintenance only.
+                        {
+                            let mut index = state.index.write().unwrap();
+                            index.prune_persisted_entries();
+                            index.live.reset_dirty_count();
+                        }
+                        eprintln!(
+                            "[trace] flush: reader reopened ({reader_files} files, \
+                             {reader_trigrams} trigrams), overlay pruned"
+                        );
+                        break 'open true;
+                    } else {
+                        eprintln!(
+                            "[trace] warning: reader has {reader_files} files \
+                             (expected {num_files}), keeping live overlay as fallback"
+                        );
+                        break 'open false;
+                    }
                 }
-                eprintln!("[trace] flush: reader reopened ({reader_files} files), overlay pruned");
-                true
-            } else {
-                eprintln!(
-                    "[trace] warning: reader has {reader_files} files (expected {num_files}), keeping live overlay as fallback"
-                );
-                false
+                Err(e) => {
+                    if attempt + 1 < READER_OPEN_RETRIES {
+                        eprintln!(
+                            "[trace] warning: reader open failed (attempt {}/{READER_OPEN_RETRIES}): {e}",
+                            attempt + 1
+                        );
+                        thread::sleep(READER_OPEN_BACKOFF * (attempt + 1));
+                        continue;
+                    }
+                    eprintln!(
+                        "[trace] warning: failed to reopen reader after flush: {e}, \
+                         live overlay retained"
+                    );
+                    break 'open false;
+                }
             }
         }
-        Err(e) => {
-            eprintln!(
-                "[trace] warning: failed to reopen reader after flush: {e}, live overlay retained"
-            );
-            false
-        }
+        false
     };
     let _ = std::fs::remove_dir_all(&staging_dir);
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -464,23 +464,15 @@ fn handle_search(
             })
             .collect();
 
-        // Diagnostic: detect when raw candidates are lost in filtering
-        if raw_candidate_count > 0 && filtered.is_empty() {
-            let sample_fids: Vec<u32> = candidates.iter().copied().take(5).collect();
-            let sample_paths: Vec<Option<String>> =
-                sample_fids.iter().map(|&fid| index.file_path(fid)).collect();
+        // Only log when the index itself returns 0 candidates (indicates a
+        // potential index-level bug).  Glob/type filtering reducing results to 0
+        // is normal for path-scoped searches and should not be logged.
+        if raw_candidate_count == 0 && !pattern.is_empty() {
             eprintln!(
-                "[trace] WARNING: {} raw candidates filtered to 0! sample_fids={:?} sample_paths={:?}",
-                raw_candidate_count, sample_fids, sample_paths,
-            );
-        }
-        if raw_candidate_count != filtered.len() && raw_candidate_count > 0 {
-            eprintln!(
-                "[trace] search filter: raw={} filtered={} (type={:?} globs={})",
-                raw_candidate_count,
-                filtered.len(),
-                file_type,
+                "[trace] search: 0 raw candidates for pattern={:?} (globs={} type={:?})",
+                &pattern[..pattern.len().min(40)],
                 glob_filters.len(),
+                file_type,
             );
         }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -442,7 +442,12 @@ fn handle_search(
     let (candidate_info, raw_candidate_count): (Vec<(String, PathBuf)>, usize) = {
         let index = state.index.read().unwrap();
 
-        let candidates = index.execute_query_with_masks(&plan);
+        // The reader snapshot is returned alongside the file IDs so that
+        // path resolution below uses the *same* reader that produced the
+        // posting-list results.  Without this, a concurrent `swap_reader`
+        // between the query and the path lookups would silently drop every
+        // candidate whose ID does not exist in the new reader.
+        let (candidates, reader_snapshot) = index.execute_query_with_masks(&plan);
         let raw_count = candidates.len();
 
         // Diagnostic counters for filter stages
@@ -453,8 +458,8 @@ fn handle_search(
         let filtered: Vec<(String, PathBuf)> = candidates
             .iter()
             .filter_map(|&fid| {
-                let rel_path = match index.file_path(fid) {
-                    Some(p) => p.to_string(),
+                let rel_path = match index.resolve_path(fid, &reader_snapshot) {
+                    Some(p) => p,
                     None => {
                         no_path_count += 1;
                         return None;
@@ -472,7 +477,7 @@ fn handle_search(
                     glob_filtered_count += 1;
                     return None;
                 }
-                let full_path = index.full_path(fid)?;
+                let full_path = index.resolve_full_path(fid, &reader_snapshot)?;
                 Some((rel_path, full_path))
             })
             .collect();

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -445,24 +445,47 @@ fn handle_search(
         let candidates = index.execute_query_with_masks(&plan);
         let raw_count = candidates.len();
 
+        // Diagnostic counters for filter stages
+        let mut no_path_count: usize = 0;
+        let mut type_filtered_count: usize = 0;
+        let mut glob_filtered_count: usize = 0;
+
         let filtered: Vec<(String, PathBuf)> = candidates
             .iter()
             .filter_map(|&fid| {
-                let rel_path = index.file_path(fid)?.to_string();
+                let rel_path = match index.file_path(fid) {
+                    Some(p) => p.to_string(),
+                    None => {
+                        no_path_count += 1;
+                        return None;
+                    }
+                };
                 if let Some(ref type_name) = file_type
                     && !tgrep_core::filetypes::matches_type(&rel_path, type_name)
                 {
+                    type_filtered_count += 1;
                     return None;
                 }
                 if !glob_filters.is_empty()
                     && !glob_filters.iter().any(|g| simple_glob_match(g, &rel_path))
                 {
+                    glob_filtered_count += 1;
                     return None;
                 }
                 let full_path = index.full_path(fid)?;
                 Some((rel_path, full_path))
             })
             .collect();
+
+        // Log filter breakdown when raw candidates are dropped to zero
+        if raw_count > 0 && filtered.is_empty() {
+            eprintln!(
+                "[trace] filter: raw={raw_count} no_path={no_path_count} \
+                 type_filtered={type_filtered_count} glob_filtered={glob_filtered_count} \
+                 file_type={file_type:?} globs={glob_count}",
+                glob_count = glob_filters.len(),
+            );
+        }
 
         (filtered, raw_count)
     }; // index lock released here

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -473,7 +473,7 @@ fn handle_search(
                     return None;
                 }
                 if !glob_filters.is_empty()
-                    && !glob_filters.iter().any(|g| simple_glob_match(g, &rel_path))
+                    && !glob_filter_matches(&glob_filters, &rel_path)
                 {
                     glob_filtered_count += 1;
                     if first_glob_rejected.is_none() {
@@ -1068,6 +1068,37 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
             let _ = std::fs::remove_dir_all(&staging_dir);
         }
     }
+}
+
+/// Check whether `path` passes the glob filter list.
+///
+/// Glob semantics:
+/// - Patterns starting with `!` are **exclusion** patterns (path must NOT match).
+/// - All other patterns are **inclusion** patterns (path must match at least one).
+/// - If only exclusion patterns are present, the path passes unless it matches
+///   an exclusion.
+/// - If inclusion patterns are present, the path must match at least one AND
+///   must not match any exclusion.
+fn glob_filter_matches(globs: &[String], path: &str) -> bool {
+    if globs.is_empty() {
+        return true;
+    }
+    let mut has_include = false;
+    let mut included = false;
+    for g in globs {
+        if let Some(neg) = g.strip_prefix('!') {
+            if simple_glob_match(neg, path) {
+                return false; // excluded
+            }
+        } else {
+            has_include = true;
+            if !included && simple_glob_match(g, path) {
+                included = true;
+            }
+        }
+    }
+    // If there were no inclusion patterns, the path passes (only exclusions existed)
+    !has_include || included
 }
 
 fn simple_glob_match(pattern: &str, path: &str) -> bool {
@@ -1980,6 +2011,31 @@ mod tests {
     fn simple_glob_match_case_insensitive() {
         assert!(simple_glob_match("**/*.CS", "src/foo/bar.cs"));
         assert!(simple_glob_match("**/*.cs", "src/foo/BAR.CS"));
+    }
+
+    #[test]
+    fn glob_filter_negation_only() {
+        // Only exclusion patterns: path passes unless it matches an exclusion
+        let globs = vec!["!.git".to_string()];
+        assert!(glob_filter_matches(&globs, "src/foo/bar.cs"));
+        assert!(glob_filter_matches(&globs, "README.md"));
+        assert!(!glob_filter_matches(&globs, ".git"));
+        assert!(!glob_filter_matches(&globs, "foo/.git"));
+    }
+
+    #[test]
+    fn glob_filter_inclusion_and_exclusion() {
+        // Mix of include and exclude: must match an include AND not match any exclude
+        let globs = vec!["**/*.cs".to_string(), "!**/test/**".to_string()];
+        assert!(glob_filter_matches(&globs, "src/foo/bar.cs"));
+        assert!(!glob_filter_matches(&globs, "src/test/bar.cs"));
+        assert!(!glob_filter_matches(&globs, "src/foo/bar.rs")); // no include match
+    }
+
+    #[test]
+    fn glob_filter_empty_passes_all() {
+        let globs: Vec<String> = vec![];
+        assert!(glob_filter_matches(&globs, "anything"));
     }
 
     fn write_file(path: &Path, content: &[u8]) {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -439,11 +439,11 @@ fn handle_search(
 
     // Collect candidates and their paths/full_paths while holding the index lock briefly
     let t_index = Instant::now();
-    let candidate_info: Vec<(String, PathBuf)> = {
+    let (candidate_info, raw_candidate_count): (Vec<(String, PathBuf)>, usize) = {
         let index = state.index.read().unwrap();
 
         let candidates = index.execute_query_with_masks(&plan);
-        let raw_candidate_count = candidates.len();
+        let raw_count = candidates.len();
 
         let filtered: Vec<(String, PathBuf)> = candidates
             .iter()
@@ -464,20 +464,7 @@ fn handle_search(
             })
             .collect();
 
-        // Only log when the index itself returns 0 candidates (indicates a
-        // potential index-level bug).  Glob/type filtering reducing results to 0
-        // is normal for path-scoped searches and should not be logged.
-        if raw_candidate_count == 0 && !pattern.is_empty() {
-            let pattern_preview: String = pattern.chars().take(40).collect();
-            eprintln!(
-                "[trace] search: 0 raw candidates for pattern={:?} (globs={} type={:?})",
-                pattern_preview,
-                glob_filters.len(),
-                file_type,
-            );
-        }
-
-        filtered
+        (filtered, raw_count)
     }; // index lock released here
     let index_ms = t_index.elapsed().as_secs_f64() * 1000.0;
 
@@ -531,9 +518,10 @@ fn handle_search(
     let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
 
     eprintln!(
-        "[trace] search: pattern={:?} case_insensitive={} candidates={} matches={} elapsed={:.1}ms (index={:.1}ms resolve={:.1}ms search={:.1}ms)",
+        "[trace] search: pattern={:?} case_insensitive={} raw_candidates={} candidates={} matches={} elapsed={:.1}ms (index={:.1}ms resolve={:.1}ms search={:.1}ms)",
         pattern,
         case_insensitive,
+        raw_candidate_count,
         candidate_info.len(),
         matches.len(),
         elapsed_ms,

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -442,13 +442,7 @@ fn handle_search(
     let candidate_info: Vec<(String, PathBuf)> = {
         let index = state.index.read().unwrap();
 
-        // Use mask-aware filtering for literal patterns (fixed_string or simple literals)
-        let effective_pattern = if case_insensitive {
-            pattern.to_lowercase()
-        } else {
-            pattern.to_string()
-        };
-        let candidates = index.execute_query_with_masks(&plan, &effective_pattern);
+        let candidates = index.execute_query_with_masks(&plan);
 
         candidates
             .iter()

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1071,6 +1071,8 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
 }
 
 fn simple_glob_match(pattern: &str, path: &str) -> bool {
+    // Normalize backslashes so Windows-style globs match forward-slash index paths
+    let pattern = pattern.replace('\\', "/");
     let pattern = pattern.replace('.', r"\.");
     let pattern = pattern.replace("**", "§§");
     let pattern = pattern.replace('*', "[^/]*");
@@ -1952,6 +1954,32 @@ mod tests {
             &no_exclude,
             Some(&gi)
         ));
+    }
+
+    #[test]
+    fn simple_glob_match_unix_patterns() {
+        // Standard forward-slash globs against forward-slash index paths
+        assert!(simple_glob_match("**/*.cs", "src/foo/bar.cs"));
+        assert!(simple_glob_match("*.cs", "src/foo/bar.cs"));
+        assert!(simple_glob_match("*.cs", "bar.cs"));
+        assert!(!simple_glob_match("**/*.cs", "src/foo/bar.rs"));
+        assert!(simple_glob_match("src/**", "src/foo/bar.cs"));
+        assert!(!simple_glob_match("src/**", "lib/foo/bar.cs"));
+    }
+
+    #[test]
+    fn simple_glob_match_backslash_normalization() {
+        // Windows-style globs with backslashes must match forward-slash paths
+        assert!(simple_glob_match(r"**\*.cs", "src/foo/bar.cs"));
+        assert!(simple_glob_match(r"src\**\*.cs", "src/foo/bar.cs"));
+        assert!(simple_glob_match(r"src\**", "src/foo/bar.cs"));
+        assert!(!simple_glob_match(r"lib\**", "src/foo/bar.cs"));
+    }
+
+    #[test]
+    fn simple_glob_match_case_insensitive() {
+        assert!(simple_glob_match("**/*.CS", "src/foo/bar.cs"));
+        assert!(simple_glob_match("**/*.cs", "src/foo/BAR.CS"));
     }
 
     fn write_file(path: &Path, content: &[u8]) {

--- a/tgrep-cli/tests/concurrent_search.rs
+++ b/tgrep-cli/tests/concurrent_search.rs
@@ -1,0 +1,498 @@
+//! Integration tests for concurrent search requests to the tgrep server.
+//!
+//! Starts a `tgrep serve` instance and fires multiple parallel search requests
+//! over TCP to verify the server handles concurrency correctly.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+use std::{env, fs};
+
+use tempfile::TempDir;
+
+/// Create a temp directory with enough files to make concurrent searches meaningful.
+fn setup_fixture() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let sub = dir.path().join("src");
+    fs::create_dir_all(&sub).unwrap();
+
+    // Create a variety of source files
+    for i in 0..20 {
+        let content = format!(
+            "fn function_{i}() {{\n    let value = {i};\n    println!(\"result: {{}}\", value);\n}}\n\n\
+             pub struct Widget{i} {{\n    name: String,\n    count: u32,\n}}\n\n\
+             impl Widget{i} {{\n    pub fn new() -> Self {{\n        Widget{i} {{ name: String::new(), count: 0 }}\n    }}\n}}\n"
+        );
+        fs::write(sub.join(format!("mod_{i}.rs")), content).unwrap();
+    }
+
+    // A few files with unique content for targeted searches
+    fs::write(
+        sub.join("unique_alpha.rs"),
+        "fn alpha_handler() {\n    let alpha_value = 42;\n    process_alpha(alpha_value);\n}\n",
+    )
+    .unwrap();
+
+    fs::write(
+        sub.join("unique_beta.rs"),
+        "fn beta_handler() {\n    let beta_value = 99;\n    process_beta(beta_value);\n}\n",
+    )
+    .unwrap();
+
+    dir
+}
+
+/// Finds the tgrep binary path from cargo build output.
+fn tgrep_bin() -> std::path::PathBuf {
+    let mut path = env::current_exe().unwrap();
+    // Go up from deps dir to the target debug/release dir
+    path.pop();
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push("tgrep");
+    if cfg!(windows) {
+        path.set_extension("exe");
+    }
+    assert!(
+        path.exists(),
+        "tgrep binary not found at {}",
+        path.display()
+    );
+    path
+}
+
+struct ServerGuard {
+    child: Child,
+    port: u16,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Starts a tgrep server and waits until it's ready to accept connections.
+fn start_server(root: &Path) -> ServerGuard {
+    let index_dir = root.join(".tgrep_test_index");
+    fs::create_dir_all(&index_dir).unwrap();
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--no-watch",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+
+    // Read stderr to find the port
+    let _stderr = child.stderr.as_ref().unwrap();
+
+    // Wait for serve.json to appear
+    let serve_json = index_dir.join("serve.json");
+    let start = Instant::now();
+    let port = loop {
+        if start.elapsed() > Duration::from_secs(30) {
+            panic!("tgrep serve did not start within 30 seconds");
+        }
+        if let Ok(data) = fs::read_to_string(&serve_json)
+            && let Ok(info) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(p) = info.get("port").and_then(|v| v.as_u64())
+        {
+            // Verify we can connect
+            if TcpStream::connect(format!("127.0.0.1:{p}")).is_ok() {
+                break p as u16;
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    };
+
+    // Wait for indexing to complete by polling status
+    let start = Instant::now();
+    loop {
+        if start.elapsed() > Duration::from_secs(60) {
+            // Proceed anyway; tests may still pass with partial index
+            break;
+        }
+        if let Ok(resp) = send_request(port, r#"{"jsonrpc":"2.0","method":"status","id":0}"#)
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&resp)
+        {
+            let indexing = v
+                .pointer("/result/indexing")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            if !indexing {
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+
+    ServerGuard { child, port }
+}
+
+/// Send a single JSON-RPC request and read the response.
+fn send_request(port: u16, request: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    writeln!(stream, "{request}")?;
+    stream.flush()?;
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader.read_line(&mut response)?;
+    Ok(response)
+}
+
+/// Build a search JSON-RPC request.
+fn search_request(id: u64, pattern: &str) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "search",
+        "id": id,
+        "params": { "pattern": pattern }
+    })
+    .to_string()
+}
+
+fn search_request_with_opts(id: u64, pattern: &str, opts: serde_json::Value) -> String {
+    let mut params = opts;
+    params.as_object_mut().unwrap().insert(
+        "pattern".to_string(),
+        serde_json::Value::String(pattern.to_string()),
+    );
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "search",
+        "id": id,
+        "params": params
+    })
+    .to_string()
+}
+
+// ─── Concurrent search tests ─────────────────────────────────────────
+
+#[test]
+fn concurrent_identical_searches() {
+    let dir = setup_fixture();
+    let server = start_server(dir.path().join("src").as_path());
+    let port = server.port;
+
+    // Fire 10 identical search requests in parallel
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            thread::spawn(move || {
+                let req = search_request(i, "function");
+                let resp = send_request(port, &req).expect("request failed");
+                let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+                assert!(v.get("error").is_none(), "got error: {v}");
+                let num_matches = v
+                    .pointer("/result/num_matches")
+                    .and_then(|n| n.as_u64())
+                    .expect("missing num_matches");
+                (i, num_matches)
+            })
+        })
+        .collect();
+
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // All concurrent requests should return the same result count
+    let first_count = results[0].1;
+    assert!(first_count > 0, "expected matches for 'function'");
+    for (id, count) in &results {
+        assert_eq!(
+            *count, first_count,
+            "request {id} got {count} matches, expected {first_count}"
+        );
+    }
+}
+
+#[test]
+fn concurrent_different_searches() {
+    let dir = setup_fixture();
+    let server = start_server(dir.path().join("src").as_path());
+    let port = server.port;
+
+    let patterns = vec![
+        "function",
+        "Widget",
+        "String",
+        "println",
+        "pub struct",
+        "impl",
+        "new",
+        "count",
+        "value",
+        "let",
+    ];
+
+    let patterns = Arc::new(patterns);
+
+    // Fire different searches concurrently
+    let handles: Vec<_> = (0..patterns.len())
+        .map(|i| {
+            let patterns = Arc::clone(&patterns);
+            thread::spawn(move || {
+                let req = search_request(i as u64, patterns[i]);
+                let resp = send_request(port, &req).expect("request failed");
+                let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+                assert!(
+                    v.get("error").is_none(),
+                    "got error for '{}': {v}",
+                    patterns[i]
+                );
+                let num_matches = v
+                    .pointer("/result/num_matches")
+                    .and_then(|n| n.as_u64())
+                    .expect("missing num_matches");
+                (patterns[i], num_matches)
+            })
+        })
+        .collect();
+
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // Each pattern should have at least one match
+    for (pattern, count) in &results {
+        assert!(
+            *count > 0,
+            "expected matches for pattern '{pattern}', got 0"
+        );
+    }
+}
+
+#[test]
+fn concurrent_searches_with_different_options() {
+    let dir = setup_fixture();
+    let server = start_server(dir.path().join("src").as_path());
+    let port = server.port;
+
+    // Fire searches with varying options concurrently
+    let handles: Vec<_> = vec![
+        thread::spawn(move || {
+            let req = search_request_with_opts(
+                1,
+                "widget",
+                serde_json::json!({"case_insensitive": true}),
+            );
+            let resp = send_request(port, &req).expect("request failed");
+            let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+            assert!(
+                v.get("error").is_none(),
+                "case insensitive search failed: {v}"
+            );
+            let n = v
+                .pointer("/result/num_matches")
+                .and_then(|n| n.as_u64())
+                .unwrap();
+            assert!(
+                n > 0,
+                "case_insensitive search for 'widget' should match Widget"
+            );
+            ("case_insensitive", n)
+        }),
+        thread::spawn(move || {
+            let req = search_request_with_opts(2, "fn", serde_json::json!({"files_only": true}));
+            let resp = send_request(port, &req).expect("request failed");
+            let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+            assert!(v.get("error").is_none(), "files_only search failed: {v}");
+            let n = v
+                .pointer("/result/num_matches")
+                .and_then(|n| n.as_u64())
+                .unwrap();
+            assert!(n > 0, "files_only search for 'fn' should find files");
+            ("files_only", n)
+        }),
+        thread::spawn(move || {
+            // max_count is per-file, so use max_count=1 to limit each file to 1 match
+            let req = search_request_with_opts(3, "value", serde_json::json!({"max_count": 1}));
+            let resp = send_request(port, &req).expect("request failed");
+            let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+            assert!(v.get("error").is_none(), "max_count search failed: {v}");
+            let matches = v
+                .pointer("/result/matches")
+                .and_then(|m| m.as_array())
+                .unwrap();
+            // With max_count=1, each file should contribute at most 1 match
+            let mut files_seen = std::collections::HashMap::new();
+            for m in matches {
+                let file = m.get("file").and_then(|f| f.as_str()).unwrap_or("");
+                *files_seen.entry(file.to_string()).or_insert(0u64) += 1;
+            }
+            for (file, count) in &files_seen {
+                assert!(
+                    *count <= 1,
+                    "file {file} has {count} matches with max_count=1"
+                );
+            }
+            ("max_count", matches.len() as u64)
+        }),
+        thread::spawn(move || {
+            let req =
+                search_request_with_opts(4, "alpha_handler", serde_json::json!({"glob": ["*.rs"]}));
+            let resp = send_request(port, &req).expect("request failed");
+            let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+            assert!(v.get("error").is_none(), "glob search failed: {v}");
+            let n = v
+                .pointer("/result/num_matches")
+                .and_then(|n| n.as_u64())
+                .unwrap();
+            assert!(n > 0, "glob search for 'alpha_handler' should find matches");
+            ("glob_filter", n)
+        }),
+        thread::spawn(move || {
+            let req =
+                search_request_with_opts(5, "String", serde_json::json!({"fixed_string": true}));
+            let resp = send_request(port, &req).expect("request failed");
+            let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+            assert!(v.get("error").is_none(), "fixed_string search failed: {v}");
+            let n = v
+                .pointer("/result/num_matches")
+                .and_then(|n| n.as_u64())
+                .unwrap();
+            assert!(
+                n > 0,
+                "fixed_string search for 'String' should find matches"
+            );
+            ("fixed_string", n)
+        }),
+    ];
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}
+
+#[test]
+fn concurrent_high_volume_searches() {
+    let dir = setup_fixture();
+    let server = start_server(dir.path().join("src").as_path());
+    let port = server.port;
+
+    // Stress test: 50 concurrent requests
+    let num_requests = 50;
+    let handles: Vec<_> = (0..num_requests)
+        .map(|i| {
+            thread::spawn(move || {
+                let pattern = match i % 5 {
+                    0 => "fn",
+                    1 => "struct",
+                    2 => "impl",
+                    3 => "pub",
+                    _ => "let",
+                };
+                let req = search_request(i, pattern);
+                let resp = send_request(port, &req).expect("request failed");
+                let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+                assert!(
+                    v.get("error").is_none(),
+                    "request {i} (pattern={pattern}) got error: {v}"
+                );
+                let num_matches = v
+                    .pointer("/result/num_matches")
+                    .and_then(|n| n.as_u64())
+                    .expect("missing num_matches");
+                assert!(
+                    num_matches > 0,
+                    "request {i} (pattern={pattern}) got 0 matches"
+                );
+                num_matches
+            })
+        })
+        .collect();
+
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // Verify all requests completed successfully (they did if we got here)
+    assert_eq!(results.len(), num_requests as usize);
+}
+
+#[test]
+fn concurrent_searches_on_single_connection() {
+    let dir = setup_fixture();
+    let server = start_server(dir.path().join("src").as_path());
+    let port = server.port;
+
+    // Multiple threads sharing separate connections but also test pipelining
+    // on a single connection: send multiple requests before reading responses
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(30)))
+        .unwrap();
+
+    let patterns = ["fn", "struct", "impl", "pub", "let"];
+
+    // Send all requests
+    for (i, pattern) in patterns.iter().enumerate() {
+        let req = search_request(i as u64, pattern);
+        writeln!(stream, "{req}").unwrap();
+    }
+    stream.flush().unwrap();
+
+    // Read all responses
+    let mut reader = BufReader::new(stream);
+    for (i, pattern) in patterns.iter().enumerate() {
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&line).expect("invalid JSON response");
+        assert!(
+            v.get("error").is_none(),
+            "pipelined request {i} (pattern={pattern}) got error: {v}"
+        );
+        let num_matches = v
+            .pointer("/result/num_matches")
+            .and_then(|n| n.as_u64())
+            .expect("missing num_matches");
+        assert!(
+            num_matches > 0,
+            "pipelined request {i} (pattern={pattern}) got 0 matches"
+        );
+    }
+}
+
+#[test]
+fn concurrent_search_and_status_requests() {
+    let dir = setup_fixture();
+    let server = start_server(dir.path().join("src").as_path());
+    let port = server.port;
+
+    // Mix search and status requests concurrently
+    let handles: Vec<_> = (0..20)
+        .map(|i| {
+            thread::spawn(move || {
+                if i % 3 == 0 {
+                    // Status request
+                    let req = r#"{"jsonrpc":"2.0","method":"status","id":100}"#;
+                    let resp = send_request(port, req).expect("status request failed");
+                    let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+                    assert!(v.get("error").is_none(), "status request failed: {v}");
+                    assert!(
+                        v.pointer("/result/num_files").is_some(),
+                        "status missing num_files"
+                    );
+                } else {
+                    // Search request
+                    let req = search_request(i, "fn");
+                    let resp = send_request(port, &req).expect("search request failed");
+                    let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+                    assert!(v.get("error").is_none(), "search request {i} failed: {v}");
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}

--- a/tgrep-cli/tests/concurrent_search.rs
+++ b/tgrep-cli/tests/concurrent_search.rs
@@ -3,6 +3,7 @@
 //! Starts a `tgrep serve` instance and fires multiple parallel search requests
 //! over TCP to verify the server handles concurrency correctly.
 
+use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::path::Path;
@@ -10,7 +11,6 @@ use std::process::{Child, Command};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
-use std::{env, fs};
 
 use tempfile::TempDir;
 
@@ -46,24 +46,9 @@ fn setup_fixture() -> TempDir {
     dir
 }
 
-/// Finds the tgrep binary path from cargo build output.
+/// Returns the path to the tgrep binary, located by Cargo.
 fn tgrep_bin() -> std::path::PathBuf {
-    let mut path = env::current_exe().unwrap();
-    // Go up from deps dir to the target debug/release dir
-    path.pop();
-    if path.ends_with("deps") {
-        path.pop();
-    }
-    path.push("tgrep");
-    if cfg!(windows) {
-        path.set_extension("exe");
-    }
-    assert!(
-        path.exists(),
-        "tgrep binary not found at {}",
-        path.display()
-    );
-    path
+    assert_cmd::cargo::cargo_bin("tgrep")
 }
 
 struct ServerGuard {
@@ -91,13 +76,10 @@ fn start_server(root: &Path) -> ServerGuard {
             index_dir.to_str().unwrap(),
             root.to_str().unwrap(),
         ])
-        .stderr(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .spawn()
         .expect("failed to start tgrep serve");
-
-    // Read stderr to find the port
-    let _stderr = child.stderr.as_ref().unwrap();
 
     // Wait for serve.json to appear
     let serve_json = index_dir.join("serve.json");

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -132,13 +132,13 @@ pub fn default_index_dir(root: &Path) -> std::path::PathBuf {
 /// Write the on-disk index from a pre-computed snapshot (paths + inverted index).
 /// This allows the caller to snapshot under a brief lock, then write without holding it.
 ///
-/// Note: snapshots from the server still use the legacy format (no masks).
-/// This writes v1-compatible posting entries (file_id only) unless masks are available.
+/// Preserves mask data (loc_mask/next_mask) from the snapshot so Bloom-filter
+/// optimizations survive flush cycles.
 pub fn write_index_from_snapshot(
     root: &Path,
     index_dir: &Path,
     paths: &[String],
-    inverted: &HashMap<u32, Vec<u32>>,
+    inverted: &HashMap<u32, Vec<PostingEntry>>,
     complete: bool,
 ) -> Result<()> {
     std::fs::create_dir_all(index_dir)?;
@@ -146,8 +146,7 @@ pub fn write_index_from_snapshot(
     let mut sorted_trigrams: Vec<u32> = inverted.keys().copied().collect();
     sorted_trigrams.sort_unstable();
 
-    // Write index.bin — v2 posting entries with zero masks (still benefits from
-    // the v2 reader, and a subsequent `tgrep index` will compute real masks).
+    // Write index.bin — v2 posting entries with masks preserved from snapshot.
     let mut postings_file =
         std::io::BufWriter::new(std::fs::File::create(index_dir.join("index.bin"))?);
     let mut lookup_entries: Vec<LookupEntry> = Vec::with_capacity(sorted_trigrams.len());
@@ -163,12 +162,7 @@ pub fn write_index_from_snapshot(
             length,
         });
 
-        for &fid in posting_list {
-            let entry = PostingEntry {
-                file_id: fid,
-                loc_mask: u8::MAX, // all bits set = no filtering
-                next_mask: u8::MAX,
-            };
+        for entry in posting_list {
             postings_file.write_all(&entry.encode())?;
         }
         offset += length as u64 * ondisk::POSTING_ENTRY_SIZE as u64;

--- a/tgrep-core/src/filetypes.rs
+++ b/tgrep-core/src/filetypes.rs
@@ -24,6 +24,7 @@ pub fn builtin_types() -> HashMap<&'static str, &'static [&'static str]> {
     );
     m.insert("cs", &["*.cs"]);
     m.insert("csharp", &["*.cs"]);
+    m.insert("csproj", &["*.csproj"]);
     m.insert("css", &["*.css", "*.scss", "*.less"]);
     m.insert("csv", &["*.csv"]);
     m.insert("cuda", &["*.cu", "*.cuh"]);

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -306,7 +306,12 @@ impl HybridIndex {
     /// Reader files not superseded by overlay are included with remapped IDs.
     /// Preserves loc_mask and next_mask from both the on-disk reader and the
     /// live overlay so that Bloom-filter optimizations survive flush cycles.
-    pub fn full_snapshot(&self) -> (Vec<String>, std::collections::HashMap<u32, Vec<PostingEntry>>) {
+    pub fn full_snapshot(
+        &self,
+    ) -> (
+        Vec<String>,
+        std::collections::HashMap<u32, Vec<PostingEntry>>,
+    ) {
         use std::collections::HashMap;
 
         let reader = self.reader();
@@ -343,11 +348,13 @@ impl HybridIndex {
             let remapped: Vec<PostingEntry> = posting
                 .into_iter()
                 .filter_map(|entry| {
-                    reader_id_map.get(&entry.file_id).map(|&new_id| PostingEntry {
-                        file_id: new_id,
-                        loc_mask: entry.loc_mask,
-                        next_mask: entry.next_mask,
-                    })
+                    reader_id_map
+                        .get(&entry.file_id)
+                        .map(|&new_id| PostingEntry {
+                            file_id: new_id,
+                            loc_mask: entry.loc_mask,
+                            next_mask: entry.next_mask,
+                        })
                 })
                 .collect();
             if !remapped.is_empty() {

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -176,15 +176,61 @@ impl HybridIndex {
     }
 
     /// Execute a query plan with mask-aware filtering.
-    pub fn execute_query_with_masks(&self, plan: &QueryPlan) -> Vec<u32> {
-        if plan.is_match_all() {
-            return self.all_file_ids();
-        }
-        // Snapshot reader once to ensure all trigram lookups use the same
-        // reader version — prevents race conditions during concurrent flushes.
+    ///
+    /// Returns the matching file IDs **and** the `Arc<IndexReader>` snapshot
+    /// used for the lookups.  Callers that need to resolve file paths from
+    /// the returned IDs **must** use [`resolve_path`] / [`resolve_full_path`]
+    /// with the same snapshot — calling [`file_path`] instead introduces a
+    /// race: a concurrent `swap_reader` between the query and the path
+    /// resolution would resolve IDs against a different reader, silently
+    /// dropping every candidate whose ID does not exist in the new reader.
+    pub fn execute_query_with_masks(&self, plan: &QueryPlan) -> (Vec<u32>, Arc<IndexReader>) {
         let reader = self.reader();
-        query::execute_plan_with_masks(plan, &|tri| {
-            self.lookup_trigram_with_masks_using_reader(tri, &reader)
+        let ids = if plan.is_match_all() {
+            self.all_file_ids_using(&reader)
+        } else {
+            query::execute_plan_with_masks(plan, &|tri| {
+                self.lookup_trigram_with_masks_using_reader(tri, &reader)
+            })
+        };
+        (ids, reader)
+    }
+
+    /// Like [`all_file_ids`] but uses a caller-provided reader snapshot.
+    fn all_file_ids_using(&self, reader: &Arc<IndexReader>) -> Vec<u32> {
+        let mut ids: Vec<u32> = reader
+            .all_file_ids()
+            .into_iter()
+            .filter(|&fid| {
+                if let Some(path) = reader.file_path(fid) {
+                    !self.live.is_deleted(path) && !self.live_has_path(path)
+                } else {
+                    false
+                }
+            })
+            .collect();
+        ids.extend(self.live.all_file_ids());
+        ids
+    }
+
+    /// Resolve a file ID to a relative path using a specific reader snapshot.
+    ///
+    /// Handles both reader IDs (looked up in the provided snapshot) and
+    /// overlay IDs (looked up in the live index).  Pair with the snapshot
+    /// returned by [`execute_query_with_masks`] to guarantee consistency.
+    pub fn resolve_path(&self, file_id: u32, reader: &IndexReader) -> Option<String> {
+        if live::LiveIndex::is_overlay_id(file_id) {
+            self.live.file_path(file_id).map(|s| s.to_string())
+        } else {
+            reader.file_path(file_id).map(|s| s.to_string())
+        }
+    }
+
+    /// Resolve a file ID to an absolute path using a specific reader snapshot.
+    pub fn resolve_full_path(&self, file_id: u32, reader: &IndexReader) -> Option<PathBuf> {
+        self.resolve_path(file_id, reader).map(|rel| {
+            self.root
+                .join(rel.replace('/', std::path::MAIN_SEPARATOR_STR))
         })
     }
 

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -154,15 +154,63 @@ impl HybridIndex {
         if plan.is_match_all() {
             return self.all_file_ids();
         }
-        query::execute_plan(plan, &|tri| self.lookup_trigram(tri))
+        // Snapshot reader once to ensure all trigram lookups use the same
+        // reader version — prevents race conditions during concurrent flushes.
+        let reader = self.reader();
+        query::execute_plan(plan, &|tri| self.lookup_trigram_using_reader(tri, &reader))
     }
 
     /// Execute a query plan with mask-aware filtering.
-    pub fn execute_query_with_masks(&self, plan: &QueryPlan, pattern: &str) -> Vec<u32> {
+    pub fn execute_query_with_masks(&self, plan: &QueryPlan) -> Vec<u32> {
         if plan.is_match_all() {
             return self.all_file_ids();
         }
-        query::execute_plan_with_masks(plan, pattern, &|tri| self.lookup_trigram_with_masks(tri))
+        // Snapshot reader once to ensure all trigram lookups use the same
+        // reader version — prevents race conditions during concurrent flushes.
+        let reader = self.reader();
+        query::execute_plan_with_masks(plan, &|tri| {
+            self.lookup_trigram_with_masks_using_reader(tri, &reader)
+        })
+    }
+
+    /// Look up candidate file IDs for a trigram using a specific reader snapshot.
+    /// Ensures all trigrams in a query are evaluated against the same reader version.
+    fn lookup_trigram_using_reader(&self, trigram: u32, reader: &Arc<IndexReader>) -> Vec<u32> {
+        let mut reader_ids = reader.lookup_trigram(trigram);
+        let live_ids = self.live.lookup_trigram(trigram);
+
+        reader_ids.retain(|&fid| {
+            if let Some(path) = reader.file_path(fid) {
+                !self.live.is_deleted(path) && !self.live_has_path(path)
+            } else {
+                false
+            }
+        });
+
+        reader_ids.extend(live_ids);
+        reader_ids
+    }
+
+    /// Look up candidate posting entries with masks using a specific reader snapshot.
+    /// Ensures all trigrams in a query are evaluated against the same reader version.
+    fn lookup_trigram_with_masks_using_reader(
+        &self,
+        trigram: u32,
+        reader: &Arc<IndexReader>,
+    ) -> Vec<PostingEntry> {
+        let mut reader_entries = reader.lookup_trigram_with_masks(trigram);
+        let live_entries = self.live.lookup_trigram_with_masks(trigram);
+
+        reader_entries.retain(|e| {
+            if let Some(path) = reader.file_path(e.file_id) {
+                !self.live.is_deleted(path) && !self.live_has_path(path)
+            } else {
+                false
+            }
+        });
+
+        reader_entries.extend(live_entries);
+        reader_entries
     }
 
     /// Total number of files across both layers.
@@ -242,7 +290,9 @@ impl HybridIndex {
 
     /// Produce a full snapshot merging reader + overlay for disk serialization.
     /// Reader files not superseded by overlay are included with remapped IDs.
-    pub fn full_snapshot(&self) -> (Vec<String>, std::collections::HashMap<u32, Vec<u32>>) {
+    /// Preserves loc_mask and next_mask from both the on-disk reader and the
+    /// live overlay so that Bloom-filter optimizations survive flush cycles.
+    pub fn full_snapshot(&self) -> (Vec<String>, std::collections::HashMap<u32, Vec<PostingEntry>>) {
         use std::collections::HashMap;
 
         let reader = self.reader();
@@ -271,30 +321,43 @@ impl HybridIndex {
             paths.push(op.to_string());
         }
 
-        // Phase 2: Build merged inverted index
-        let mut inverted: HashMap<u32, Vec<u32>> = HashMap::new();
+        // Phase 2: Build merged inverted index with masks
+        let mut inverted: HashMap<u32, Vec<PostingEntry>> = HashMap::new();
 
-        // Reader trigram postings (remapped, excluding superseded files)
-        for (trigram, posting) in reader.all_trigram_postings() {
-            let remapped: Vec<u32> = posting
+        // Reader trigram postings with masks (remapped, excluding superseded files)
+        for (trigram, posting) in reader.all_trigram_postings_with_masks() {
+            let remapped: Vec<PostingEntry> = posting
                 .into_iter()
-                .filter_map(|old_id| reader_id_map.get(&old_id).copied())
+                .filter_map(|entry| {
+                    reader_id_map.get(&entry.file_id).map(|&new_id| PostingEntry {
+                        file_id: new_id,
+                        loc_mask: entry.loc_mask,
+                        next_mask: entry.next_mask,
+                    })
+                })
                 .collect();
             if !remapped.is_empty() {
                 inverted.entry(trigram).or_default().extend(remapped);
             }
         }
 
-        // Overlay trigram postings (remapped)
+        // Overlay trigram postings with masks (remapped)
         let overlay_inverted = self.live.inverted_index();
         for (&trigram, file_ids) in overlay_inverted {
             let tri_clean = trigram & !crate::live::OVERLAY_BIT;
-            let remapped: Vec<u32> = file_ids
+            let remapped: Vec<PostingEntry> = file_ids
                 .iter()
                 .filter_map(|&fid| {
-                    self.live
-                        .file_path(fid)
-                        .and_then(|p| overlay_path_to_new_id.get(p).copied())
+                    self.live.file_path(fid).and_then(|p| {
+                        overlay_path_to_new_id.get(p).map(|&new_id| {
+                            let m = self.live.get_masks(trigram, fid);
+                            PostingEntry {
+                                file_id: new_id,
+                                loc_mask: m.loc_mask,
+                                next_mask: m.next_mask,
+                            }
+                        })
+                    })
                 })
                 .collect();
             if !remapped.is_empty() {
@@ -302,9 +365,9 @@ impl HybridIndex {
             }
         }
 
-        // Sort all posting lists
+        // Sort all posting lists by file_id
         for posting in inverted.values_mut() {
-            posting.sort_unstable();
+            posting.sort_by_key(|e| e.file_id);
         }
 
         (paths, inverted)

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -29,13 +29,14 @@ pub struct HybridIndex {
 impl HybridIndex {
     pub fn open(index_dir: &Path, root: &Path) -> Result<Self> {
         let reader = IndexReader::open(index_dir)?;
-        // Reject degenerate readers (files present but 0 trigrams) at startup.
-        // This matches the retry logic in flush_index_to_disk.
+        // Reject structurally inconsistent readers (mmap sections present but
+        // counters say zero entries). This catches stale-metadata corruption
+        // on Windows without rejecting valid indexes where all files are too
+        // short to produce trigrams.
         if reader.is_degenerate() {
-            return Err(crate::Error::IndexCorrupted(format!(
-                "degenerate reader: {} files but 0 trigrams",
-                reader.num_files()
-            )));
+            return Err(crate::Error::IndexCorrupted(
+                "degenerate reader: mmap sections non-empty but num_entries is 0".to_string(),
+            ));
         }
         // Validate and warm up the lookup mmap so the first searches after
         // startup don't hit cold pages (which caused zero-candidate results

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -363,9 +363,10 @@ impl HybridIndex {
         }
 
         // Overlay trigram postings with masks (remapped)
+        // Trigram keys in the live inverted index never have OVERLAY_BIT set
+        // (OVERLAY_BIT is only used in file IDs), so they can be used directly.
         let overlay_inverted = self.live.inverted_index();
         for (&trigram, file_ids) in overlay_inverted {
-            let tri_clean = trigram & !crate::live::OVERLAY_BIT;
             let remapped: Vec<PostingEntry> = file_ids
                 .iter()
                 .filter_map(|&fid| {
@@ -382,7 +383,7 @@ impl HybridIndex {
                 })
                 .collect();
             if !remapped.is_empty() {
-                inverted.entry(tri_clean).or_default().extend(remapped);
+                inverted.entry(trigram).or_default().extend(remapped);
             }
         }
 

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -29,6 +29,20 @@ pub struct HybridIndex {
 impl HybridIndex {
     pub fn open(index_dir: &Path, root: &Path) -> Result<Self> {
         let reader = IndexReader::open(index_dir)?;
+        // Reject degenerate readers (files present but 0 trigrams) at startup.
+        // This matches the retry logic in flush_index_to_disk.
+        if reader.is_degenerate() {
+            return Err(crate::Error::IndexCorrupted(format!(
+                "degenerate reader: {} files but 0 trigrams",
+                reader.num_files()
+            )));
+        }
+        // Validate and warm up the lookup mmap so the first searches after
+        // startup don't hit cold pages (which caused zero-candidate results
+        // on Windows).
+        if let Err(msg) = reader.validate_lookup() {
+            return Err(crate::Error::IndexCorrupted(msg));
+        }
         Ok(Self {
             reader: RwLock::new(Arc::new(reader)),
             live: LiveIndex::new(),

--- a/tgrep-core/src/live.rs
+++ b/tgrep-core/src/live.rs
@@ -196,6 +196,18 @@ impl LiveIndex {
         self.file_paths.get(&file_id).map(|s| s.as_str())
     }
 
+    /// Get masks for a specific (trigram, file_id) pair. Returns the
+    /// no-filter sentinel when no masks are stored (e.g. bulk-insert path).
+    pub fn get_masks(&self, trigram: u32, file_id: u32) -> trigram::TrigramMasks {
+        self.masks
+            .get(&(trigram, file_id))
+            .copied()
+            .unwrap_or(trigram::TrigramMasks {
+                loc_mask: u8::MAX,
+                next_mask: u8::MAX,
+            })
+    }
+
     /// Check if a path has been deleted from the overlay.
     pub fn is_deleted(&self, path: &str) -> bool {
         self.deleted_paths.contains(path)

--- a/tgrep-core/src/live.rs
+++ b/tgrep-core/src/live.rs
@@ -340,7 +340,7 @@ impl LiveIndex {
             }
             if !posting.is_empty() {
                 posting.sort_unstable();
-                remapped.insert(trigram & !OVERLAY_BIT, posting);
+                remapped.insert(trigram, posting);
             }
         }
 

--- a/tgrep-core/src/query.rs
+++ b/tgrep-core/src/query.rs
@@ -325,8 +325,18 @@ where
             if candidates.is_empty() && queries.len() >= 3 {
                 let any_empty = list_sizes.iter().any(|(_, sz)| *sz == 0);
                 if any_empty {
-                    let min_size = list_sizes.iter().map(|(_, sz)| sz).min().copied().unwrap_or(0);
-                    let max_size = list_sizes.iter().map(|(_, sz)| sz).max().copied().unwrap_or(0);
+                    let min_size = list_sizes
+                        .iter()
+                        .map(|(_, sz)| sz)
+                        .min()
+                        .copied()
+                        .unwrap_or(0);
+                    let max_size = list_sizes
+                        .iter()
+                        .map(|(_, sz)| sz)
+                        .max()
+                        .copied()
+                        .unwrap_or(0);
                     eprintln!(
                         "[trace] AND plan: 0 candidates from {} trigrams (EMPTY posting list detected). \
                          min_list={min_size} max_list={max_size}",

--- a/tgrep-core/src/query.rs
+++ b/tgrep-core/src/query.rs
@@ -320,17 +320,19 @@ where
                 }
             }
 
-            // Diagnostic: when a non-trivial query returns 0, log per-trigram posting sizes
+            // Only log when a posting list is unexpectedly empty (trigram in
+            // lookup but 0 postings — indicates index corruption).
             if candidates.is_empty() && queries.len() >= 3 {
                 let any_empty = list_sizes.iter().any(|(_, sz)| *sz == 0);
-                let min_size = list_sizes.iter().map(|(_, sz)| sz).min().copied().unwrap_or(0);
-                let max_size = list_sizes.iter().map(|(_, sz)| sz).max().copied().unwrap_or(0);
-                eprintln!(
-                    "[trace] AND plan: 0 candidates from {} trigrams. \
-                     any_empty={any_empty} min_list={min_size} max_list={max_size} \
-                     sizes={list_sizes:?}",
-                    queries.len(),
-                );
+                if any_empty {
+                    let min_size = list_sizes.iter().map(|(_, sz)| sz).min().copied().unwrap_or(0);
+                    let max_size = list_sizes.iter().map(|(_, sz)| sz).max().copied().unwrap_or(0);
+                    eprintln!(
+                        "[trace] AND plan: 0 candidates from {} trigrams (EMPTY posting list detected). \
+                         min_list={min_size} max_list={max_size}",
+                        queries.len(),
+                    );
+                }
             }
 
             candidates.into_iter().map(|(fid, _, _)| fid).collect()

--- a/tgrep-core/src/query.rs
+++ b/tgrep-core/src/query.rs
@@ -321,29 +321,28 @@ where
                 }
             }
 
-            // Only log when a posting list is unexpectedly empty (trigram in
-            // lookup but 0 postings — indicates index corruption).
+            // Log when the AND intersection produces 0 candidates — helps diagnose
+            // whether the issue is empty posting lists, mask filtering, or intersection.
             if candidates.is_empty() && queries.len() >= 3 {
                 let any_empty = list_sizes.iter().any(|(_, sz)| *sz == 0);
-                if any_empty {
-                    let min_size = list_sizes
-                        .iter()
-                        .map(|(_, sz)| sz)
-                        .min()
-                        .copied()
-                        .unwrap_or(0);
-                    let max_size = list_sizes
-                        .iter()
-                        .map(|(_, sz)| sz)
-                        .max()
-                        .copied()
-                        .unwrap_or(0);
-                    eprintln!(
-                        "[trace] AND plan: 0 candidates from {} trigrams (EMPTY posting list detected). \
-                         min_list={min_size} max_list={max_size}",
-                        queries.len(),
-                    );
-                }
+                let min_size = list_sizes
+                    .iter()
+                    .map(|(_, sz)| sz)
+                    .min()
+                    .copied()
+                    .unwrap_or(0);
+                let max_size = list_sizes
+                    .iter()
+                    .map(|(_, sz)| sz)
+                    .max()
+                    .copied()
+                    .unwrap_or(0);
+                eprintln!(
+                    "[trace] AND plan: 0 candidates from {} trigrams. \
+                     any_empty={any_empty} min_list={min_size} max_list={max_size} \
+                     sizes={list_sizes:?}",
+                    queries.len(),
+                );
             }
 
             candidates.into_iter().map(|(fid, _, _)| fid).collect()

--- a/tgrep-core/src/query.rs
+++ b/tgrep-core/src/query.rs
@@ -8,11 +8,24 @@ use regex_syntax::hir::{Class, Hir, HirKind, Literal};
 use crate::ondisk::PostingEntry;
 use crate::trigram::{self, TrigramHash};
 
+/// A single trigram query with optional next-byte constraint.
+///
+/// `expected_next` is the byte that follows this trigram in the parsed
+/// literal, used for next_mask Bloom-filter checks. Computed at plan-build
+/// time from the HIR-extracted literal so it is always correct — even for
+/// regex patterns where the raw pattern string differs from the matched text.
+#[derive(Debug, Clone)]
+pub struct TrigramQuery {
+    pub hash: TrigramHash,
+    /// Expected next character for next_mask Bloom check.
+    pub expected_next: Option<u8>,
+}
+
 /// A node in the query plan tree.
 #[derive(Debug, Clone)]
 pub enum QueryPlan {
     /// All trigrams must match (intersection of posting lists).
-    And(Vec<TrigramHash>),
+    And(Vec<TrigramQuery>),
     /// Any branch can match (union of results).
     Or(Vec<QueryPlan>),
     /// No trigrams could be extracted — must scan all files.
@@ -39,12 +52,32 @@ pub fn build_literal_plan(literal: &str, case_insensitive: bool) -> QueryPlan {
     } else {
         literal.to_string()
     };
-    let trigrams = trigram::extract_from_literal(&text);
-    if trigrams.is_empty() {
-        QueryPlan::MatchAll
-    } else {
-        QueryPlan::And(trigrams)
+    literals_to_query_plan(text.as_bytes())
+}
+
+/// Convert a byte sequence into a QueryPlan of AND'd trigram queries.
+/// Each `TrigramQuery` carries the expected next byte (if any) so that
+/// next_mask Bloom-filter checks use the correct literal byte — not the
+/// raw regex pattern string.
+fn literals_to_query_plan(bytes: &[u8]) -> QueryPlan {
+    if bytes.len() < 3 {
+        return QueryPlan::MatchAll;
     }
+    let queries: Vec<TrigramQuery> = (0..bytes.len() - 2)
+        .map(|i| {
+            let hash = trigram::hash(bytes[i], bytes[i + 1], bytes[i + 2]);
+            let expected_next = if i + 3 < bytes.len() {
+                Some(bytes[i + 3])
+            } else {
+                None
+            };
+            TrigramQuery {
+                hash,
+                expected_next,
+            }
+        })
+        .collect();
+    QueryPlan::And(queries)
 }
 
 fn decompose_hir(hir: &Hir, case_insensitive: bool) -> QueryPlan {
@@ -55,17 +88,12 @@ fn decompose_hir(hir: &Hir, case_insensitive: bool) -> QueryPlan {
             } else {
                 String::from_utf8_lossy(bytes).into_owned()
             };
-            let trigrams = trigram::extract_from_literal(&text);
-            if trigrams.is_empty() {
-                QueryPlan::MatchAll
-            } else {
-                QueryPlan::And(trigrams)
-            }
+            literals_to_query_plan(text.as_bytes())
         }
         HirKind::Concat(subs) => {
             // Collect all literals from concat children into a single string,
             // then extract trigrams. Non-literal children break the chain.
-            let mut all_trigrams = Vec::new();
+            let mut all_queries = Vec::new();
             let mut current_literal = String::new();
 
             for sub in subs {
@@ -80,13 +108,15 @@ fn decompose_hir(hir: &Hir, case_insensitive: bool) -> QueryPlan {
                         } else {
                             current_literal.clone()
                         };
-                        all_trigrams.extend(trigram::extract_from_literal(&text));
+                        if let QueryPlan::And(queries) = literals_to_query_plan(text.as_bytes()) {
+                            all_queries.extend(queries);
+                        }
                         current_literal.clear();
                     }
                     // Recurse into the non-literal child
                     let sub_plan = decompose_hir(sub, case_insensitive);
-                    if let QueryPlan::And(tris) = sub_plan {
-                        all_trigrams.extend(tris);
+                    if let QueryPlan::And(queries) = sub_plan {
+                        all_queries.extend(queries);
                     }
                     // MatchAll or Or children don't contribute AND trigrams
                 }
@@ -99,13 +129,15 @@ fn decompose_hir(hir: &Hir, case_insensitive: bool) -> QueryPlan {
                 } else {
                     current_literal
                 };
-                all_trigrams.extend(trigram::extract_from_literal(&text));
+                if let QueryPlan::And(queries) = literals_to_query_plan(text.as_bytes()) {
+                    all_queries.extend(queries);
+                }
             }
 
-            if all_trigrams.is_empty() {
+            if all_queries.is_empty() {
                 QueryPlan::MatchAll
             } else {
-                QueryPlan::And(all_trigrams)
+                QueryPlan::And(all_queries)
             }
         }
         HirKind::Alternation(alts) => {
@@ -137,13 +169,27 @@ fn decompose_hir(hir: &Hir, case_insensitive: bool) -> QueryPlan {
 /// Simplify the query plan (dedup trigrams, flatten nested structures).
 fn simplify(plan: QueryPlan) -> QueryPlan {
     match plan {
-        QueryPlan::And(mut tris) => {
-            tris.sort_unstable();
-            tris.dedup();
-            if tris.is_empty() {
+        QueryPlan::And(mut queries) => {
+            queries.sort_by_key(|q| q.hash);
+            // Dedup by trigram hash. When the same trigram appears with
+            // different expected_next values (e.g. from separate literal
+            // segments in `mutex.*mutex_lock`), clear expected_next to
+            // avoid false negatives — we can't reliably filter on the
+            // next byte if the trigram appears in multiple contexts.
+            queries.dedup_by(|b, a| {
+                if a.hash == b.hash {
+                    if a.expected_next != b.expected_next {
+                        a.expected_next = None;
+                    }
+                    true
+                } else {
+                    false
+                }
+            });
+            if queries.is_empty() {
                 QueryPlan::MatchAll
             } else {
-                QueryPlan::And(tris)
+                QueryPlan::And(queries)
             }
         }
         QueryPlan::Or(plans) => {
@@ -164,11 +210,11 @@ where
     F: Fn(TrigramHash) -> Vec<u32>,
 {
     match plan {
-        QueryPlan::And(trigrams) => {
-            if trigrams.is_empty() {
+        QueryPlan::And(queries) => {
+            if queries.is_empty() {
                 return Vec::new();
             }
-            let mut lists: Vec<Vec<u32>> = trigrams.iter().map(|&t| lookup(t)).collect();
+            let mut lists: Vec<Vec<u32>> = queries.iter().map(|q| lookup(q.hash)).collect();
             lists.sort_by_key(|l| l.len());
 
             let mut result: Vec<u32> = lists.remove(0);
@@ -201,28 +247,26 @@ where
 
 /// Execute a query plan with mask-aware filtering.
 ///
-/// Uses loc_mask adjacency and next_mask checks to reduce false-positive
-/// candidates. The `pattern` is the original search literal used to extract
-/// the trigrams — needed for next_mask verification.
-pub fn execute_plan_with_masks<F>(plan: &QueryPlan, pattern: &str, lookup: &F) -> Vec<u32>
+/// Uses next_mask Bloom-filter checks to reduce false-positive candidates.
+/// The `expected_next` byte is embedded in each `TrigramQuery` at plan-build
+/// time from the HIR-parsed literal, so no raw pattern string is needed.
+pub fn execute_plan_with_masks<F>(plan: &QueryPlan, lookup: &F) -> Vec<u32>
 where
     F: Fn(TrigramHash) -> Vec<PostingEntry>,
 {
     match plan {
-        QueryPlan::And(trigrams) => {
-            if trigrams.is_empty() {
+        QueryPlan::And(queries) => {
+            if queries.is_empty() {
                 return Vec::new();
             }
 
-            let pattern_bytes = pattern.as_bytes();
-
             // Fetch full posting entries (with masks) for each trigram
-            let mut lists: Vec<(TrigramHash, Vec<PostingEntry>)> =
-                trigrams.iter().map(|&t| (t, lookup(t))).collect();
+            let mut lists: Vec<(&TrigramQuery, Vec<PostingEntry>)> =
+                queries.iter().map(|q| (q, lookup(q.hash))).collect();
             lists.sort_by_key(|(_, l)| l.len());
 
             // Start with smallest posting list
-            let (first_tri, first_list) = lists.remove(0);
+            let (first_query, first_list) = lists.remove(0);
             let mut candidates: Vec<(u32, u8, u8)> = first_list
                 .into_iter()
                 .map(|e| (e.file_id, e.loc_mask, e.next_mask))
@@ -231,13 +275,13 @@ where
             candidates.dedup_by_key(|e| e.0);
 
             // Apply next_mask check for the first trigram
-            if let Some(next_byte) = next_byte_after_trigram(first_tri, pattern_bytes) {
+            if let Some(next_byte) = first_query.expected_next {
                 let bit = trigram::bloom_hash(next_byte);
                 candidates.retain(|&(_, _, nm)| nm & bit != 0);
             }
 
             // Intersect with remaining posting lists
-            for (tri, mut list) in lists {
+            for (query, mut list) in lists {
                 list.sort_by_key(|e| e.file_id);
                 list.dedup_by_key(|e| e.file_id);
 
@@ -250,8 +294,8 @@ where
                     match fid_a.cmp(&fid_b) {
                         std::cmp::Ordering::Equal => {
                             let nm = list[j].next_mask;
-                            // Apply next_mask check for this trigram
-                            let pass = match next_byte_after_trigram(tri, pattern_bytes) {
+                            // Apply next_mask check using the literal-derived expected_next
+                            let pass = match query.expected_next {
                                 Some(nb) => nm & trigram::bloom_hash(nb) != 0,
                                 None => true,
                             };
@@ -276,7 +320,7 @@ where
         QueryPlan::Or(plans) => {
             let mut result = Vec::new();
             for sub in plans {
-                let mut sub_result = execute_plan_with_masks(sub, pattern, lookup);
+                let mut sub_result = execute_plan_with_masks(sub, lookup);
                 result.append(&mut sub_result);
             }
             result.sort_unstable();
@@ -285,20 +329,6 @@ where
         }
         QueryPlan::MatchAll => Vec::new(),
     }
-}
-
-/// Find the byte that follows a given trigram in the pattern string.
-fn next_byte_after_trigram(trigram: TrigramHash, pattern: &[u8]) -> Option<u8> {
-    if pattern.len() < 4 {
-        return None;
-    }
-    for window in pattern.windows(4) {
-        let h = trigram::hash(window[0], window[1], window[2]);
-        if h == trigram {
-            return Some(window[3]);
-        }
-    }
-    None
 }
 
 fn intersect_sorted(a: &[u32], b: &[u32]) -> Vec<u32> {
@@ -368,12 +398,13 @@ mod tests {
         // from "class alertschema"
         let plan = build_literal_plan("class AlertSchema", true);
         match &plan {
-            QueryPlan::And(tris) => {
-                assert!(!tris.is_empty(), "should have trigrams");
+            QueryPlan::And(queries) => {
+                assert!(!queries.is_empty(), "should have trigrams");
                 // Verify these are lowercase trigrams
                 let expected = trigram::extract_from_literal("class alertschema");
+                let hashes: Vec<TrigramHash> = queries.iter().map(|q| q.hash).collect();
                 for tri in &expected {
-                    assert!(tris.contains(tri), "missing trigram {tri:#010x}");
+                    assert!(hashes.contains(tri), "missing trigram {tri:#010x}");
                 }
             }
             _ => panic!("expected And plan"),
@@ -385,11 +416,12 @@ mod tests {
         // Same test but via regex parser path
         let plan = build_query_plan("class AlertSchema", true).unwrap();
         match &plan {
-            QueryPlan::And(tris) => {
-                assert!(!tris.is_empty(), "should have trigrams");
+            QueryPlan::And(queries) => {
+                assert!(!queries.is_empty(), "should have trigrams");
                 let expected = trigram::extract_from_literal("class alertschema");
+                let hashes: Vec<TrigramHash> = queries.iter().map(|q| q.hash).collect();
                 for tri in &expected {
-                    assert!(tris.contains(tri), "missing trigram {tri:#010x}");
+                    assert!(hashes.contains(tri), "missing trigram {tri:#010x}");
                 }
             }
             _ => panic!("expected And plan, got {plan:?}"),
@@ -449,7 +481,7 @@ mod tests {
         }
 
         let plan = build_literal_plan("mutex_lock", false);
-        let candidates = execute_plan_with_masks(&plan, "mutex_lock", &|tri| {
+        let candidates = execute_plan_with_masks(&plan, &|tri| {
             inverted.get(&tri).cloned().unwrap_or_default()
         });
 
@@ -485,7 +517,7 @@ mod tests {
         // overlapping trigrams. The mask filtering should reduce or eliminate
         // this as a candidate.
         let plan = build_literal_plan("mutex_lock", false);
-        let candidates = execute_plan_with_masks(&plan, "mutex_lock", &|tri| {
+        let candidates = execute_plan_with_masks(&plan, &|tri| {
             inverted.get(&tri).cloned().unwrap_or_default()
         });
 

--- a/tgrep-core/src/query.rs
+++ b/tgrep-core/src/query.rs
@@ -173,13 +173,14 @@ fn simplify(plan: QueryPlan) -> QueryPlan {
             queries.sort_by_key(|q| q.hash);
             // Dedup by trigram hash. When the same trigram appears with
             // different expected_next values (e.g. from separate literal
-            // segments in `mutex.*mutex_lock`), clear expected_next to
-            // avoid false negatives — we can't reliably filter on the
-            // next byte if the trigram appears in multiple contexts.
-            queries.dedup_by(|b, a| {
-                if a.hash == b.hash {
-                    if a.expected_next != b.expected_next {
-                        a.expected_next = None;
+            // segments in `mutex.*mutex_lock`), clear expected_next on the
+            // retained query to avoid false negatives — we can't reliably
+            // filter on the next byte if the trigram appears in multiple
+            // contexts.
+            queries.dedup_by(|retained, duplicate| {
+                if retained.hash == duplicate.hash {
+                    if retained.expected_next != duplicate.expected_next {
+                        retained.expected_next = None;
                     }
                     true
                 } else {

--- a/tgrep-core/src/query.rs
+++ b/tgrep-core/src/query.rs
@@ -263,6 +263,11 @@ where
             // Fetch full posting entries (with masks) for each trigram
             let mut lists: Vec<(&TrigramQuery, Vec<PostingEntry>)> =
                 queries.iter().map(|q| (q, lookup(q.hash))).collect();
+
+            // Diagnostic: collect sizes before sort for zero-candidate analysis
+            let list_sizes: Vec<(u32, usize)> =
+                lists.iter().map(|(q, l)| (q.hash, l.len())).collect();
+
             lists.sort_by_key(|(_, l)| l.len());
 
             // Start with smallest posting list
@@ -313,6 +318,19 @@ where
                 if candidates.is_empty() {
                     break;
                 }
+            }
+
+            // Diagnostic: when a non-trivial query returns 0, log per-trigram posting sizes
+            if candidates.is_empty() && queries.len() >= 3 {
+                let any_empty = list_sizes.iter().any(|(_, sz)| *sz == 0);
+                let min_size = list_sizes.iter().map(|(_, sz)| sz).min().copied().unwrap_or(0);
+                let max_size = list_sizes.iter().map(|(_, sz)| sz).max().copied().unwrap_or(0);
+                eprintln!(
+                    "[trace] AND plan: 0 candidates from {} trigrams. \
+                     any_empty={any_empty} min_list={min_size} max_list={max_size} \
+                     sizes={list_sizes:?}",
+                    queries.len(),
+                );
             }
 
             candidates.into_iter().map(|(fid, _, _)| fid).collect()

--- a/tgrep-core/src/query.rs
+++ b/tgrep-core/src/query.rs
@@ -265,10 +265,6 @@ where
             let mut lists: Vec<(&TrigramQuery, Vec<PostingEntry>)> =
                 queries.iter().map(|q| (q, lookup(q.hash))).collect();
 
-            // Diagnostic: collect sizes before sort for zero-candidate analysis
-            let list_sizes: Vec<(u32, usize)> =
-                lists.iter().map(|(q, l)| (q.hash, l.len())).collect();
-
             lists.sort_by_key(|(_, l)| l.len());
 
             // Start with smallest posting list
@@ -319,30 +315,6 @@ where
                 if candidates.is_empty() {
                     break;
                 }
-            }
-
-            // Log when the AND intersection produces 0 candidates — helps diagnose
-            // whether the issue is empty posting lists, mask filtering, or intersection.
-            if candidates.is_empty() && queries.len() >= 3 {
-                let any_empty = list_sizes.iter().any(|(_, sz)| *sz == 0);
-                let min_size = list_sizes
-                    .iter()
-                    .map(|(_, sz)| sz)
-                    .min()
-                    .copied()
-                    .unwrap_or(0);
-                let max_size = list_sizes
-                    .iter()
-                    .map(|(_, sz)| sz)
-                    .max()
-                    .copied()
-                    .unwrap_or(0);
-                eprintln!(
-                    "[trace] AND plan: 0 candidates from {} trigrams. \
-                     any_empty={any_empty} min_list={min_size} max_list={max_size} \
-                     sizes={list_sizes:?}",
-                    queries.len(),
-                );
             }
 
             candidates.into_iter().map(|(fid, _, _)| fid).collect()

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -199,6 +199,15 @@ impl IndexReader {
     /// indicating that the in-memory counters and on-disk metadata disagree
     /// (observed on Windows NTFS after rapid file renames when stale
     /// metadata causes a zero-length mmap despite non-empty files on disk).
+    ///
+    /// Note: because `open()` derives `num_entries` directly from the
+    /// lookup mmap length, this condition cannot occur through normal
+    /// construction — it represents a post-construction inconsistency
+    /// (e.g. partial `close()` or direct field mutation). Call sites in
+    /// `serve.rs` that need to detect the "files present, trigrams missing"
+    /// Windows stale-metadata heuristic should compare `num_files()` vs
+    /// `num_trigrams()` independently rather than relying solely on this
+    /// method.
     pub fn is_degenerate(&self) -> bool {
         self.num_entries == 0
             && (self.lookup.as_ref().is_some_and(|m| !m.is_empty())
@@ -228,10 +237,13 @@ impl IndexReader {
                     entry.trigram, prev
                 ));
             }
-            let byte_len = (entry.length as usize).checked_mul(POSTING_ENTRY_SIZE);
-            let end = byte_len.and_then(|bl| (entry.offset as usize).checked_add(bl));
+            // Perform range math in u64 to avoid truncation on 32-bit targets
+            // or corrupted indexes with large offsets.
+            let postings_len_u64 = postings_len as u64;
+            let byte_len = (entry.length as u64).checked_mul(POSTING_ENTRY_SIZE as u64);
+            let end = byte_len.and_then(|bl| entry.offset.checked_add(bl));
             match end {
-                Some(e) if e <= postings_len => {}
+                Some(e) if e <= postings_len_u64 => {}
                 _ => {
                     return Err(format!(
                         "lookup entry {i} (trigram {:#x}): posting range \
@@ -425,31 +437,45 @@ mod tests {
     #[test]
     fn is_degenerate_detects_mmap_counter_disagreement() {
         let tmp = TempDir::new().unwrap();
-        // Fabricate a case where lookup.bin has data but num_entries is 0.
-        // This simulates the stale-metadata corruption path.
         let (lookup, postings) = make_sorted_index(&[0x616263]);
-        // Write non-empty lookup/postings but *no* files — after open,
-        // num_entries > 0, so is_degenerate is false. That's fine; we need
-        // to test the *other* direction: counters say 0 but mmaps are
-        // non-empty. We can't easily create that via public API because
-        // open() derives num_entries from lookup len. Instead, verify the
-        // "files but empty sections" case is NOT degenerate (valid index).
         let files = ondisk::encode_file_entry(0, "a.rs").unwrap();
+
+        // Files present but empty lookup/postings is valid (files <3 bytes)
         write_index(tmp.path(), &[], &[], &files);
         let reader = IndexReader::open(tmp.path()).expect("should open");
-        // Files present but empty lookup/postings is valid (files <3 bytes)
         assert!(
             !reader.is_degenerate(),
             "files with empty sections is valid, not degenerate"
         );
 
-        // Non-empty sections with entries IS also not degenerate
+        // Non-empty sections with matching entries IS also not degenerate
         let tmp2 = TempDir::new().unwrap();
         write_index(tmp2.path(), &lookup, &postings, &files);
         let reader2 = IndexReader::open(tmp2.path()).expect("should open");
         assert!(
             !reader2.is_degenerate(),
             "well-formed index is not degenerate"
+        );
+
+        // Fabricate the inconsistent internal state: mmap-backed
+        // lookup/postings are present, but num_entries is forced to 0.
+        // This simulates a post-construction inconsistency.
+        let tmp3 = TempDir::new().unwrap();
+        write_index(tmp3.path(), &lookup, &postings, &files);
+        let opened = IndexReader::open(tmp3.path()).expect("should open");
+        assert!(
+            opened.lookup.as_ref().map_or(0, |m| m.len()) >= LOOKUP_ENTRY_SIZE,
+            "fixture should have a non-empty lookup mmap"
+        );
+        let degenerate_reader = IndexReader {
+            lookup: opened.lookup,
+            postings: opened.postings,
+            file_paths: opened.file_paths,
+            num_entries: 0,
+        };
+        assert!(
+            degenerate_reader.is_degenerate(),
+            "non-empty mmap with num_entries == 0 must be degenerate"
         );
     }
 

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -47,22 +47,37 @@ impl IndexReader {
         let mut lookup_file = File::open(&lookup_path)?;
         let mut postings_file = File::open(&postings_path)?;
 
-        let lookup_len = lookup_file.seek(SeekFrom::End(0))? as usize;
-        let postings_len = postings_file.seek(SeekFrom::End(0))? as usize;
+        let lookup_len_u64 = lookup_file.seek(SeekFrom::End(0))?;
+        let postings_len_u64 = postings_file.seek(SeekFrom::End(0))?;
 
-        let (lookup, postings, num_entries) = if lookup_len == 0 || postings_len == 0 {
+        let (lookup, postings, num_entries) = if lookup_len_u64 == 0 || postings_len_u64 == 0 {
             (None, None, 0)
         } else {
             // A corrupted lookup.bin whose size is not a multiple of the fixed
             // entry size would cause silent truncation of the trailing entry
             // (and binary search would still see it via integer division).
             // Reject up-front so the failure is loud and obvious.
-            if !lookup_len.is_multiple_of(LOOKUP_ENTRY_SIZE) {
+            //
+            // Validate in u64 before narrowing to usize so that oversized files
+            // on 32-bit targets are caught before any truncation.
+            if !lookup_len_u64.is_multiple_of(LOOKUP_ENTRY_SIZE as u64) {
                 return Err(crate::Error::IndexCorrupted(format!(
                     "lookup.bin size {} is not a multiple of {}",
-                    lookup_len, LOOKUP_ENTRY_SIZE
+                    lookup_len_u64, LOOKUP_ENTRY_SIZE
                 )));
             }
+            let lookup_len = usize::try_from(lookup_len_u64).map_err(|_| {
+                crate::Error::IndexCorrupted(format!(
+                    "lookup.bin size {} does not fit in usize on this platform",
+                    lookup_len_u64
+                ))
+            })?;
+            let postings_len = usize::try_from(postings_len_u64).map_err(|_| {
+                crate::Error::IndexCorrupted(format!(
+                    "index.bin size {} does not fit in usize on this platform",
+                    postings_len_u64
+                ))
+            })?;
             // SAFETY: Files are opened read-only and the Mmap lifetime is tied
             // to IndexReader. The close() method drops the mappings before any
             // file overwrites (required on Windows).

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -27,43 +27,47 @@ impl IndexReader {
             return Err(crate::Error::IndexNotFound(index_dir.display().to_string()));
         }
 
-        // Open files and create mmaps. We intentionally use the *mmap
-        // length* (not `std::fs::metadata().len()`) as the source of truth
-        // for the empty-index check. On Windows, `metadata()` can return a
-        // stale zero length for a file that was just renamed into place by
-        // `move_staged_files`, because NTFS directory-entry metadata updates
-        // are not always immediately visible to a separate `metadata()` call
-        // even though `File::open` + `CreateFileMapping` see the correct
-        // data. Using the mmap length avoids this race entirely.
-        let lookup_file = File::open(&lookup_path)?;
-        let postings_file = File::open(&postings_path)?;
+        // Map files first, then use *mmap length* as the source of truth.
+        //
+        // On Windows, `File::metadata().len()` (fstat) can transiently return
+        // zero for a file that was just renamed into place by
+        // `move_staged_files`, because NTFS metadata updates are not always
+        // immediately visible — even from the same file handle. Since memmap2
+        // internally queries `File::metadata().len()` to determine the mapping
+        // size, we bypass it by seeking to the end of the file to get the true
+        // length, then passing it explicitly via `MmapOptions::len()`.
+        //
+        // `SetFilePointerEx` (which backs `file.seek(SeekFrom::End(0))`) reads
+        // the file object's size directly from the kernel, which is always
+        // up-to-date even when the NTFS directory-entry metadata cache has not
+        // yet been invalidated.
+        use std::io::{Seek, SeekFrom};
+        use memmap2::MmapOptions;
 
-        let lookup_file_len = lookup_file.metadata()?.len();
-        let postings_file_len = postings_file.metadata()?.len();
+        let mut lookup_file = File::open(&lookup_path)?;
+        let mut postings_file = File::open(&postings_path)?;
 
-        let (lookup, postings, num_entries) = if lookup_file_len == 0 || postings_file_len == 0 {
+        let lookup_len = lookup_file.seek(SeekFrom::End(0))? as usize;
+        let postings_len = postings_file.seek(SeekFrom::End(0))? as usize;
+
+        let (lookup, postings, num_entries) = if lookup_len == 0 || postings_len == 0 {
             (None, None, 0)
         } else {
             // A corrupted lookup.bin whose size is not a multiple of the fixed
             // entry size would cause silent truncation of the trailing entry
             // (and binary search would still see it via integer division).
             // Reject up-front so the failure is loud and obvious.
-            //
-            // Do the modulo in u64 (file sizes are u64) so a >4GiB file on
-            // 32-bit targets isn't truncated by an `as usize` cast before
-            // the validation runs.
-            if lookup_file_len % (LOOKUP_ENTRY_SIZE as u64) != 0 {
+            if lookup_len % LOOKUP_ENTRY_SIZE != 0 {
                 return Err(crate::Error::IndexCorrupted(format!(
                     "lookup.bin size {} is not a multiple of {}",
-                    lookup_file_len,
-                    LOOKUP_ENTRY_SIZE
+                    lookup_len, LOOKUP_ENTRY_SIZE
                 )));
             }
-            // SAFETY: Files are opened read-only and the Mmap lifetime is tied to
-            // IndexReader. The close() method drops the mappings before any file
-            // overwrites (required on Windows).
-            let lk = unsafe { Mmap::map(&lookup_file)? };
-            let pk = unsafe { Mmap::map(&postings_file)? };
+            // SAFETY: Files are opened read-only and the Mmap lifetime is tied
+            // to IndexReader. The close() method drops the mappings before any
+            // file overwrites (required on Windows).
+            let lk = unsafe { MmapOptions::new().len(lookup_len).map(&lookup_file)? };
+            let pk = unsafe { MmapOptions::new().len(postings_len).map(&postings_file)? };
             let n = lk.len() / LOOKUP_ENTRY_SIZE;
             (Some(lk), Some(pk), n)
         };
@@ -178,6 +182,50 @@ impl IndexReader {
     /// NTFS after rapid file renames) and the reader should be reopened.
     pub fn is_degenerate(&self) -> bool {
         !self.file_paths.is_empty() && self.num_entries == 0
+    }
+
+    /// Validate that the lookup table is sorted by trigram hash and that
+    /// posting-list ranges stay within `index.bin` bounds.
+    ///
+    /// Returns `Ok(())` when the table is well-formed. As a side-effect, this
+    /// sequentially reads every lookup entry, warming the mmap pages into the
+    /// OS page cache so that subsequent binary searches never hit cold pages.
+    pub fn validate_lookup(&self) -> std::result::Result<(), String> {
+        let lookup = match self.lookup.as_ref() {
+            Some(l) => l,
+            None => return Ok(()), // empty index, nothing to validate
+        };
+        let postings_len = self.postings.as_ref().map_or(0, |p| p.len());
+        let mut prev_trigram: Option<u32> = None;
+        for i in 0..self.num_entries {
+            let entry = self.read_lookup_entry(i);
+            if let Some(prev) = prev_trigram {
+                if entry.trigram <= prev {
+                    return Err(format!(
+                        "lookup.bin not sorted at entry {i}: trigram {:#x} <= prev {:#x}",
+                        entry.trigram, prev
+                    ));
+                }
+            }
+            let byte_len = (entry.length as usize).checked_mul(POSTING_ENTRY_SIZE);
+            let end = byte_len.and_then(|bl| (entry.offset as usize).checked_add(bl));
+            match end {
+                Some(e) if e <= postings_len => {}
+                _ => {
+                    return Err(format!(
+                        "lookup entry {i} (trigram {:#x}): posting range \
+                         [offset={}, length={}] exceeds index.bin length {postings_len}",
+                        entry.trigram, entry.offset, entry.length
+                    ));
+                }
+            }
+            prev_trigram = Some(entry.trigram);
+        }
+        // Touch last byte of lookup to ensure the final page is paged in.
+        if !lookup.is_empty() {
+            std::hint::black_box(lookup[lookup.len() - 1]);
+        }
+        Ok(())
     }
 
     /// Get all file IDs present in this reader.
@@ -369,5 +417,82 @@ mod tests {
         write_index(tmp.path(), &[], &[], &[]);
         let reader = IndexReader::open(tmp.path()).expect("should open");
         assert!(!reader.is_degenerate(), "empty index is not degenerate");
+    }
+
+    /// Build a well-formed lookup + postings for testing validate_lookup.
+    fn make_sorted_index(trigrams: &[u32]) -> (Vec<u8>, Vec<u8>) {
+        let mut lookup_buf = Vec::new();
+        let mut postings_buf = Vec::new();
+        for &tri in trigrams {
+            let offset = postings_buf.len() as u64;
+            // One posting entry per trigram for simplicity
+            let pe = PostingEntry {
+                file_id: 0,
+                loc_mask: 0xFF,
+                next_mask: 0xFF,
+            };
+            postings_buf.extend_from_slice(&pe.encode());
+            let le = LookupEntry {
+                trigram: tri,
+                offset,
+                length: 1,
+            };
+            lookup_buf.extend_from_slice(&le.encode());
+        }
+        (lookup_buf, postings_buf)
+    }
+
+    #[test]
+    fn validate_lookup_accepts_sorted_table() {
+        let tmp = TempDir::new().unwrap();
+        let (lookup, postings) = make_sorted_index(&[100, 200, 300]);
+        let files = ondisk::encode_file_entry(0, "a.rs").unwrap();
+        write_index(tmp.path(), &lookup, &postings, &files);
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        assert!(reader.validate_lookup().is_ok());
+    }
+
+    #[test]
+    fn validate_lookup_rejects_unsorted_table() {
+        let tmp = TempDir::new().unwrap();
+        let (lookup, postings) = make_sorted_index(&[200, 100, 300]); // unsorted!
+        let files = ondisk::encode_file_entry(0, "a.rs").unwrap();
+        write_index(tmp.path(), &lookup, &postings, &files);
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        let err = reader.validate_lookup().unwrap_err();
+        assert!(err.contains("not sorted"), "expected sort error, got: {err}");
+    }
+
+    #[test]
+    fn validate_lookup_rejects_out_of_bounds_postings() {
+        let tmp = TempDir::new().unwrap();
+        // Create lookup that points past the end of postings
+        let le = LookupEntry {
+            trigram: 100,
+            offset: 0,
+            length: 999, // way past the single entry we provide
+        };
+        let mut lookup = Vec::new();
+        lookup.extend_from_slice(&le.encode());
+        let pe = PostingEntry {
+            file_id: 0,
+            loc_mask: 0xFF,
+            next_mask: 0xFF,
+        };
+        let mut postings = Vec::new();
+        postings.extend_from_slice(&pe.encode());
+        let files = ondisk::encode_file_entry(0, "a.rs").unwrap();
+        write_index(tmp.path(), &lookup, &postings, &files);
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        let err = reader.validate_lookup().unwrap_err();
+        assert!(err.contains("exceeds"), "expected bounds error, got: {err}");
+    }
+
+    #[test]
+    fn validate_lookup_empty_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        write_index(tmp.path(), &[], &[], &[]);
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        assert!(reader.validate_lookup().is_ok());
     }
 }

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -41,8 +41,8 @@ impl IndexReader {
         // the file object's size directly from the kernel, which is always
         // up-to-date even when the NTFS directory-entry metadata cache has not
         // yet been invalidated.
-        use std::io::{Seek, SeekFrom};
         use memmap2::MmapOptions;
+        use std::io::{Seek, SeekFrom};
 
         let mut lookup_file = File::open(&lookup_path)?;
         let mut postings_file = File::open(&postings_path)?;
@@ -57,7 +57,7 @@ impl IndexReader {
             // entry size would cause silent truncation of the trailing entry
             // (and binary search would still see it via integer division).
             // Reject up-front so the failure is loud and obvious.
-            if lookup_len % LOOKUP_ENTRY_SIZE != 0 {
+            if !lookup_len.is_multiple_of(LOOKUP_ENTRY_SIZE) {
                 return Err(crate::Error::IndexCorrupted(format!(
                     "lookup.bin size {} is not a multiple of {}",
                     lookup_len, LOOKUP_ENTRY_SIZE
@@ -199,13 +199,13 @@ impl IndexReader {
         let mut prev_trigram: Option<u32> = None;
         for i in 0..self.num_entries {
             let entry = self.read_lookup_entry(i);
-            if let Some(prev) = prev_trigram {
-                if entry.trigram <= prev {
-                    return Err(format!(
-                        "lookup.bin not sorted at entry {i}: trigram {:#x} <= prev {:#x}",
-                        entry.trigram, prev
-                    ));
-                }
+            if let Some(prev) = prev_trigram
+                && entry.trigram <= prev
+            {
+                return Err(format!(
+                    "lookup.bin not sorted at entry {i}: trigram {:#x} <= prev {:#x}",
+                    entry.trigram, prev
+                ));
             }
             let byte_len = (entry.length as usize).checked_mul(POSTING_ENTRY_SIZE);
             let end = byte_len.and_then(|bl| (entry.offset as usize).checked_add(bl));
@@ -460,7 +460,10 @@ mod tests {
         write_index(tmp.path(), &lookup, &postings, &files);
         let reader = IndexReader::open(tmp.path()).unwrap();
         let err = reader.validate_lookup().unwrap_err();
-        assert!(err.contains("not sorted"), "expected sort error, got: {err}");
+        assert!(
+            err.contains("not sorted"),
+            "expected sort error, got: {err}"
+        );
     }
 
     #[test]

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -27,12 +27,21 @@ impl IndexReader {
             return Err(crate::Error::IndexNotFound(index_dir.display().to_string()));
         }
 
-        let lookup_meta = std::fs::metadata(&lookup_path)?;
-        let postings_meta = std::fs::metadata(&postings_path)?;
+        // Open files and create mmaps. We intentionally use the *mmap
+        // length* (not `std::fs::metadata().len()`) as the source of truth
+        // for the empty-index check. On Windows, `metadata()` can return a
+        // stale zero length for a file that was just renamed into place by
+        // `move_staged_files`, because NTFS directory-entry metadata updates
+        // are not always immediately visible to a separate `metadata()` call
+        // even though `File::open` + `CreateFileMapping` see the correct
+        // data. Using the mmap length avoids this race entirely.
+        let lookup_file = File::open(&lookup_path)?;
+        let postings_file = File::open(&postings_path)?;
 
-        // Handle empty index (no files indexed yet) — mmap requires non-zero length
-        let (lookup, postings, num_entries) = if lookup_meta.len() == 0 || postings_meta.len() == 0
-        {
+        let lookup_file_len = lookup_file.metadata()?.len();
+        let postings_file_len = postings_file.metadata()?.len();
+
+        let (lookup, postings, num_entries) = if lookup_file_len == 0 || postings_file_len == 0 {
             (None, None, 0)
         } else {
             // A corrupted lookup.bin whose size is not a multiple of the fixed
@@ -43,15 +52,13 @@ impl IndexReader {
             // Do the modulo in u64 (file sizes are u64) so a >4GiB file on
             // 32-bit targets isn't truncated by an `as usize` cast before
             // the validation runs.
-            if lookup_meta.len() % (LOOKUP_ENTRY_SIZE as u64) != 0 {
+            if lookup_file_len % (LOOKUP_ENTRY_SIZE as u64) != 0 {
                 return Err(crate::Error::IndexCorrupted(format!(
                     "lookup.bin size {} is not a multiple of {}",
-                    lookup_meta.len(),
+                    lookup_file_len,
                     LOOKUP_ENTRY_SIZE
                 )));
             }
-            let lookup_file = File::open(&lookup_path)?;
-            let postings_file = File::open(&postings_path)?;
             // SAFETY: Files are opened read-only and the Mmap lifetime is tied to
             // IndexReader. The close() method drops the mappings before any file
             // overwrites (required on Windows).
@@ -160,6 +167,17 @@ impl IndexReader {
     /// Total number of unique trigrams.
     pub fn num_trigrams(&self) -> usize {
         self.num_entries
+    }
+
+    /// Returns `true` when the reader has files but zero trigram entries.
+    ///
+    /// This is a degenerate state that should never occur for a well-formed
+    /// index with > 0 files — every indexed file produces at least one
+    /// trigram. When detected after a flush, it indicates the mmap was
+    /// opened against stale / zero-length metadata (observed on Windows
+    /// NTFS after rapid file renames) and the reader should be reopened.
+    pub fn is_degenerate(&self) -> bool {
+        !self.file_paths.is_empty() && self.num_entries == 0
     }
 
     /// Get all file IDs present in this reader.
@@ -333,5 +351,23 @@ mod tests {
         assert_eq!(reader.file_paths[0], "a.rs");
         assert_eq!(reader.file_paths[1], "b.rs");
         assert_eq!(reader.file_paths[2], "c.rs");
+    }
+
+    #[test]
+    fn is_degenerate_detects_files_without_trigrams() {
+        let tmp = TempDir::new().unwrap();
+        // Files present but lookup/postings are empty → degenerate reader
+        let files = ondisk::encode_file_entry(0, "a.rs").unwrap();
+        write_index(tmp.path(), &[], &[], &files);
+        let reader = IndexReader::open(tmp.path()).expect("should open");
+        assert!(reader.is_degenerate(), "files but no trigrams = degenerate");
+    }
+
+    #[test]
+    fn is_degenerate_false_for_empty_index() {
+        let tmp = TempDir::new().unwrap();
+        write_index(tmp.path(), &[], &[], &[]);
+        let reader = IndexReader::open(tmp.path()).expect("should open");
+        assert!(!reader.is_degenerate(), "empty index is not degenerate");
     }
 }

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -27,7 +27,8 @@ impl IndexReader {
             return Err(crate::Error::IndexNotFound(index_dir.display().to_string()));
         }
 
-        // Map files first, then use *mmap length* as the source of truth.
+        // Open files and seek to get their true length, then mmap with that
+        // explicit length.
         //
         // On Windows, `File::metadata().len()` (fstat) can transiently return
         // zero for a file that was just renamed into place by
@@ -188,15 +189,20 @@ impl IndexReader {
         self.num_entries
     }
 
-    /// Returns `true` when the reader has files but zero trigram entries.
+    /// Returns `true` when the reader state is structurally inconsistent.
     ///
-    /// This is a degenerate state that should never occur for a well-formed
-    /// index with > 0 files — every indexed file produces at least one
-    /// trigram. When detected after a flush, it indicates the mmap was
-    /// opened against stale / zero-length metadata (observed on Windows
-    /// NTFS after rapid file renames) and the reader should be reopened.
+    /// A well-formed index may legitimately contain files that produce no
+    /// trigrams (for example, files shorter than 3 bytes), so
+    /// `num_files() > 0 && num_trigrams() == 0` is not inherently
+    /// degenerate. The zero-trigram case is only suspicious when one of the
+    /// mmap-backed binary sections is nevertheless present and non-empty,
+    /// indicating that the in-memory counters and on-disk metadata disagree
+    /// (observed on Windows NTFS after rapid file renames when stale
+    /// metadata causes a zero-length mmap despite non-empty files on disk).
     pub fn is_degenerate(&self) -> bool {
-        !self.file_paths.is_empty() && self.num_entries == 0
+        self.num_entries == 0
+            && (self.lookup.as_ref().is_some_and(|m| !m.is_empty())
+                || self.postings.as_ref().is_some_and(|m| !m.is_empty()))
     }
 
     /// Validate that the lookup table is sorted by trigram hash and that
@@ -417,13 +423,34 @@ mod tests {
     }
 
     #[test]
-    fn is_degenerate_detects_files_without_trigrams() {
+    fn is_degenerate_detects_mmap_counter_disagreement() {
         let tmp = TempDir::new().unwrap();
-        // Files present but lookup/postings are empty → degenerate reader
+        // Fabricate a case where lookup.bin has data but num_entries is 0.
+        // This simulates the stale-metadata corruption path.
+        let (lookup, postings) = make_sorted_index(&[0x616263]);
+        // Write non-empty lookup/postings but *no* files — after open,
+        // num_entries > 0, so is_degenerate is false. That's fine; we need
+        // to test the *other* direction: counters say 0 but mmaps are
+        // non-empty. We can't easily create that via public API because
+        // open() derives num_entries from lookup len. Instead, verify the
+        // "files but empty sections" case is NOT degenerate (valid index).
         let files = ondisk::encode_file_entry(0, "a.rs").unwrap();
         write_index(tmp.path(), &[], &[], &files);
         let reader = IndexReader::open(tmp.path()).expect("should open");
-        assert!(reader.is_degenerate(), "files but no trigrams = degenerate");
+        // Files present but empty lookup/postings is valid (files <3 bytes)
+        assert!(
+            !reader.is_degenerate(),
+            "files with empty sections is valid, not degenerate"
+        );
+
+        // Non-empty sections with entries IS also not degenerate
+        let tmp2 = TempDir::new().unwrap();
+        write_index(tmp2.path(), &lookup, &postings, &files);
+        let reader2 = IndexReader::open(tmp2.path()).expect("should open");
+        assert!(
+            !reader2.is_degenerate(),
+            "well-formed index is not degenerate"
+        );
     }
 
     #[test]

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -185,6 +185,18 @@ impl IndexReader {
         result
     }
 
+    /// Iterate all trigram entries with full posting data (including masks).
+    /// Returns (trigram_hash, Vec<PostingEntry>) preserving loc_mask/next_mask.
+    pub fn all_trigram_postings_with_masks(&self) -> Vec<(u32, Vec<PostingEntry>)> {
+        let mut result = Vec::with_capacity(self.num_entries);
+        for i in 0..self.num_entries {
+            let entry = self.read_lookup_entry(i);
+            let postings = self.read_posting_entries(entry.offset, entry.length);
+            result.push((entry.trigram, postings));
+        }
+        result
+    }
+
     fn binary_search(&self, trigram: u32) -> Option<usize> {
         let mut lo = 0usize;
         let mut hi = self.num_entries;

--- a/tgrep-core/tests/case_insensitive_roundtrip.rs
+++ b/tgrep-core/tests/case_insensitive_roundtrip.rs
@@ -1,19 +1,31 @@
 use std::collections::HashMap;
-use tgrep_core::{builder, query, reader, trigram};
+use tgrep_core::{PostingEntry, builder, query, reader, trigram};
 
 #[test]
 fn case_insensitive_search_roundtrip() {
     let content = b"internal class AlertSchema : AlertBaseSchema";
 
-    // Extract trigrams (original + lowercase) just like builder/serve does
-    let mut file_tris = trigram::extract(content);
+    // Extract trigrams with masks (original + lowercase) just like builder/serve does
+    let mut tri_masks = trigram::extract_with_masks(content);
     let lower = content.to_ascii_lowercase();
-    file_tris.extend(trigram::extract(&lower));
+    if lower != *content {
+        tri_masks.extend(trigram::extract_with_masks(&lower));
+    }
 
-    // Build inverted index for file_id=0
-    let mut inverted: HashMap<u32, Vec<u32>> = HashMap::new();
-    for &tri in &file_tris {
-        inverted.entry(tri).or_default().push(0);
+    // Build inverted index with masks for file_id=0
+    let mut per_tri: HashMap<u32, trigram::TrigramMasks> = HashMap::new();
+    for &(tri, m) in &tri_masks {
+        let entry = per_tri.entry(tri).or_default();
+        entry.loc_mask |= m.loc_mask;
+        entry.next_mask |= m.next_mask;
+    }
+    let mut inverted: HashMap<u32, Vec<PostingEntry>> = HashMap::new();
+    for (tri, m) in per_tri {
+        inverted.entry(tri).or_default().push(PostingEntry {
+            file_id: 0,
+            loc_mask: m.loc_mask,
+            next_mask: m.next_mask,
+        });
     }
 
     // Write to temp directory

--- a/tgrep-core/tests/snapshot_consistency.rs
+++ b/tgrep-core/tests/snapshot_consistency.rs
@@ -6,16 +6,13 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use tgrep_core::hybrid::HybridIndex;
 use tgrep_core::PostingEntry;
+use tgrep_core::hybrid::HybridIndex;
 use tgrep_core::{builder, query, trigram};
 
 /// Build a test index on disk from a set of file contents.
 /// Returns the temp directory path (caller owns cleanup).
-fn build_test_index(
-    root: &Path,
-    files: &[(&str, &[u8])],
-) -> tempfile::TempDir {
+fn build_test_index(root: &Path, files: &[(&str, &[u8])]) -> tempfile::TempDir {
     let tmp = tempfile::TempDir::new().unwrap();
     let index_dir = tmp.path();
 
@@ -54,8 +51,14 @@ fn all_query_ids_resolve_via_snapshot() {
     let root = tempfile::TempDir::new().unwrap();
     let files: Vec<(&str, &[u8])> = vec![
         ("src/main.rs", b"fn main() { println!(\"hello\"); }"),
-        ("src/lib.rs", b"pub fn hello() -> &'static str { \"hello\" }"),
-        ("src/util.rs", b"pub fn format_hello(name: &str) -> String { format!(\"hello {}\", name) }"),
+        (
+            "src/lib.rs",
+            b"pub fn hello() -> &'static str { \"hello\" }",
+        ),
+        (
+            "src/util.rs",
+            b"pub fn format_hello(name: &str) -> String { format!(\"hello {}\", name) }",
+        ),
     ];
 
     // Create the actual files on disk (for root)
@@ -174,9 +177,7 @@ fn snapshot_survives_reader_swap() {
 #[test]
 fn new_query_after_swap_resolves_correctly() {
     let root = tempfile::TempDir::new().unwrap();
-    let files_v1: Vec<(&str, &[u8])> = vec![
-        ("a.rs", b"fn search_target() {}"),
-    ];
+    let files_v1: Vec<(&str, &[u8])> = vec![("a.rs", b"fn search_target() {}")];
     for (path, content) in &files_v1 {
         let full = root.path().join(path);
         std::fs::create_dir_all(full.parent().unwrap()).unwrap();
@@ -216,10 +217,7 @@ fn new_query_after_swap_resolves_correctly() {
 #[test]
 fn match_all_uses_consistent_snapshot() {
     let root = tempfile::TempDir::new().unwrap();
-    let files: Vec<(&str, &[u8])> = vec![
-        ("a.txt", b"hello world"),
-        ("b.txt", b"goodbye world"),
-    ];
+    let files: Vec<(&str, &[u8])> = vec![("a.txt", b"hello world"), ("b.txt", b"goodbye world")];
     for (path, content) in &files {
         let full = root.path().join(path);
         std::fs::write(&full, content).unwrap();
@@ -261,7 +259,10 @@ fn concurrent_swap_during_query() {
         files_v1.push((path, content.into_bytes()));
     }
 
-    let files_refs: Vec<(&str, &[u8])> = files_v1.iter().map(|(p, c)| (p.as_str(), c.as_slice())).collect();
+    let files_refs: Vec<(&str, &[u8])> = files_v1
+        .iter()
+        .map(|(p, c)| (p.as_str(), c.as_slice()))
+        .collect();
     let index_v1 = build_test_index(root.path(), &files_refs);
     let hybrid = Arc::new(HybridIndex::open(index_v1.path(), root.path()).unwrap());
 
@@ -274,7 +275,10 @@ fn concurrent_swap_during_query() {
         std::fs::write(&full, content.as_bytes()).unwrap();
         files_v2.push((path, content.into_bytes()));
     }
-    let files_refs_v2: Vec<(&str, &[u8])> = files_v2.iter().map(|(p, c)| (p.as_str(), c.as_slice())).collect();
+    let files_refs_v2: Vec<(&str, &[u8])> = files_v2
+        .iter()
+        .map(|(p, c)| (p.as_str(), c.as_slice()))
+        .collect();
     let index_v2 = build_test_index(root.path(), &files_refs_v2);
 
     let barrier = Arc::new(Barrier::new(2));

--- a/tgrep-core/tests/snapshot_consistency.rs
+++ b/tgrep-core/tests/snapshot_consistency.rs
@@ -1,0 +1,319 @@
+//! Tests for reader snapshot consistency in HybridIndex.
+//!
+//! Verifies that query execution and path resolution use the same reader
+//! snapshot, preventing a race condition where a concurrent `swap_reader`
+//! could cause all file_path lookups to fail.
+
+use std::collections::HashMap;
+use std::path::Path;
+use tgrep_core::hybrid::HybridIndex;
+use tgrep_core::PostingEntry;
+use tgrep_core::{builder, query, trigram};
+
+/// Build a test index on disk from a set of file contents.
+/// Returns the temp directory path (caller owns cleanup).
+fn build_test_index(
+    root: &Path,
+    files: &[(&str, &[u8])],
+) -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let index_dir = tmp.path();
+
+    let mut paths: Vec<String> = Vec::new();
+    let mut inverted: HashMap<u32, Vec<PostingEntry>> = HashMap::new();
+
+    for (i, (rel_path, content)) in files.iter().enumerate() {
+        paths.push(rel_path.to_string());
+
+        // Extract trigrams with masks
+        let tri_masks = trigram::extract_with_masks(content);
+        let mut per_tri: HashMap<u32, trigram::TrigramMasks> = HashMap::new();
+        for &(tri, m) in &tri_masks {
+            let entry = per_tri.entry(tri).or_default();
+            entry.loc_mask |= m.loc_mask;
+            entry.next_mask |= m.next_mask;
+        }
+
+        for (tri, m) in per_tri {
+            inverted.entry(tri).or_default().push(PostingEntry {
+                file_id: i as u32,
+                loc_mask: m.loc_mask,
+                next_mask: m.next_mask,
+            });
+        }
+    }
+
+    builder::write_index_from_snapshot(root, index_dir, &paths, &inverted, true).unwrap();
+    tmp
+}
+
+/// Every file ID returned by execute_query_with_masks must resolve via the
+/// returned reader snapshot — even without any concurrent swap.
+#[test]
+fn all_query_ids_resolve_via_snapshot() {
+    let root = tempfile::TempDir::new().unwrap();
+    let files: Vec<(&str, &[u8])> = vec![
+        ("src/main.rs", b"fn main() { println!(\"hello\"); }"),
+        ("src/lib.rs", b"pub fn hello() -> &'static str { \"hello\" }"),
+        ("src/util.rs", b"pub fn format_hello(name: &str) -> String { format!(\"hello {}\", name) }"),
+    ];
+
+    // Create the actual files on disk (for root)
+    for (path, content) in &files {
+        let full = root.path().join(path);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(&full, content).unwrap();
+    }
+
+    let index_dir = build_test_index(root.path(), &files);
+    let hybrid = HybridIndex::open(index_dir.path(), root.path()).unwrap();
+
+    // Query for "hello" which appears in all files
+    let plan = query::build_query_plan("hello", false).unwrap();
+    let (file_ids, reader_snapshot) = hybrid.execute_query_with_masks(&plan);
+
+    assert!(!file_ids.is_empty(), "expected candidates for 'hello'");
+
+    // Every returned ID must resolve to a valid path
+    for &fid in &file_ids {
+        let path = hybrid.resolve_path(fid, &reader_snapshot);
+        assert!(
+            path.is_some(),
+            "file_id {fid} should resolve to a path via the reader snapshot"
+        );
+        let full = hybrid.resolve_full_path(fid, &reader_snapshot);
+        assert!(
+            full.is_some(),
+            "file_id {fid} should resolve to a full path via the reader snapshot"
+        );
+    }
+}
+
+/// After swapping the reader to a completely different index, the OLD file IDs
+/// should fail to resolve via the NEW reader — but should still resolve via
+/// the snapshot returned from execute_query_with_masks.
+#[test]
+fn snapshot_survives_reader_swap() {
+    let root = tempfile::TempDir::new().unwrap();
+    let files_v1: Vec<(&str, &[u8])> = vec![
+        ("alpha.rs", b"fn alpha() { println!(\"function_alpha\"); }"),
+        ("beta.rs", b"fn beta() { println!(\"function_beta\"); }"),
+        ("gamma.rs", b"fn gamma() { println!(\"function_gamma\"); }"),
+    ];
+
+    for (path, content) in &files_v1 {
+        let full = root.path().join(path);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(&full, content).unwrap();
+    }
+
+    let index_v1 = build_test_index(root.path(), &files_v1);
+    let hybrid = HybridIndex::open(index_v1.path(), root.path()).unwrap();
+
+    // Query to get file IDs from reader v1
+    let plan = query::build_query_plan("function", false).unwrap();
+    let (file_ids_v1, snapshot_v1) = hybrid.execute_query_with_masks(&plan);
+    assert!(
+        !file_ids_v1.is_empty(),
+        "expected candidates for 'function' in v1"
+    );
+
+    // Verify all IDs resolve with the v1 snapshot
+    for &fid in &file_ids_v1 {
+        assert!(
+            hybrid.resolve_path(fid, &snapshot_v1).is_some(),
+            "fid {fid} should resolve with v1 snapshot"
+        );
+    }
+
+    // Build a DIFFERENT index (v2) with completely different files
+    let files_v2: Vec<(&str, &[u8])> = vec![
+        ("one.py", b"def function_one(): pass"),
+        ("two.py", b"def function_two(): pass"),
+    ];
+    for (path, content) in &files_v2 {
+        let full = root.path().join(path);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(&full, content).unwrap();
+    }
+
+    let index_v2 = build_test_index(root.path(), &files_v2);
+    let reader_v2 = tgrep_core::reader::IndexReader::open(index_v2.path()).unwrap();
+
+    // Swap the reader to v2 — simulates a concurrent flush
+    hybrid.swap_reader(reader_v2);
+
+    // The v1 snapshot should STILL resolve the old file IDs
+    for &fid in &file_ids_v1 {
+        let path = hybrid.resolve_path(fid, &snapshot_v1);
+        assert!(
+            path.is_some(),
+            "fid {fid} should STILL resolve with v1 snapshot after swap"
+        );
+    }
+
+    // But the OLD file_path method (which gets a fresh reader) may fail
+    // because the v2 reader has fewer files (2 vs 3)
+    let mut failures = 0;
+    for &fid in &file_ids_v1 {
+        if hybrid.file_path(fid).is_none() {
+            failures += 1;
+        }
+    }
+    // At least some IDs should fail (v1 had 3 files, v2 has 2)
+    // fid=2 is out of range for v2's file_paths
+    assert!(
+        failures > 0 || file_ids_v1.iter().all(|&fid| fid < 2),
+        "expected some file_path failures after swap to smaller reader, \
+         unless all IDs happen to be < 2 (v2 file count)"
+    );
+}
+
+/// After swap, a new query against the new reader should produce IDs
+/// that resolve correctly — no stale state.
+#[test]
+fn new_query_after_swap_resolves_correctly() {
+    let root = tempfile::TempDir::new().unwrap();
+    let files_v1: Vec<(&str, &[u8])> = vec![
+        ("a.rs", b"fn search_target() {}"),
+    ];
+    for (path, content) in &files_v1 {
+        let full = root.path().join(path);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(&full, content).unwrap();
+    }
+
+    let index_v1 = build_test_index(root.path(), &files_v1);
+    let hybrid = HybridIndex::open(index_v1.path(), root.path()).unwrap();
+
+    // Build v2 with different content
+    let files_v2: Vec<(&str, &[u8])> = vec![
+        ("x.rs", b"fn search_target() { /* v2 */ }"),
+        ("y.rs", b"fn search_target() { /* also v2 */ }"),
+    ];
+    for (path, content) in &files_v2 {
+        let full = root.path().join(path);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(&full, content).unwrap();
+    }
+
+    let index_v2 = build_test_index(root.path(), &files_v2);
+    let reader_v2 = tgrep_core::reader::IndexReader::open(index_v2.path()).unwrap();
+    hybrid.swap_reader(reader_v2);
+
+    // Query after swap should use the new reader
+    let plan = query::build_query_plan("search_target", false).unwrap();
+    let (file_ids, snapshot) = hybrid.execute_query_with_masks(&plan);
+
+    assert_eq!(file_ids.len(), 2, "v2 has 2 files with search_target");
+    for &fid in &file_ids {
+        let path = hybrid.resolve_path(fid, &snapshot);
+        assert!(path.is_some(), "v2 IDs should resolve with v2 snapshot");
+    }
+}
+
+/// MatchAll plan should also return a consistent reader snapshot.
+#[test]
+fn match_all_uses_consistent_snapshot() {
+    let root = tempfile::TempDir::new().unwrap();
+    let files: Vec<(&str, &[u8])> = vec![
+        ("a.txt", b"hello world"),
+        ("b.txt", b"goodbye world"),
+    ];
+    for (path, content) in &files {
+        let full = root.path().join(path);
+        std::fs::write(&full, content).unwrap();
+    }
+
+    let index_dir = build_test_index(root.path(), &files);
+    let hybrid = HybridIndex::open(index_dir.path(), root.path()).unwrap();
+
+    // A very short pattern that produces MatchAll
+    let plan = query::build_query_plan(".", false).unwrap();
+    assert!(plan.is_match_all(), "single-char regex should be MatchAll");
+
+    let (file_ids, snapshot) = hybrid.execute_query_with_masks(&plan);
+    assert_eq!(file_ids.len(), 2);
+    for &fid in &file_ids {
+        assert!(
+            hybrid.resolve_path(fid, &snapshot).is_some(),
+            "MatchAll IDs should resolve with snapshot"
+        );
+    }
+}
+
+/// Concurrent reader swap during query execution: demonstrates that the
+/// snapshot-based API is safe while the old API would fail.
+#[test]
+fn concurrent_swap_during_query() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    let root = tempfile::TempDir::new().unwrap();
+
+    // v1: many files to slow down query
+    let mut files_v1: Vec<(String, Vec<u8>)> = Vec::new();
+    for i in 0..50 {
+        let path = format!("file_{i}.rs");
+        let content = format!("fn target_function_{i}() {{ /* content */ }}");
+        let full = root.path().join(&path);
+        std::fs::write(&full, content.as_bytes()).unwrap();
+        files_v1.push((path, content.into_bytes()));
+    }
+
+    let files_refs: Vec<(&str, &[u8])> = files_v1.iter().map(|(p, c)| (p.as_str(), c.as_slice())).collect();
+    let index_v1 = build_test_index(root.path(), &files_refs);
+    let hybrid = Arc::new(HybridIndex::open(index_v1.path(), root.path()).unwrap());
+
+    // v2: completely different files
+    let mut files_v2: Vec<(String, Vec<u8>)> = Vec::new();
+    for i in 0..10 {
+        let path = format!("other_{i}.py");
+        let content = format!("def other_function_{i}(): pass");
+        let full = root.path().join(&path);
+        std::fs::write(&full, content.as_bytes()).unwrap();
+        files_v2.push((path, content.into_bytes()));
+    }
+    let files_refs_v2: Vec<(&str, &[u8])> = files_v2.iter().map(|(p, c)| (p.as_str(), c.as_slice())).collect();
+    let index_v2 = build_test_index(root.path(), &files_refs_v2);
+
+    let barrier = Arc::new(Barrier::new(2));
+    let hybrid_clone = Arc::clone(&hybrid);
+    let barrier_clone = Arc::clone(&barrier);
+
+    // Thread 1: query and resolve paths using snapshot
+    let query_thread = thread::spawn(move || {
+        let plan = query::build_query_plan("target_function", false).unwrap();
+        let (file_ids, snapshot) = hybrid_clone.execute_query_with_masks(&plan);
+
+        // Signal the swap thread to proceed
+        barrier_clone.wait();
+        // Brief delay to increase chance of swap happening during resolution
+        thread::sleep(std::time::Duration::from_millis(10));
+
+        // Resolve using the snapshot — should always work
+        let mut resolved = 0;
+        for &fid in &file_ids {
+            if hybrid_clone.resolve_path(fid, &snapshot).is_some() {
+                resolved += 1;
+            }
+        }
+        (file_ids.len(), resolved)
+    });
+
+    // Thread 2: swap the reader after query completes
+    let swap_thread = thread::spawn(move || {
+        barrier.wait();
+        let reader_v2 = tgrep_core::reader::IndexReader::open(index_v2.path()).unwrap();
+        hybrid.swap_reader(reader_v2);
+    });
+
+    let (total, resolved) = query_thread.join().unwrap();
+    swap_thread.join().unwrap();
+
+    // With the snapshot-based API, ALL IDs should resolve
+    assert_eq!(
+        resolved, total,
+        "snapshot-based resolution should succeed for all {total} IDs, got {resolved}"
+    );
+}


### PR DESCRIPTION
# fix: Windows mmap correctness and search reliability (v0.1.17)

## Summary

Fixes a critical bug where **~98% of trigram searches returned 0 candidates** on Windows after an index flush cycle. Root cause: NTFS metadata caching causes `File::metadata().len()` to transiently return 0 after `std::fs::rename`, producing zero-length mmaps for `lookup.bin` and `index.bin`. Also fixes several correctness bugs in search query planning, glob filtering, and reader snapshot consistency discovered during investigation.

**Impact**: Confirmed fix against a 285K-file / 921K-trigram production index. Searches now return valid candidates after flush.

## Changes

### fix: three correctness bugs in trigram search (`aed3202`)

- **`expected_next` used raw regex pattern instead of parsed literal bytes** — `next_byte_after_trigram` was called with the user's regex string, not the extracted literal. Introduced `TrigramQuery` struct with `expected_next` computed at plan-build time from actual literal bytes.
- **Reader snapshot race during concurrent flush** — searches could see a partially-swapped reader mid-flush. Now snapshots the `Arc` at search start.
- **Mask data lost through snapshot/flush cycles** — `write_index_from_snapshot` discarded `loc_mask`/`next_mask`, writing `0xFF` for all entries. Now preserves `PostingEntry` masks end-to-end.
- **O(N²) regression in `full_snapshot()`** — added `get_masks()` O(1) accessor to `LiveIndex` to avoid scanning the overlay per posting.

### fix: prevent degenerate reader swap after flush on Windows (`9cc2360`)

- Use `fstat` (open file handle) instead of `stat` (path-based) for file size checks — avoids stale NTFS metadata.
- Add `is_degenerate()` validation to detect structurally inconsistent readers (mmap sections present but counters say zero entries).
- Retry with backoff in flush path when a newly-opened reader is degenerate.

### fix: bypass stale metadata in IndexReader::open and warm lookup mmap (`df2d6f5`)

This is the **primary fix** for the zero-candidate bug.

- **Root cause**: `File::metadata().len()` returns 0 after `rename()` on Windows NTFS due to stale metadata cache. `memmap2::Mmap::map()` also calls `metadata()` internally, so even mapping first doesn't help.
- **Fix**: Use `file.seek(SeekFrom::End(0))` to read the true file size from the kernel file object (calls `SetFilePointerEx` on Windows), then `MmapOptions::new().len(size)` to create the mmap with an explicit size, bypassing memmap2's internal metadata path.
- Add `validate_lookup()` method that validates sort order + posting-list bounds and warms all `lookup.bin` pages into the working set.
- Call validation at all reader-open paths: startup, flush, auto-save.
- Use `usize::try_from()` instead of `as usize` for file sizes to prevent silent truncation on 32-bit targets.

### fix: consistent reader snapshot for query + path resolution (`d8f817a`)

- `execute_query_with_masks` now returns the `Arc<IndexReader>` snapshot alongside file IDs.
- Search handler uses that snapshot for path resolution instead of acquiring a fresh one, eliminating a race where a concurrent `swap_reader` between query and path resolution would silently drop all candidates.

### fix: glob filter correctness (`f851c0c`, `9f48a25`, `72bf727`)

- **Negation pattern handling**: The runtime sends glob patterns like `!.git` meaning "exclude .git paths". The old `simple_glob_match` treated `!.git` as a literal pattern, rejecting ALL candidates. New `glob_filter_matches()` splits patterns into include/exclude lists.
- **Windows backslash normalization**: Normalize `\` to `/` in glob patterns before regex matching so Windows-style globs work with forward-slash index paths.
- **Aligned local and server glob semantics**: Updated `passes_glob_filters` in `search.rs` to support `!` prefix negation and backslash normalization, matching the server-side `glob_filter_matches` implementation.

### fix: safe UTF-8 truncation for pattern preview (`439fdad`)

- `&pattern[..N]` byte-index slice panics on multi-byte UTF-8. Use `chars().take(40)` instead.

### fix: remove unnecessary OVERLAY_BIT masking from trigram keys (`806566c`)

- `OVERLAY_BIT` is only meaningful for file IDs; trigram hashes use only the low 24 bits. The masking was a no-op that created a hidden coupling.

### chore: reduce diagnostic log volume (`bccc7fe`, `72bf727`)

- Remove per-search filter diagnostics that fired on ~98% of normal searches.
- Remove unconditional `eprintln!` trace in `execute_plan_with_masks` that spammed stderr on normal no-match queries.
- Retain narrow-condition logging for actual corruption/degenerate indicators.

### chore: improve test coverage and reliability

- Use `assert_cmd::cargo_bin()` instead of manual binary path derivation in integration tests.
- Redirect server stderr to null to prevent pipe buffer deadlock under concurrent load.
- `is_degenerate` test now fabricates inconsistent `IndexReader` state to exercise the positive path (not just non-degenerate cases).
- Add `validate_lookup` bounds-checking in u64 to prevent truncation on 32-bit targets.

### chore: bump version to 0.1.17 (`517dc2d`)

## Testing

- All **108 tests** pass (46 core unit + 1 case-insensitive roundtrip + 5 snapshot consistency + 6 concurrent search integration + 17 CLI ripgrep-compat + 33 CLI unit).
- Verified against large index: searches return 1K–99K candidates after flush where they previously returned 0.

## Files changed

| File | Summary |
|------|---------|
| `tgrep-core/src/reader.rs` | `seek`-based file size, `MmapOptions::len()`, `validate_lookup()` (u64 math), `is_degenerate()`, `usize::try_from()` for sizes, 7 new tests |
| `tgrep-core/src/query.rs` | `TrigramQuery` struct, `literals_to_query_plan()`, mask filtering, removed unconditional trace log |
| `tgrep-core/src/hybrid.rs` | Reader snapshot helpers, `validate_lookup()` + degenerate check at open, `full_snapshot` with masks, removed OVERLAY_BIT masking |
| `tgrep-core/src/live.rs` | `get_masks()` O(1) accessor |
| `tgrep-core/src/builder.rs` | `write_index_from_snapshot` preserves `PostingEntry` masks |
| `tgrep-core/src/ondisk.rs` | `PostingEntry` encode/decode helpers |
| `tgrep-core/src/gitignore.rs` | New: gitignore matcher for watcher filtering |
| `tgrep-core/src/filetypes.rs` | Added `csproj` to builtin file types |
| `tgrep-cli/src/serve.rs` | Flush retry + validation, auto-save validation, glob negation + backslash normalization, reduced log noise, filter stage breakdown diagnostics, safe UTF-8 truncation |
| `tgrep-cli/src/search.rs` | Aligned glob filter semantics (negation + backslash normalization) |
| `tgrep-cli/tests/concurrent_search.rs` | New: 6 concurrent search integration tests |
| `tgrep-core/tests/snapshot_consistency.rs` | New: 5 snapshot consistency tests |
| `tgrep-core/tests/case_insensitive_roundtrip.rs` | Updated for `PostingEntry` API |
| `Cargo.toml` / `Cargo.lock` | Version bump 0.1.16 → 0.1.17 |