### PR TITLE
chore: bump version to 0.1.18

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -5,22 +5,139 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 ---
 
-## chromium/chromium (493K files)
+## chromium/chromium (494K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24171177161)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24171159517)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805535539)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805536677)
 
-- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (492,734 files)
+- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (494,093 files)
 - **Queries**: 30 (mix of literals, multi-word, and regex)
-- **Index build time**: ~106s (Linux), ~312s (Windows), ~668s (macOS)
-- **Index size**: 2,470 MB (~2.4 GB)
+- **Index build time**: ~112s (Linux), ~293s (Windows), ~497s (macOS)
+- **Index size**: 2,478 MB (~2.5 GB)
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 770,353 | 25,678.4 |
-| tgrep (client → serve) | 75,473 | 2,515.8 |
+| ripgrep | 873,795 | 29,126.5 |
+| tgrep (client → serve) | 73,521 | 2,450.7 |
+
+**tgrep is ~12x faster**
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 2,079,314 | 69,310.5 |
+| tgrep (client → serve) | 87,352 | 2,911.7 |
+
+**tgrep is ~24x faster**
+
+### Linux x86_64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 83,876 | 2,795.9 |
+| tgrep (client → serve) | 36,314 | 1,210.5 |
+
+**tgrep is ~2.3x faster**
+
+---
+
+## mozilla/gecko-dev (388K files)
+
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805537755)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805538770)
+
+- **Repo**: [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev) (387,841 files)
+- **Queries**: 122 (mix of C++, JavaScript, and Python patterns)
+- **Index build time**: ~92s (Linux), ~180s (Windows), ~257s (macOS)
+- **Index size**: 1,938 MB (~1.9 GB)
+
+### Windows AMD64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 2,301,586 | 18,865.5 |
+| tgrep (client → serve) | 83,381 | 683.5 |
+
+**tgrep is ~28x faster**
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 5,579,958 | 45,737.4 |
+| tgrep (client → serve) | 62,027 | 508.4 |
+
+**tgrep is ~90x faster**
+
+### Linux x86_64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 243,421 | 1,995.3 |
+| tgrep (client → serve) | 33,463 | 274.3 |
+
+**tgrep is ~7x faster**
+
+---
+
+## torvalds/linux (94K files)
+
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805547294)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805548476)
+
+- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (93,931 files)
+- **Queries**: 102 (mix of literals, multi-word, and regex)
+- **Index build time**: ~41s (Linux), ~50s (Windows), ~144s (macOS)
+- **Index size**: ~977 MB
+
+### Windows AMD64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 323,962 | 3,176.1 |
+| tgrep (client → serve) | 75,612 | 741.3 |
+
+**tgrep is ~4x faster**
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 343,684 | 3,369.5 |
+| tgrep (client → serve) | 165,523 | 1,622.8 |
+
+**tgrep is ~2x faster**
+
+### Linux x86_64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 47,120 | 462.0 |
+| tgrep (client → serve) | 49,511 | 485.4 |
+
+**~1x (comparable — Linux I/O cache narrows the gap on this repo)**
+
+---
+
+## rust-lang/rust (59K files)
+
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805544808)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805546001)
+
+- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (59,267 files)
+- **Queries**: 102 (mix of Rust patterns, macros, traits, and regex)
+- **Index build time**: ~7s (Linux), ~11s (Windows/macOS)
+- **Index size**: ~189 MB
+
+### Windows AMD64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 203,367 | 1,993.8 |
+| tgrep (client → serve) | 19,362 | 189.8 |
 
 **tgrep is ~10x faster**
 
@@ -28,116 +145,77 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 1,825,058 | 60,835.3 |
-| tgrep (client → serve) | 88,415 | 2,947.2 |
+| ripgrep | 38,985 | 382.2 |
+| tgrep (client → serve) | 12,795 | 125.4 |
 
-**tgrep is ~21x faster**
+**tgrep is ~3x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 95,974 | 3,199.1 |
-| tgrep (client → serve) | 37,483 | 1,249.4 |
+| ripgrep | 13,909 | 136.4 |
+| tgrep (client → serve) | 9,709 | 95.2 |
 
-**tgrep is ~2.6x faster**
+**tgrep is ~1.4x faster**
 
 ---
 
-## mozilla/gecko-dev (388K files)
+## kubernetes/kubernetes (29K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24166560879)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24166565600)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805542622)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805543634)
 
-- **Repo**: [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev) (387,841 files)
-- **Queries**: 122 (mix of C++, JavaScript, and Python patterns)
-- **Index build time**: ~84s (Linux), ~239s (Windows), ~292s (macOS)
-- **Index size**: 1,938 MB (~1.9 GB)
+- **Repo**: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (29,232 files)
+- **Queries**: 97 (mix of Go patterns, Kubernetes API types, and regex)
+- **Index build time**: ~9s (Linux/macOS), ~9s (Windows)
+- **Index size**: ~203 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 1,840,166 | 15,083.3 |
-| tgrep (client → serve) | 73,847 | 605.3 |
+| ripgrep | 95,187 | 981.3 |
+| tgrep (client → serve) | 13,253 | 136.6 |
 
