### PR TITLE
perf: parallelize filestamp collection and context-mode search

### DIFF
--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -534,10 +534,16 @@ fn handle_search(
     // Parallel regex matching across candidate files
     let t_search = Instant::now();
     let matches: Vec<serde_json::Value> = if has_context {
-        // Context mode: sequential (needs ordered output)
-        candidate_contents
-            .iter()
-            .flat_map(|(rel_path, content)| search_file_matches(rel_path, content, &re, &opts))
+        // Context mode: parallel search, then restore file order
+        let mut indexed: Vec<(usize, Vec<serde_json::Value>)> = candidate_contents
+            .par_iter()
+            .enumerate()
+            .map(|(i, (rel_path, content))| (i, search_file_matches(rel_path, content, &re, &opts)))
+            .collect();
+        indexed.sort_unstable_by_key(|(i, _)| *i);
+        indexed
+            .into_iter()
+            .flat_map(|(_, matches)| matches)
             .collect()
     } else {
         // No context: parallel search

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -534,17 +534,12 @@ fn handle_search(
     // Parallel regex matching across candidate files
     let t_search = Instant::now();
     let matches: Vec<serde_json::Value> = if has_context {
-        // Context mode: parallel search, then restore file order
-        let mut indexed: Vec<(usize, Vec<serde_json::Value>)> = candidate_contents
+        // Context mode: parallel search, order preserved by indexed par_iter
+        let per_file: Vec<Vec<serde_json::Value>> = candidate_contents
             .par_iter()
-            .enumerate()
-            .map(|(i, (rel_path, content))| (i, search_file_matches(rel_path, content, &re, &opts)))
+            .map(|(rel_path, content)| search_file_matches(rel_path, content, &re, &opts))
             .collect();
-        indexed.sort_unstable_by_key(|(i, _)| *i);
-        indexed
-            .into_iter()
-            .flat_map(|(_, matches)| matches)
-            .collect()
+        per_file.into_iter().flatten().collect()
     } else {
         // No context: parallel search
         candidate_contents

--- a/tgrep-core/src/meta.rs
+++ b/tgrep-core/src/meta.rs
@@ -89,24 +89,27 @@ pub fn read_filestamps(index_dir: &Path) -> Result<HashMap<String, FileStamp>> {
 
 /// Collect file stamps (mtime + size) for a list of relative paths under `root`.
 pub fn collect_filestamps(root: &Path, paths: &[String]) -> HashMap<String, FileStamp> {
-    let mut stamps = HashMap::with_capacity(paths.len());
-    for rel_path in paths {
-        let full_path = root.join(rel_path);
-        if let Ok(metadata) = std::fs::metadata(&full_path) {
-            let mtime = metadata
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            stamps.insert(
-                rel_path.clone(),
-                FileStamp {
-                    mtime,
-                    size: metadata.len(),
-                },
-            );
-        }
-    }
-    stamps
+    use rayon::prelude::*;
+
+    paths
+        .par_iter()
+        .filter_map(|rel_path| {
+            let full_path = root.join(rel_path);
+            std::fs::metadata(&full_path).ok().map(|metadata| {
+                let mtime = metadata
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                (
+                    rel_path.clone(),
+                    FileStamp {
+                        mtime,
+                        size: metadata.len(),
+                    },
+                )
+            })
+        })
+        .collect()
 }


### PR DESCRIPTION
## Summary

Two parallelization improvements that eliminate unnecessary sequential I/O and computation.

## Changes

### 1. Parallel filestamp collection (meta.rs)
\collect_filestamps()\ previously looped sequentially over all indexed paths calling \s::metadata()\. Now uses \ayon::par_iter()\ for parallel metadata collection. Expected 2-4x speedup on large repos where this is I/O-bound.

### 2. Parallel context-mode search (serve.rs)
Context-mode searches (\-B\/\-A\ flags) previously fell back to sequential \iter()\ to preserve output ordering. Now uses \par_iter().enumerate()\ + sort by index to restore file order while keeping parallel matching. Expected 4-8x speedup for context searches.

## Testing

All 108 existing tests pass. No new dependencies added (\ayon\ already in use).

Fixes #70
Fixes #71