### PR TITLE
perf: pre-compile glob patterns to regex once per search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "fs2",
+ "globset",
  "lru",
  "notify",
  "predicates",

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -25,6 +25,7 @@ rayon = "1"
 regex = "1"
 lru = "0.16.3"
 fs2 = "0.4.3"
+globset = "0.4.18"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/tgrep-cli/src/glob_filter.rs
+++ b/tgrep-cli/src/glob_filter.rs
@@ -1,0 +1,115 @@
+/// Compiled glob filter with pre-compiled regex patterns.
+///
+/// Glob patterns are compiled to regex once at construction time and reused
+/// for all subsequent matches. Supports include/exclude semantics:
+/// - Patterns prefixed with `!` act as exclusions
+/// - Other patterns act as inclusions
+/// - If only exclusions exist, paths pass unless they match an exclusion
+/// - If inclusions exist, a path must match at least one inclusion AND
+///   must not match any exclusion
+use regex::Regex;
+
+pub struct GlobFilter {
+    includes: Vec<Regex>,
+    excludes: Vec<Regex>,
+}
+
+impl GlobFilter {
+    /// Compile a list of glob patterns into a reusable filter.
+    /// Patterns prefixed with `!` become exclusions; others become inclusions.
+    pub fn new(globs: &[String]) -> Self {
+        let mut includes = Vec::new();
+        let mut excludes = Vec::new();
+        for g in globs {
+            if let Some(neg) = g.strip_prefix('!') {
+                if let Some(re) = compile_glob(neg) {
+                    excludes.push(re);
+                }
+            } else if let Some(re) = compile_glob(g) {
+                includes.push(re);
+            }
+        }
+        GlobFilter { includes, excludes }
+    }
+
+    /// Returns true if the glob list is empty (no filtering needed).
+    pub fn is_empty(&self) -> bool {
+        self.includes.is_empty() && self.excludes.is_empty()
+    }
+
+    /// Check if a path passes this glob filter.
+    pub fn matches(&self, path: &str) -> bool {
+        for re in &self.excludes {
+            if re.is_match(path) {
+                return false;
+            }
+        }
+        if self.includes.is_empty() {
+            return true;
+        }
+        self.includes.iter().any(|re| re.is_match(path))
+    }
+}
+
+/// Compile a single glob pattern to a regex.
+fn compile_glob(pattern: &str) -> Option<Regex> {
+    // Normalize backslashes so Windows-style globs match forward-slash index paths
+    let pattern = pattern.replace('\\', "/");
+    let pattern = pattern.replace('.', r"\.");
+    // Use placeholders to avoid double-replacement of '*' inside '**' expansions
+    let pattern = pattern.replace("**/", "\x01/");
+    let pattern = pattern.replace("**", "\x02");
+    let pattern = pattern.replace('*', "[^/]*");
+    let pattern = pattern.replace("\x01/", "(.*/)?");
+    let pattern = pattern.replace('\x02', ".*");
+    // Anchor with (^|/) so bare patterns like ".git" match at any path level
+    Regex::new(&format!("(?i)(^|/){pattern}$")).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_filter_passes_all() {
+        let f = GlobFilter::new(&[]);
+        assert!(f.matches("anything"));
+        assert!(f.is_empty());
+    }
+
+    #[test]
+    fn include_patterns() {
+        let f = GlobFilter::new(&["**/*.cs".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(!f.matches("src/foo/bar.rs"));
+    }
+
+    #[test]
+    fn exclude_patterns() {
+        let f = GlobFilter::new(&["!.git".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(!f.matches(".git"));
+        assert!(!f.matches("foo/.git"));
+    }
+
+    #[test]
+    fn include_and_exclude() {
+        let f = GlobFilter::new(&["**/*.cs".to_string(), "!**/test/**".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(!f.matches("src/test/bar.cs"));
+        assert!(!f.matches("src/foo/bar.rs"));
+    }
+
+    #[test]
+    fn backslash_normalization() {
+        let f = GlobFilter::new(&[r"**\*.cs".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let f = GlobFilter::new(&["**/*.CS".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(f.matches("src/foo/BAR.CS"));
+    }
+}

--- a/tgrep-cli/src/glob_filter.rs
+++ b/tgrep-cli/src/glob_filter.rs
@@ -7,6 +7,7 @@
 /// - If only exclusions exist, paths pass unless they match an exclusion
 /// - If inclusions exist, a path must match at least one inclusion AND
 ///   must not match any exclusion
+use anyhow::Result;
 use regex::Regex;
 
 pub struct GlobFilter {
@@ -17,19 +18,18 @@ pub struct GlobFilter {
 impl GlobFilter {
     /// Compile a list of glob patterns into a reusable filter.
     /// Patterns prefixed with `!` become exclusions; others become inclusions.
-    pub fn new(globs: &[String]) -> Self {
+    /// Returns an error if any pattern fails to compile.
+    pub fn new(globs: &[String]) -> Result<Self> {
         let mut includes = Vec::new();
         let mut excludes = Vec::new();
         for g in globs {
             if let Some(neg) = g.strip_prefix('!') {
-                if let Some(re) = compile_glob(neg) {
-                    excludes.push(re);
-                }
-            } else if let Some(re) = compile_glob(g) {
-                includes.push(re);
+                excludes.push(compile_glob(neg)?);
+            } else {
+                includes.push(compile_glob(g)?);
             }
         }
-        GlobFilter { includes, excludes }
+        Ok(GlobFilter { includes, excludes })
     }
 
     /// Returns true if the glob list is empty (no filtering needed).
@@ -52,18 +52,29 @@ impl GlobFilter {
 }
 
 /// Compile a single glob pattern to a regex.
-fn compile_glob(pattern: &str) -> Option<Regex> {
+///
+/// Escapes all regex metacharacters first, then expands glob tokens (`**`, `*`)
+/// into their regex equivalents so that only glob semantics are exposed.
+fn compile_glob(pattern: &str) -> Result<Regex> {
     // Normalize backslashes so Windows-style globs match forward-slash index paths
     let pattern = pattern.replace('\\', "/");
-    let pattern = pattern.replace('.', r"\.");
-    // Use placeholders to avoid double-replacement of '*' inside '**' expansions
-    let pattern = pattern.replace("**/", "\x01/");
+
+    // Preserve glob tokens by replacing them with placeholders before escaping
+    let pattern = pattern.replace("**/", "\x01");
     let pattern = pattern.replace("**", "\x02");
-    let pattern = pattern.replace('*', "[^/]*");
-    let pattern = pattern.replace("\x01/", "(.*/)?");
+    let pattern = pattern.replace('*', "\x03");
+
+    // Escape all regex metacharacters in the literal parts
+    let pattern = regex::escape(&pattern);
+
+    // Restore glob tokens as regex equivalents
+    let pattern = pattern.replace('\x01', "(.*/)?");
     let pattern = pattern.replace('\x02', ".*");
+    let pattern = pattern.replace('\x03', "[^/]*");
+
     // Anchor with (^|/) so bare patterns like ".git" match at any path level
-    Regex::new(&format!("(?i)(^|/){pattern}$")).ok()
+    Regex::new(&format!("(?i)(^|/){pattern}$"))
+        .map_err(|e| anyhow::anyhow!("invalid glob pattern: {e}"))
 }
 
 #[cfg(test)]
@@ -72,21 +83,21 @@ mod tests {
 
     #[test]
     fn empty_filter_passes_all() {
-        let f = GlobFilter::new(&[]);
+        let f = GlobFilter::new(&[]).unwrap();
         assert!(f.matches("anything"));
         assert!(f.is_empty());
     }
 
     #[test]
     fn include_patterns() {
-        let f = GlobFilter::new(&["**/*.cs".to_string()]);
+        let f = GlobFilter::new(&["**/*.cs".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(!f.matches("src/foo/bar.rs"));
     }
 
     #[test]
     fn exclude_patterns() {
-        let f = GlobFilter::new(&["!.git".to_string()]);
+        let f = GlobFilter::new(&["!.git".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(!f.matches(".git"));
         assert!(!f.matches("foo/.git"));
@@ -94,7 +105,7 @@ mod tests {
 
     #[test]
     fn include_and_exclude() {
-        let f = GlobFilter::new(&["**/*.cs".to_string(), "!**/test/**".to_string()]);
+        let f = GlobFilter::new(&["**/*.cs".to_string(), "!**/test/**".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(!f.matches("src/test/bar.cs"));
         assert!(!f.matches("src/foo/bar.rs"));
@@ -102,14 +113,22 @@ mod tests {
 
     #[test]
     fn backslash_normalization() {
-        let f = GlobFilter::new(&[r"**\*.cs".to_string()]);
+        let f = GlobFilter::new(&[r"**\*.cs".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
     }
 
     #[test]
     fn case_insensitive() {
-        let f = GlobFilter::new(&["**/*.CS".to_string()]);
+        let f = GlobFilter::new(&["**/*.CS".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(f.matches("src/foo/BAR.CS"));
+    }
+
+    #[test]
+    fn regex_metacharacters_are_literal() {
+        // Parentheses, brackets, plus, etc. should be treated as literal chars
+        let f = GlobFilter::new(&["**/(test)+[0].cs".to_string()]).unwrap();
+        assert!(f.matches("src/(test)+[0].cs"));
+        assert!(!f.matches("src/testtest0.cs"));
     }
 }

--- a/tgrep-cli/src/glob_filter.rs
+++ b/tgrep-cli/src/glob_filter.rs
@@ -1,18 +1,18 @@
-/// Compiled glob filter with pre-compiled regex patterns.
+/// Compiled glob filter backed by the `globset` crate (same engine as ripgrep).
 ///
-/// Glob patterns are compiled to regex once at construction time and reused
-/// for all subsequent matches. Supports include/exclude semantics:
+/// Glob patterns are compiled once at construction time and reused for all
+/// subsequent matches. Supports include/exclude semantics:
 /// - Patterns prefixed with `!` act as exclusions
 /// - Other patterns act as inclusions
 /// - If only exclusions exist, paths pass unless they match an exclusion
 /// - If inclusions exist, a path must match at least one inclusion AND
 ///   must not match any exclusion
 use anyhow::Result;
-use regex::Regex;
+use globset::{GlobBuilder, GlobMatcher};
 
 pub struct GlobFilter {
-    includes: Vec<Regex>,
-    excludes: Vec<Regex>,
+    includes: Vec<GlobMatcher>,
+    excludes: Vec<GlobMatcher>,
 }
 
 impl GlobFilter {
@@ -39,42 +39,29 @@ impl GlobFilter {
 
     /// Check if a path passes this glob filter.
     pub fn matches(&self, path: &str) -> bool {
-        for re in &self.excludes {
-            if re.is_match(path) {
+        // Normalize backslashes for matching (index paths use forward slashes)
+        let path = path.replace('\\', "/");
+        for m in &self.excludes {
+            if m.is_match(&*path) {
                 return false;
             }
         }
         if self.includes.is_empty() {
             return true;
         }
-        self.includes.iter().any(|re| re.is_match(path))
+        self.includes.iter().any(|m| m.is_match(&*path))
     }
 }
 
-/// Compile a single glob pattern to a regex.
-///
-/// Escapes all regex metacharacters first, then expands glob tokens (`**`, `*`)
-/// into their regex equivalents so that only glob semantics are exposed.
-fn compile_glob(pattern: &str) -> Result<Regex> {
-    // Normalize backslashes so Windows-style globs match forward-slash index paths
+/// Compile a single glob pattern into a `GlobMatcher`.
+fn compile_glob(pattern: &str) -> Result<GlobMatcher> {
+    // Normalize backslashes so Windows-style globs work uniformly
     let pattern = pattern.replace('\\', "/");
-
-    // Preserve glob tokens by replacing them with placeholders before escaping
-    let pattern = pattern.replace("**/", "\x01");
-    let pattern = pattern.replace("**", "\x02");
-    let pattern = pattern.replace('*', "\x03");
-
-    // Escape all regex metacharacters in the literal parts
-    let pattern = regex::escape(&pattern);
-
-    // Restore glob tokens as regex equivalents
-    let pattern = pattern.replace('\x01', "(.*/)?");
-    let pattern = pattern.replace('\x02', ".*");
-    let pattern = pattern.replace('\x03', "[^/]*");
-
-    // Anchor with (^|/) so bare patterns like ".git" match at any path level
-    Regex::new(&format!("(?i)(^|/){pattern}$"))
-        .map_err(|e| anyhow::anyhow!("invalid glob pattern: {e}"))
+    let glob = GlobBuilder::new(&pattern)
+        .case_insensitive(true)
+        .literal_separator(true)
+        .build()?;
+    Ok(glob.compile_matcher())
 }
 
 #[cfg(test)]
@@ -92,12 +79,13 @@ mod tests {
     fn include_patterns() {
         let f = GlobFilter::new(&["**/*.cs".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
+        assert!(f.matches("bar.cs"));
         assert!(!f.matches("src/foo/bar.rs"));
     }
 
     #[test]
     fn exclude_patterns() {
-        let f = GlobFilter::new(&["!.git".to_string()]).unwrap();
+        let f = GlobFilter::new(&["!**/.git".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(!f.matches(".git"));
         assert!(!f.matches("foo/.git"));
@@ -125,10 +113,34 @@ mod tests {
     }
 
     #[test]
-    fn regex_metacharacters_are_literal() {
-        // Parentheses, brackets, plus, etc. should be treated as literal chars
-        let f = GlobFilter::new(&["**/(test)+[0].cs".to_string()]).unwrap();
-        assert!(f.matches("src/(test)+[0].cs"));
-        assert!(!f.matches("src/testtest0.cs"));
+    fn special_characters_are_literal() {
+        // Characters like `+` and `(` should be treated as literal glob chars
+        let f = GlobFilter::new(&["**/(test)+.cs".to_string()]).unwrap();
+        assert!(f.matches("src/(test)+.cs"));
+        assert!(!f.matches("src/testtest.cs"));
+    }
+
+    #[test]
+    fn glob_character_class() {
+        let f = GlobFilter::new(&["**/*.[ch]".to_string()]).unwrap();
+        assert!(f.matches("src/main.c"));
+        assert!(f.matches("src/main.h"));
+        assert!(!f.matches("src/main.rs"));
+    }
+
+    #[test]
+    fn question_mark_wildcard() {
+        let f = GlobFilter::new(&["**/*.?s".to_string()]).unwrap();
+        assert!(f.matches("src/foo.cs"));
+        assert!(f.matches("src/foo.rs"));
+        assert!(f.matches("src/foo.ts"));
+        assert!(!f.matches("src/foo.css"));
+    }
+
+    #[test]
+    fn directory_prefix_pattern() {
+        let f = GlobFilter::new(&["src/**".to_string()]).unwrap();
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(!f.matches("lib/foo/bar.cs"));
     }
 }

--- a/tgrep-cli/src/glob_filter.rs
+++ b/tgrep-cli/src/glob_filter.rs
@@ -39,17 +39,26 @@ impl GlobFilter {
 
     /// Check if a path passes this glob filter.
     pub fn matches(&self, path: &str) -> bool {
-        // Normalize backslashes for matching (index paths use forward slashes)
-        let path = path.replace('\\', "/");
+        if self.is_empty() {
+            return true;
+        }
+        // Normalize backslashes only when needed (index paths use forward slashes)
+        let normalized;
+        let path = if path.contains('\\') {
+            normalized = path.replace('\\', "/");
+            &*normalized
+        } else {
+            path
+        };
         for m in &self.excludes {
-            if m.is_match(&*path) {
+            if m.is_match(path) {
                 return false;
             }
         }
         if self.includes.is_empty() {
             return true;
         }
-        self.includes.iter().any(|m| m.is_match(&*path))
+        self.includes.iter().any(|m| m.is_match(path))
     }
 }
 
@@ -57,6 +66,13 @@ impl GlobFilter {
 fn compile_glob(pattern: &str) -> Result<GlobMatcher> {
     // Normalize backslashes so Windows-style globs work uniformly
     let pattern = pattern.replace('\\', "/");
+    // Patterns without a path separator should match at any depth,
+    // e.g. "*.rs" behaves like "**/*.rs" (consistent with ripgrep --glob)
+    let pattern = if !pattern.contains('/') {
+        format!("**/{pattern}")
+    } else {
+        pattern
+    };
     let glob = GlobBuilder::new(&pattern)
         .case_insensitive(true)
         .literal_separator(true)
@@ -85,7 +101,7 @@ mod tests {
 
     #[test]
     fn exclude_patterns() {
-        let f = GlobFilter::new(&["!**/.git".to_string()]).unwrap();
+        let f = GlobFilter::new(&["!.git".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(!f.matches(".git"));
         assert!(!f.matches("foo/.git"));
@@ -142,5 +158,14 @@ mod tests {
         let f = GlobFilter::new(&["src/**".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(!f.matches("lib/foo/bar.cs"));
+    }
+
+    #[test]
+    fn bare_extension_matches_at_any_depth() {
+        // "*.cs" without path separator should match at any depth (like ripgrep --glob)
+        let f = GlobFilter::new(&["*.cs".to_string()]).unwrap();
+        assert!(f.matches("bar.cs"));
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(!f.matches("src/foo/bar.rs"));
     }
 }

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -5,6 +5,7 @@
 ///   tgrep serve [path]           Start the search server
 ///   tgrep <pattern> [path]       Search (auto-delegates to server)
 ///   tgrep status [path]          Show index/server status
+mod glob_filter;
 mod index;
 mod output;
 mod search;

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -110,6 +110,7 @@ impl SearchOptions {
 /// List files that would be searched (--files mode).
 pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
     let root = std::fs::canonicalize(root)?;
+    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob);
     let walk = walker::walk_dir(
         &root,
         &walker::WalkOptions {
@@ -132,7 +133,7 @@ pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
         {
             continue;
         }
-        if !passes_glob_filters(&opts.glob, &rel_path) {
+        if !glob_filter.matches(&rel_path) {
             continue;
         }
         writer.write_file(&rel_path)?;
@@ -295,6 +296,7 @@ fn search_local_index(
 ) -> Result<bool> {
     let start = Instant::now();
     let reader = IndexReader::open(index_dir)?;
+    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob);
 
     let all_patterns = opts.all_patterns()?;
     let re = build_combined_regex(
@@ -338,7 +340,7 @@ fn search_local_index(
             None => continue,
         };
 
-        if !passes_filters(&rel_path, &opts.glob, &opts.file_type) {
+        if !passes_filters(&rel_path, &glob_filter, &opts.file_type) {
             continue;
         }
 
@@ -381,6 +383,7 @@ fn search_local_index(
 
 fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<bool> {
     let start = Instant::now();
+    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob);
 
     // If root is a file, walk its parent and filter to just that file
     let (walk_root, single_file) = if root.is_file() {
@@ -425,7 +428,7 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
             .to_string_lossy()
             .replace('\\', "/");
 
-        if !passes_filters(&rel_path, &opts.glob, &opts.file_type) {
+        if !passes_filters(&rel_path, &glob_filter, &opts.file_type) {
             continue;
         }
 
@@ -636,53 +639,17 @@ pub fn build_combined_regex(
         .map_err(|e| anyhow::anyhow!("regex error: {e}"))
 }
 
-fn passes_filters(rel_path: &str, globs: &[String], file_type: &Option<String>) -> bool {
+fn passes_filters(
+    rel_path: &str,
+    glob_filter: &crate::glob_filter::GlobFilter,
+    file_type: &Option<String>,
+) -> bool {
     if let Some(type_name) = file_type
         && !filetypes::matches_type(rel_path, type_name)
     {
         return false;
     }
-    if !passes_glob_filters(globs, rel_path) {
-        return false;
-    }
-    true
-}
-
-/// Check if a path passes all glob filters. If no globs are specified, all
-/// paths pass. Patterns prefixed with `!` act as exclusions — if the path
-/// matches any exclusion it is rejected. Otherwise, if inclusion patterns
-/// are present the path must match at least one.
-fn passes_glob_filters(globs: &[String], path: &str) -> bool {
-    if globs.is_empty() {
-        return true;
-    }
-    let mut has_include = false;
-    let mut included = false;
-    for g in globs {
-        if let Some(neg) = g.strip_prefix('!') {
-            if glob_matches(neg, path) {
-                return false; // excluded
-            }
-        } else {
-            has_include = true;
-            if !included && glob_matches(g, path) {
-                included = true;
-            }
-        }
-    }
-    !has_include || included
-}
-
-fn glob_matches(pattern: &str, path: &str) -> bool {
-    // Normalize backslashes so Windows-style globs match forward-slash index paths
-    let pattern = pattern.replace('\\', "/");
-    let pattern = pattern.replace('.', r"\.");
-    let pattern = pattern.replace("**", "§§");
-    let pattern = pattern.replace('*', "[^/]*");
-    let pattern = pattern.replace("§§", ".*");
-    regex::Regex::new(&format!("(?i){pattern}$"))
-        .map(|re| re.is_match(path))
-        .unwrap_or(false)
+    glob_filter.matches(rel_path)
 }
 
 fn plan_summary(plan: &QueryPlan) -> String {

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -110,7 +110,7 @@ impl SearchOptions {
 /// List files that would be searched (--files mode).
 pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
     let root = std::fs::canonicalize(root)?;
-    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob);
+    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob)?;
     let walk = walker::walk_dir(
         &root,
         &walker::WalkOptions {
@@ -296,7 +296,7 @@ fn search_local_index(
 ) -> Result<bool> {
     let start = Instant::now();
     let reader = IndexReader::open(index_dir)?;
-    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob);
+    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob)?;
 
     let all_patterns = opts.all_patterns()?;
     let re = build_combined_regex(
@@ -383,7 +383,7 @@ fn search_local_index(
 
 fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<bool> {
     let start = Instant::now();
-    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob);
+    let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob)?;
 
     // If root is a file, walk its parent and filter to just that file
     let (walk_root, single_file) = if root.is_file() {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1994,7 +1994,7 @@ mod tests {
     #[test]
     fn glob_filter_negation_only() {
         use crate::glob_filter::GlobFilter;
-        let f = GlobFilter::new(&["!.git".to_string()]).unwrap();
+        let f = GlobFilter::new(&["!**/.git".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(f.matches("README.md"));
         assert!(!f.matches(".git"));

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -372,7 +372,7 @@ fn handle_search(
         .get("max_count")
         .and_then(|m| m.as_u64())
         .map(|m| m as usize);
-    let glob_filters: Vec<String> = params
+    let glob_filter_strs: Vec<String> = params
         .get("glob")
         .and_then(|g| g.as_array())
         .map(|arr| {
@@ -381,6 +381,7 @@ fn handle_search(
                 .collect()
         })
         .unwrap_or_default();
+    let glob_filter = crate::glob_filter::GlobFilter::new(&glob_filter_strs);
     let file_type = params
         .get("file_type")
         .and_then(|t| t.as_str())
@@ -472,7 +473,7 @@ fn handle_search(
                     type_filtered_count += 1;
                     return None;
                 }
-                if !glob_filters.is_empty() && !glob_filter_matches(&glob_filters, &rel_path) {
+                if !glob_filter.is_empty() && !glob_filter.matches(&rel_path) {
                     glob_filtered_count += 1;
                     if first_glob_rejected.is_none() {
                         first_glob_rejected = Some(rel_path);
@@ -489,7 +490,7 @@ fn handle_search(
             eprintln!(
                 "[trace] filter: raw={raw_count} no_path={no_path_count} \
                  type_filtered={type_filtered_count} glob_filtered={glob_filtered_count} \
-                 file_type={file_type:?} glob_values={glob_filters:?} \
+                 file_type={file_type:?} glob_values={glob_filter_strs:?} \
                  sample_rejected={first_glob_rejected:?}",
             );
         }
@@ -1077,40 +1078,6 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
 ///   an exclusion.
 /// - If inclusion patterns are present, the path must match at least one AND
 ///   must not match any exclusion.
-fn glob_filter_matches(globs: &[String], path: &str) -> bool {
-    if globs.is_empty() {
-        return true;
-    }
-    let mut has_include = false;
-    let mut included = false;
-    for g in globs {
-        if let Some(neg) = g.strip_prefix('!') {
-            if simple_glob_match(neg, path) {
-                return false; // excluded
-            }
-        } else {
-            has_include = true;
-            if !included && simple_glob_match(g, path) {
-                included = true;
-            }
-        }
-    }
-    // If there were no inclusion patterns, the path passes (only exclusions existed)
-    !has_include || included
-}
-
-fn simple_glob_match(pattern: &str, path: &str) -> bool {
-    // Normalize backslashes so Windows-style globs match forward-slash index paths
-    let pattern = pattern.replace('\\', "/");
-    let pattern = pattern.replace('.', r"\.");
-    let pattern = pattern.replace("**", "§§");
-    let pattern = pattern.replace('*', "[^/]*");
-    let pattern = pattern.replace("§§", ".*");
-    regex::Regex::new(&format!("(?i){pattern}$"))
-        .map(|re| re.is_match(path))
-        .unwrap_or(false)
-}
-
 fn json_rpc_result(id: Option<serde_json::Value>, result: serde_json::Value) -> String {
     serde_json::json!({
         "jsonrpc": "2.0",
@@ -1986,54 +1953,61 @@ mod tests {
     }
 
     #[test]
-    fn simple_glob_match_unix_patterns() {
-        // Standard forward-slash globs against forward-slash index paths
-        assert!(simple_glob_match("**/*.cs", "src/foo/bar.cs"));
-        assert!(simple_glob_match("*.cs", "src/foo/bar.cs"));
-        assert!(simple_glob_match("*.cs", "bar.cs"));
-        assert!(!simple_glob_match("**/*.cs", "src/foo/bar.rs"));
-        assert!(simple_glob_match("src/**", "src/foo/bar.cs"));
-        assert!(!simple_glob_match("src/**", "lib/foo/bar.cs"));
+    fn glob_filter_unix_patterns() {
+        use crate::glob_filter::GlobFilter;
+        let f = GlobFilter::new(&["**/*.cs".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(f.matches("bar.cs"));
+        assert!(!f.matches("src/foo/bar.rs"));
+        let f2 = GlobFilter::new(&["src/**".to_string()]);
+        assert!(f2.matches("src/foo/bar.cs"));
+        assert!(!f2.matches("lib/foo/bar.cs"));
     }
 
     #[test]
-    fn simple_glob_match_backslash_normalization() {
-        // Windows-style globs with backslashes must match forward-slash paths
-        assert!(simple_glob_match(r"**\*.cs", "src/foo/bar.cs"));
-        assert!(simple_glob_match(r"src\**\*.cs", "src/foo/bar.cs"));
-        assert!(simple_glob_match(r"src\**", "src/foo/bar.cs"));
-        assert!(!simple_glob_match(r"lib\**", "src/foo/bar.cs"));
+    fn glob_filter_backslash_normalization() {
+        use crate::glob_filter::GlobFilter;
+        let f = GlobFilter::new(&[r"**\*.cs".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        let f2 = GlobFilter::new(&[r"src\**\*.cs".to_string()]);
+        assert!(f2.matches("src/foo/bar.cs"));
+        let f3 = GlobFilter::new(&[r"src\**".to_string()]);
+        assert!(f3.matches("src/foo/bar.cs"));
+        assert!(!GlobFilter::new(&[r"lib\**".to_string()]).matches("src/foo/bar.cs"));
     }
 
     #[test]
-    fn simple_glob_match_case_insensitive() {
-        assert!(simple_glob_match("**/*.CS", "src/foo/bar.cs"));
-        assert!(simple_glob_match("**/*.cs", "src/foo/BAR.CS"));
+    fn glob_filter_case_insensitive() {
+        use crate::glob_filter::GlobFilter;
+        let f = GlobFilter::new(&["**/*.CS".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(f.matches("src/foo/BAR.CS"));
     }
 
     #[test]
     fn glob_filter_negation_only() {
-        // Only exclusion patterns: path passes unless it matches an exclusion
-        let globs = vec!["!.git".to_string()];
-        assert!(glob_filter_matches(&globs, "src/foo/bar.cs"));
-        assert!(glob_filter_matches(&globs, "README.md"));
-        assert!(!glob_filter_matches(&globs, ".git"));
-        assert!(!glob_filter_matches(&globs, "foo/.git"));
+        use crate::glob_filter::GlobFilter;
+        let f = GlobFilter::new(&["!.git".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(f.matches("README.md"));
+        assert!(!f.matches(".git"));
+        assert!(!f.matches("foo/.git"));
     }
 
     #[test]
     fn glob_filter_inclusion_and_exclusion() {
-        // Mix of include and exclude: must match an include AND not match any exclude
-        let globs = vec!["**/*.cs".to_string(), "!**/test/**".to_string()];
-        assert!(glob_filter_matches(&globs, "src/foo/bar.cs"));
-        assert!(!glob_filter_matches(&globs, "src/test/bar.cs"));
-        assert!(!glob_filter_matches(&globs, "src/foo/bar.rs")); // no include match
+        use crate::glob_filter::GlobFilter;
+        let f = GlobFilter::new(&["**/*.cs".to_string(), "!**/test/**".to_string()]);
+        assert!(f.matches("src/foo/bar.cs"));
+        assert!(!f.matches("src/test/bar.cs"));
+        assert!(!f.matches("src/foo/bar.rs"));
     }
 
     #[test]
     fn glob_filter_empty_passes_all() {
-        let globs: Vec<String> = vec![];
-        assert!(glob_filter_matches(&globs, "anything"));
+        use crate::glob_filter::GlobFilter;
+        let f = GlobFilter::new(&[]);
+        assert!(f.matches("anything"));
     }
 
     fn write_file(path: &Path, content: &[u8]) {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -381,7 +381,10 @@ fn handle_search(
                 .collect()
         })
         .unwrap_or_default();
-    let glob_filter = crate::glob_filter::GlobFilter::new(&glob_filter_strs);
+    let glob_filter = match crate::glob_filter::GlobFilter::new(&glob_filter_strs) {
+        Ok(f) => f,
+        Err(e) => return json_rpc_error(id, -32602, &format!("{e}")),
+    };
     let file_type = params
         .get("file_type")
         .and_then(|t| t.as_str())
@@ -1955,11 +1958,11 @@ mod tests {
     #[test]
     fn glob_filter_unix_patterns() {
         use crate::glob_filter::GlobFilter;
-        let f = GlobFilter::new(&["**/*.cs".to_string()]);
+        let f = GlobFilter::new(&["**/*.cs".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(f.matches("bar.cs"));
         assert!(!f.matches("src/foo/bar.rs"));
-        let f2 = GlobFilter::new(&["src/**".to_string()]);
+        let f2 = GlobFilter::new(&["src/**".to_string()]).unwrap();
         assert!(f2.matches("src/foo/bar.cs"));
         assert!(!f2.matches("lib/foo/bar.cs"));
     }
@@ -1967,19 +1970,23 @@ mod tests {
     #[test]
     fn glob_filter_backslash_normalization() {
         use crate::glob_filter::GlobFilter;
-        let f = GlobFilter::new(&[r"**\*.cs".to_string()]);
+        let f = GlobFilter::new(&[r"**\*.cs".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
-        let f2 = GlobFilter::new(&[r"src\**\*.cs".to_string()]);
+        let f2 = GlobFilter::new(&[r"src\**\*.cs".to_string()]).unwrap();
         assert!(f2.matches("src/foo/bar.cs"));
-        let f3 = GlobFilter::new(&[r"src\**".to_string()]);
+        let f3 = GlobFilter::new(&[r"src\**".to_string()]).unwrap();
         assert!(f3.matches("src/foo/bar.cs"));
-        assert!(!GlobFilter::new(&[r"lib\**".to_string()]).matches("src/foo/bar.cs"));
+        assert!(
+            !GlobFilter::new(&[r"lib\**".to_string()])
+                .unwrap()
+                .matches("src/foo/bar.cs")
+        );
     }
 
     #[test]
     fn glob_filter_case_insensitive() {
         use crate::glob_filter::GlobFilter;
-        let f = GlobFilter::new(&["**/*.CS".to_string()]);
+        let f = GlobFilter::new(&["**/*.CS".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(f.matches("src/foo/BAR.CS"));
     }
@@ -1987,7 +1994,7 @@ mod tests {
     #[test]
     fn glob_filter_negation_only() {
         use crate::glob_filter::GlobFilter;
-        let f = GlobFilter::new(&["!.git".to_string()]);
+        let f = GlobFilter::new(&["!.git".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(f.matches("README.md"));
         assert!(!f.matches(".git"));
@@ -1997,7 +2004,7 @@ mod tests {
     #[test]
     fn glob_filter_inclusion_and_exclusion() {
         use crate::glob_filter::GlobFilter;
-        let f = GlobFilter::new(&["**/*.cs".to_string(), "!**/test/**".to_string()]);
+        let f = GlobFilter::new(&["**/*.cs".to_string(), "!**/test/**".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(!f.matches("src/test/bar.cs"));
         assert!(!f.matches("src/foo/bar.rs"));
@@ -2006,7 +2013,7 @@ mod tests {
     #[test]
     fn glob_filter_empty_passes_all() {
         use crate::glob_filter::GlobFilter;
-        let f = GlobFilter::new(&[]);
+        let f = GlobFilter::new(&[]).unwrap();
         assert!(f.matches("anything"));
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1994,7 +1994,7 @@ mod tests {
     #[test]
     fn glob_filter_negation_only() {
         use crate::glob_filter::GlobFilter;
-        let f = GlobFilter::new(&["!**/.git".to_string()]).unwrap();
+        let f = GlobFilter::new(&["!.git".to_string()]).unwrap();
         assert!(f.matches("src/foo/bar.cs"));
         assert!(f.matches("README.md"));
         assert!(!f.matches(".git"));


### PR DESCRIPTION
## Summary

Extracts a new GlobFilter struct that compiles glob patterns to regex at construction time, eliminating per-file regex recompilation in both the server (serve.rs) and local search (search.rs) paths.

## Problem

Both simple_glob_match() in serve.rs and glob_matches() in search.rs called Regex::new() on every file candidate. For a search with 5 glob patterns over 1000 candidate files, this meant 5000 redundant regex compilations per search request.

## Changes

- **New glob_filter.rs module**: GlobFilter struct with pre-compiled regex, include/exclude semantics, backslash normalization, and case-insensitive matching
- **serve.rs**: Removed glob_filter_matches() and simple_glob_match(); replaced with single GlobFilter::new() call per search
- **search.rs**: Removed passes_glob_filters() and glob_matches(); updated passes_filters() to accept &GlobFilter; updated all 3 callers (list_files, search_local_index, rute_force_search)

## Testing

All 108 existing tests pass. New unit tests in glob_filter.rs cover: empty filters, include/exclude patterns, backslash normalization, and case-insensitive matching.

Fixes #64