-**tgrep is ~25x faster**
+**tgrep is ~7x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 5,191,142 | 42,550.3 |
-| tgrep (client → serve) | 53,166 | 435.8 |
+| ripgrep | 28,575 | 294.6 |
+| tgrep (client → serve) | 8,711 | 89.8 |
 
-**tgrep is ~98x faster**
-
-### Linux x86_64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 158,795 | 1,301.6 |
-| tgrep (client → serve) | 39,119 | 320.6 |
-
-**tgrep is ~4x faster**
-
----
-
-## torvalds/linux (93K files)
-
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/23984630704)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/23984627799)
-
-- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (93,023 files)
-- **Queries**: 102 (mix of literals, multi-word, and regex)
-- **Index build time**: ~61s (Linux/macOS), ~110s (Windows)
-- **Index size**: ~969 MB
-
-### Windows AMD64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 531,054 | 5,206.4 |
-| tgrep (client → serve) | 130,938 | 1,283.7 |
-
-**tgrep is ~4x faster**
-
-### macOS Apple Silicon (Darwin arm64)
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 93,843 | 920.0 |
-| tgrep (client → serve) | 63,896 | 626.4 |
-
-**tgrep is ~1.5x faster**
+**tgrep is ~3x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 103,194 | 1,011.7 |
-| tgrep (client → serve) | 128,157 | 1,256.4 |
+| ripgrep | 15,659 | 161.4 |
+| tgrep (client → serve) | 8,505 | 87.7 |
 
-**tgrep is ~0.8x (ripgrep faster on small repos with Linux I/O cache)**
+**tgrep is ~1.8x faster**
 
 ---
 
-## rust-lang/rust (59K files)
+## golang/go (15K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24288075733)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24288075258)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805540173)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805541524)
 
-- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (58,949 files)
-- **Queries**: 102 (mix of Rust patterns, macros, traits, and regex)
-- **Index build time**: ~8s (Linux), ~10s (Windows), ~13s (macOS)
-- **Index size**: ~188 MB
+- **Repo**: [golang/go](https://github.com/golang/go) (15,302 files)
+- **Queries**: 103 (mix of Go stdlib patterns, testing, and regex)
+- **Index build time**: ~4s (Linux), ~5s (macOS), ~6s (Windows)
+- **Index size**: ~105 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 184,124 | 1,805.1 |
-| tgrep (client → serve) | 23,359 | 229.0 |
+| ripgrep | 62,542 | 607.2 |
+| tgrep (client → serve) | 7,500 | 72.8 |
 
 **tgrep is ~8x faster**
 
@@ -145,109 +223,31 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 42,080 | 412.5 |
-| tgrep (client → serve) | 26,214 | 257.0 |
+| ripgrep | 12,250 | 118.9 |
+| tgrep (client → serve) | 5,304 | 51.5 |
 
-**tgrep is ~1.6x faster**
-
-### Linux x86_64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 18,851 | 184.8 |
-| tgrep (client → serve) | 10,658 | 104.5 |
-
-**tgrep is ~1.8x faster**
-
----
-
-## kubernetes/kubernetes (29K files)
-
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24288076754)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24288076157)
-
-- **Repo**: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (29,226 files)
-- **Queries**: 97 (mix of Go patterns, Kubernetes API types, and regex)
-- **Index build time**: ~8s (Linux), ~11s (Windows/macOS)
-- **Index size**: ~203 MB
-
-### Windows AMD64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 144,506 | 1,489.8 |
-| tgrep (client → serve) | 13,886 | 143.2 |
-
-**tgrep is ~10x faster**
-
-### macOS Apple Silicon (Darwin arm64)
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 35,611 | 367.1 |
-| tgrep (client → serve) | 14,135 | 145.7 |
-
-**tgrep is ~2.5x faster**
+**tgrep is ~2.3x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 15,457 | 159.4 |
-| tgrep (client → serve) | 7,907 | 81.5 |
+| ripgrep | 7,192 | 69.8 |
+| tgrep (client → serve) | 3,816 | 37.0 |
 
