### PR TITLE
perf: replace 16MB bitmap with HashSet in trigram::extract()

### DIFF
--- a/tgrep-core/src/trigram.rs
+++ b/tgrep-core/src/trigram.rs
@@ -3,7 +3,7 @@
 /// A trigram is every overlapping 3-byte window in a byte sequence.
 /// We pack 3 bytes into a `u32`: `(a << 16) | (b << 8) | c`.
 /// This gives us up to ~16.7M unique trigrams with zero collisions.
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub type TrigramHash = u32;
 
@@ -48,12 +48,11 @@ pub fn extract(data: &[u8]) -> Vec<TrigramHash> {
     if data.len() < 3 {
         return Vec::new();
     }
-    let mut seen = vec![false; 1 << 24]; // 16MB bitmap — faster than HashSet
+    let mut seen = HashSet::new();
     let mut result = Vec::new();
     for window in data.windows(3) {
         let h = hash(window[0], window[1], window[2]);
-        if !seen[h as usize] {
-            seen[h as usize] = true;
+        if seen.insert(h) {
             result.push(h);
         }
     }


### PR DESCRIPTION
## Summary

Replaces the 16MB bitmap allocation (`vec![false; 1 << 24]`) in `trigram::extract()` with a `HashSet`, dramatically reducing memory usage.

## Problem

Every call to `extract()` allocated a 16MB boolean array for deduplication, causing significant allocation pressure and page faults. Typical files produce far fewer than 16M unique trigrams.

The sister function `extract_with_masks()` already uses a `HashMap` for the same reason (added in the masks PR).

## Fix

Use `HashSet::insert()` for O(1) dedup with proportional memory usage.

## Testing

All 108 existing tests pass.

Fixes #66