-**tgrep is ~2x faster**
-
----
-
-## golang/go (15K files)
-
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24288077547)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24288077162)
-
-- **Repo**: [golang/go](https://github.com/golang/go) (15,267 files)
-- **Queries**: 103 (mix of Go stdlib patterns, testing, and regex)
-- **Index build time**: ~4s (Linux/macOS), ~5s (Windows)
-- **Index size**: ~105 MB
-
-### Windows AMD64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 63,254 | 614.1 |
-| tgrep (client → serve) | 6,683 | 64.9 |
-
-**tgrep is ~9.5x faster**
-
-### macOS Apple Silicon (Darwin arm64)
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 12,144 | 117.9 |
-| tgrep (client → serve) | 2,935 | 28.5 |
-
-**tgrep is ~4x faster**
-
-### Linux x86_64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 7,043 | 68.4 |
-| tgrep (client → serve) | 3,551 | 34.5 |
-
-**tgrep is ~2x faster**
+**tgrep is ~1.9x faster**
 
 ---
 
 ## Key takeaways
 
 - tgrep's advantage grows with repo size — the trigram index eliminates scanning files that can't match
-- On the 493K-file Chromium repo, tgrep is up to **21x faster** (macOS) and **10x faster** (Windows)
-- On the 388K-file gecko-dev repo, tgrep is up to **98x faster** (macOS) and **25x faster** (Windows)
-- On the 93K-file Linux kernel, tgrep is **4x faster** on Windows, ~1.5x on macOS, but Linux x86_64 is a case where ripgrep can be faster
-- On the 59K-file Rust repo, tgrep is **8x faster** on Windows, ~1.6–1.8x on macOS/Linux
-- On the 29K-file Kubernetes repo, tgrep is **10x faster** on Windows, ~2–2.5x on macOS/Linux
-- On the 15K-file Go repo, tgrep is **9.5x faster** on Windows, ~2–4x on macOS/Linux
-- On Windows, tgrep consistently shows the largest speedups (8–25x) due to slower Windows I/O
-- On Linux, aggressive OS page caching often narrows the gap; tgrep is usually faster, but some repos (such as the Linux kernel on x86_64) can favor ripgrep
+- On the 494K-file Chromium repo, tgrep is up to **24x faster** (macOS) and **12x faster** (Windows)
+- On the 388K-file gecko-dev repo, tgrep is up to **90x faster** (macOS) and **28x faster** (Windows)
+- On the 94K-file Linux kernel, tgrep is **4x faster** on Windows, ~2x on macOS; on Linux x86_64 the two are comparable
+- On the 59K-file Rust repo, tgrep is **10x faster** on Windows, ~3x on macOS, ~1.4x on Linux
+- On the 29K-file Kubernetes repo, tgrep is **7x faster** on Windows, ~3x on macOS, ~1.8x on Linux
+- On the 15K-file Go repo, tgrep is **8x faster** on Windows, ~2x on macOS/Linux
+- On Windows, tgrep consistently shows the largest speedups (4–28x) due to slower Windows I/O
+- On Linux, aggressive OS page caching often narrows the gap; tgrep is usually faster, but some repos (such as the Linux kernel on x86_64) can be comparable
 - Index build is a one-time cost; the server watches for file changes and updates incrementally

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ tgrep serve .            # start server (watches for file changes)
 tgrep "fn main" .        # instant — auto-connects to running server
 ```
 
-See [full benchmark results](BENCHMARKS.md) — up to **98x faster** than ripgrep on large repos.
+See [full benchmark results](BENCHMARKS.md) — up to **90x faster** than ripgrep on large repos.
 
 ### Benchmark highlights (avg latency per query, index pre-built)
 
 | Repo | Files | Platform | ripgrep | tgrep | Speedup |
 | --- | ---: | --- | ---: | ---: | ---: |
-| chromium | 493K | macOS arm64 | 60,835ms | 2,947ms | **21x** |
-| chromium | 493K | Windows | 25,678ms | 2,516ms | **10x** |
-| gecko-dev | 388K | macOS arm64 | 42,550ms | 436ms | **98x** |
-| gecko-dev | 388K | Windows | 15,083ms | 605ms | **25x** |
-| linux | 93K | Windows | 5,206ms | 1,284ms | **4x** |
-| rust | 59K | Windows | 1,805ms | 229ms | **8x** |
-| kubernetes | 29K | Windows | 1,490ms | 143ms | **10x** |
-| go | 15K | Windows | 614ms | 65ms | **9.5x** |
-| go | 15K | macOS arm64 | 118ms | 29ms | **4x** |
+| chromium | 494K | macOS arm64 | 69,311ms | 2,912ms | **24x** |
+| chromium | 494K | Windows | 29,127ms | 2,451ms | **12x** |
+| gecko-dev | 388K | macOS arm64 | 45,737ms | 508ms | **90x** |
+| gecko-dev | 388K | Windows | 18,866ms | 684ms | **28x** |
+| gecko-dev | 388K | Linux | 1,995ms | 274ms | **7x** |
+| linux | 94K | Windows | 3,176ms | 741ms | **4x** |
+| rust | 59K | Windows | 1,994ms | 190ms | **10x** |
+| kubernetes | 29K | Windows | 981ms | 137ms | **7x** |
+| go | 15K | Windows | 607ms | 73ms | **8x** |
 
 ## Architecture
 


### PR DESCRIPTION
Bump workspace version from 0.1.17 to 0.1.18.

Includes performance improvements from merged PRs:
- #67: glob filter using globset crate
- #68: lazy-cached builtin file types
- #69: HashSet-based trigram extraction
- #72: parallel filestamps and context search
- #74: cache read-lock contention fix