### PR TITLE
refactor: consolidate duplication across codebase (R1-R7)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -5,22 +5,139 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 ---
 
-## chromium/chromium (493K files)
+## chromium/chromium (494K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24171177161)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24171159517)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805535539)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805536677)
 
-- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (492,734 files)
+- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (494,093 files)
 - **Queries**: 30 (mix of literals, multi-word, and regex)
-- **Index build time**: ~106s (Linux), ~312s (Windows), ~668s (macOS)
-- **Index size**: 2,470 MB (~2.4 GB)
+- **Index build time**: ~112s (Linux), ~293s (Windows), ~497s (macOS)
+- **Index size**: 2,478 MB (~2.5 GB)
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 770,353 | 25,678.4 |
-| tgrep (client → serve) | 75,473 | 2,515.8 |
+| ripgrep | 873,795 | 29,126.5 |
+| tgrep (client → serve) | 73,521 | 2,450.7 |
+
+**tgrep is ~12x faster**
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 2,079,314 | 69,310.5 |
+| tgrep (client → serve) | 87,352 | 2,911.7 |
+
+**tgrep is ~24x faster**
+
+### Linux x86_64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 83,876 | 2,795.9 |
+| tgrep (client → serve) | 36,314 | 1,210.5 |
+
+**tgrep is ~2.3x faster**
+
+---
+
+## mozilla/gecko-dev (388K files)
+
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805537755)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805538770)
+
+- **Repo**: [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev) (387,841 files)
+- **Queries**: 122 (mix of C++, JavaScript, and Python patterns)
+- **Index build time**: ~92s (Linux), ~180s (Windows), ~257s (macOS)
+- **Index size**: 1,938 MB (~1.9 GB)
+
+### Windows AMD64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 2,301,586 | 18,865.5 |
+| tgrep (client → serve) | 83,381 | 683.5 |
+
+**tgrep is ~28x faster**
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 5,579,958 | 45,737.4 |
+| tgrep (client → serve) | 62,027 | 508.4 |
+
+**tgrep is ~90x faster**
+
+### Linux x86_64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 243,421 | 1,995.3 |
+| tgrep (client → serve) | 33,463 | 274.3 |
+
+**tgrep is ~7x faster**
+
+---
+
+## torvalds/linux (94K files)
+
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805547294)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805548476)
+
+- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (93,931 files)
+- **Queries**: 102 (mix of literals, multi-word, and regex)
+- **Index build time**: ~41s (Linux), ~50s (Windows), ~144s (macOS)
+- **Index size**: ~977 MB
+
+### Windows AMD64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 323,962 | 3,176.1 |
+| tgrep (client → serve) | 75,612 | 741.3 |
+
+**tgrep is ~4x faster**
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 343,684 | 3,369.5 |
+| tgrep (client → serve) | 165,523 | 1,622.8 |
+
+**tgrep is ~2x faster**
+
+### Linux x86_64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 47,120 | 462.0 |
+| tgrep (client → serve) | 49,511 | 485.4 |
+
+**~1x (comparable — Linux I/O cache narrows the gap on this repo)**
+
+---
+
+## rust-lang/rust (59K files)
+
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805544808)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805546001)
+
+- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (59,267 files)
+- **Queries**: 102 (mix of Rust patterns, macros, traits, and regex)
+- **Index build time**: ~7s (Linux), ~11s (Windows/macOS)
+- **Index size**: ~189 MB
+
+### Windows AMD64
+
+| Tool | Total (ms) | Avg per query (ms) |
+| --- | ---: | ---: |
+| ripgrep | 203,367 | 1,993.8 |
+| tgrep (client → serve) | 19,362 | 189.8 |
 
 **tgrep is ~10x faster**
 
@@ -28,116 +145,77 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 1,825,058 | 60,835.3 |
-| tgrep (client → serve) | 88,415 | 2,947.2 |
+| ripgrep | 38,985 | 382.2 |
+| tgrep (client → serve) | 12,795 | 125.4 |
 
-**tgrep is ~21x faster**
+**tgrep is ~3x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 95,974 | 3,199.1 |
-| tgrep (client → serve) | 37,483 | 1,249.4 |
+| ripgrep | 13,909 | 136.4 |
+| tgrep (client → serve) | 9,709 | 95.2 |
 
-**tgrep is ~2.6x faster**
+**tgrep is ~1.4x faster**
 
 ---
 
-## mozilla/gecko-dev (388K files)
+## kubernetes/kubernetes (29K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24166560879)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24166565600)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805542622)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805543634)
 
-- **Repo**: [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev) (387,841 files)
-- **Queries**: 122 (mix of C++, JavaScript, and Python patterns)
-- **Index build time**: ~84s (Linux), ~239s (Windows), ~292s (macOS)
-- **Index size**: 1,938 MB (~1.9 GB)
+- **Repo**: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (29,232 files)
+- **Queries**: 97 (mix of Go patterns, Kubernetes API types, and regex)
+- **Index build time**: ~9s (Linux/macOS), ~9s (Windows)
+- **Index size**: ~203 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 1,840,166 | 15,083.3 |
-| tgrep (client → serve) | 73,847 | 605.3 |
+| ripgrep | 95,187 | 981.3 |
+| tgrep (client → serve) | 13,253 | 136.6 |
 
-**tgrep is ~25x faster**
+**tgrep is ~7x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 5,191,142 | 42,550.3 |
-| tgrep (client → serve) | 53,166 | 435.8 |
+| ripgrep | 28,575 | 294.6 |
+| tgrep (client → serve) | 8,711 | 89.8 |
 
-**tgrep is ~98x faster**
-
-### Linux x86_64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 158,795 | 1,301.6 |
-| tgrep (client → serve) | 39,119 | 320.6 |
-
-**tgrep is ~4x faster**
-
----
-
-## torvalds/linux (93K files)
-
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/23984630704)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/23984627799)
-
-- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (93,023 files)
-- **Queries**: 102 (mix of literals, multi-word, and regex)
-- **Index build time**: ~61s (Linux/macOS), ~110s (Windows)
-- **Index size**: ~969 MB
-
-### Windows AMD64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 531,054 | 5,206.4 |
-| tgrep (client → serve) | 130,938 | 1,283.7 |
-
-**tgrep is ~4x faster**
-
-### macOS Apple Silicon (Darwin arm64)
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 93,843 | 920.0 |
-| tgrep (client → serve) | 63,896 | 626.4 |
-
-**tgrep is ~1.5x faster**
+**tgrep is ~3x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 103,194 | 1,011.7 |
-| tgrep (client → serve) | 128,157 | 1,256.4 |
+| ripgrep | 15,659 | 161.4 |
+| tgrep (client → serve) | 8,505 | 87.7 |
 
-**tgrep is ~0.8x (ripgrep faster on small repos with Linux I/O cache)**
+**tgrep is ~1.8x faster**
 
 ---
 
-## rust-lang/rust (59K files)
+## golang/go (15K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24288075733)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24288075258)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805540173)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805541524)
 
-- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (58,949 files)
-- **Queries**: 102 (mix of Rust patterns, macros, traits, and regex)
-- **Index build time**: ~8s (Linux), ~10s (Windows), ~13s (macOS)
-- **Index size**: ~188 MB
+- **Repo**: [golang/go](https://github.com/golang/go) (15,302 files)
+- **Queries**: 103 (mix of Go stdlib patterns, testing, and regex)
+- **Index build time**: ~4s (Linux), ~5s (macOS), ~6s (Windows)
+- **Index size**: ~105 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 184,124 | 1,805.1 |
-| tgrep (client → serve) | 23,359 | 229.0 |
+| ripgrep | 62,542 | 607.2 |
+| tgrep (client → serve) | 7,500 | 72.8 |
 
 **tgrep is ~8x faster**
 
@@ -145,109 +223,31 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 42,080 | 412.5 |
-| tgrep (client → serve) | 26,214 | 257.0 |
+| ripgrep | 12,250 | 118.9 |
+| tgrep (client → serve) | 5,304 | 51.5 |
 
-**tgrep is ~1.6x faster**
-
-### Linux x86_64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 18,851 | 184.8 |
-| tgrep (client → serve) | 10,658 | 104.5 |
-
-**tgrep is ~1.8x faster**
-
----
-
-## kubernetes/kubernetes (29K files)
-
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24288076754)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24288076157)
-
-- **Repo**: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (29,226 files)
-- **Queries**: 97 (mix of Go patterns, Kubernetes API types, and regex)
-- **Index build time**: ~8s (Linux), ~11s (Windows/macOS)
-- **Index size**: ~203 MB
-
-### Windows AMD64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 144,506 | 1,489.8 |
-| tgrep (client → serve) | 13,886 | 143.2 |
-
-**tgrep is ~10x faster**
-
-### macOS Apple Silicon (Darwin arm64)
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 35,611 | 367.1 |
-| tgrep (client → serve) | 14,135 | 145.7 |
-
-**tgrep is ~2.5x faster**
+**tgrep is ~2.3x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 15,457 | 159.4 |
-| tgrep (client → serve) | 7,907 | 81.5 |
+| ripgrep | 7,192 | 69.8 |
+| tgrep (client → serve) | 3,816 | 37.0 |
 
-**tgrep is ~2x faster**
-
----
-
-## golang/go (15K files)
-
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24288077547)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24288077162)
-
-- **Repo**: [golang/go](https://github.com/golang/go) (15,267 files)
-- **Queries**: 103 (mix of Go stdlib patterns, testing, and regex)
-- **Index build time**: ~4s (Linux/macOS), ~5s (Windows)
-- **Index size**: ~105 MB
-
-### Windows AMD64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 63,254 | 614.1 |
-| tgrep (client → serve) | 6,683 | 64.9 |
-
-**tgrep is ~9.5x faster**
-
-### macOS Apple Silicon (Darwin arm64)
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 12,144 | 117.9 |
-| tgrep (client → serve) | 2,935 | 28.5 |
-
-**tgrep is ~4x faster**
-
-### Linux x86_64
-
-| Tool | Total (ms) | Avg per query (ms) |
-| --- | ---: | ---: |
-| ripgrep | 7,043 | 68.4 |
-| tgrep (client → serve) | 3,551 | 34.5 |
-
-**tgrep is ~2x faster**
+**tgrep is ~1.9x faster**
 
 ---
 
 ## Key takeaways
 
 - tgrep's advantage grows with repo size — the trigram index eliminates scanning files that can't match
-- On the 493K-file Chromium repo, tgrep is up to **21x faster** (macOS) and **10x faster** (Windows)
-- On the 388K-file gecko-dev repo, tgrep is up to **98x faster** (macOS) and **25x faster** (Windows)
-- On the 93K-file Linux kernel, tgrep is **4x faster** on Windows, ~1.5x on macOS, but Linux x86_64 is a case where ripgrep can be faster
-- On the 59K-file Rust repo, tgrep is **8x faster** on Windows, ~1.6–1.8x on macOS/Linux
-- On the 29K-file Kubernetes repo, tgrep is **10x faster** on Windows, ~2–2.5x on macOS/Linux
-- On the 15K-file Go repo, tgrep is **9.5x faster** on Windows, ~2–4x on macOS/Linux
-- On Windows, tgrep consistently shows the largest speedups (8–25x) due to slower Windows I/O
-- On Linux, aggressive OS page caching often narrows the gap; tgrep is usually faster, but some repos (such as the Linux kernel on x86_64) can favor ripgrep
+- On the 494K-file Chromium repo, tgrep is up to **24x faster** (macOS) and **12x faster** (Windows)
+- On the 388K-file gecko-dev repo, tgrep is up to **90x faster** (macOS) and **28x faster** (Windows)
+- On the 94K-file Linux kernel, tgrep is **4x faster** on Windows, ~2x on macOS; on Linux x86_64 the two are comparable
+- On the 59K-file Rust repo, tgrep is **10x faster** on Windows, ~3x on macOS, ~1.4x on Linux
+- On the 29K-file Kubernetes repo, tgrep is **7x faster** on Windows, ~3x on macOS, ~1.8x on Linux
+- On the 15K-file Go repo, tgrep is **8x faster** on Windows, ~2x on macOS/Linux
+- On Windows, tgrep consistently shows the largest speedups (4–28x) due to slower Windows I/O
+- On Linux, aggressive OS page caching often narrows the gap; tgrep is usually faster, but some repos (such as the Linux kernel on x86_64) can be comparable
 - Index build is a one-time cost; the server watches for file changes and updates incrementally

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -7,20 +7,20 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 ## chromium/chromium (494K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805535539)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805536677)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24811114641)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24811115740)
 
-- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (494,093 files)
+- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (494,120 files)
 - **Queries**: 30 (mix of literals, multi-word, and regex)
-- **Index build time**: ~112s (Linux), ~293s (Windows), ~497s (macOS)
+- **Index build time**: ~97s (Linux), ~688s (Windows), ~540s (macOS)
 - **Index size**: 2,478 MB (~2.5 GB)
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 873,795 | 29,126.5 |
-| tgrep (client → serve) | 73,521 | 2,450.7 |
+| ripgrep | 848,569 | 28,285.6 |
+| tgrep (client → serve) | 73,143 | 2,438.1 |
 
 **tgrep is ~12x faster**
 
@@ -28,77 +28,77 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 2,079,314 | 69,310.5 |
-| tgrep (client → serve) | 87,352 | 2,911.7 |
+| ripgrep | 2,146,196 | 71,539.9 |
+| tgrep (client → serve) | 91,716 | 3,057.2 |
 
-**tgrep is ~24x faster**
+**tgrep is ~23x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 83,876 | 2,795.9 |
-| tgrep (client → serve) | 36,314 | 1,210.5 |
+| ripgrep | 83,530 | 2,784.3 |
+| tgrep (client → serve) | 34,688 | 1,156.3 |
 
-**tgrep is ~2.3x faster**
+**tgrep is ~2.4x faster**
 
 ---
 
 ## mozilla/gecko-dev (388K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805537755)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805538770)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24811116791)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24811117829)
 
 - **Repo**: [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev) (387,841 files)
 - **Queries**: 122 (mix of C++, JavaScript, and Python patterns)
-- **Index build time**: ~92s (Linux), ~180s (Windows), ~257s (macOS)
+- **Index build time**: ~77s (Linux), ~314s (Windows), ~267s (macOS)
 - **Index size**: 1,938 MB (~1.9 GB)
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 2,301,586 | 18,865.5 |
-| tgrep (client → serve) | 83,381 | 683.5 |
+| ripgrep | 2,048,034 | 16,787.2 |
+| tgrep (client → serve) | 67,794 | 555.7 |
 
-**tgrep is ~28x faster**
+**tgrep is ~30x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 5,579,958 | 45,737.4 |
-| tgrep (client → serve) | 62,027 | 508.4 |
+| ripgrep | 4,724,399 | 38,724.6 |
+| tgrep (client → serve) | 72,273 | 592.4 |
 
-**tgrep is ~90x faster**
+**tgrep is ~65x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 243,421 | 1,995.3 |
-| tgrep (client → serve) | 33,463 | 274.3 |
+| ripgrep | 212,783 | 1,744.1 |
+| tgrep (client → serve) | 34,589 | 283.5 |
 
-**tgrep is ~7x faster**
+**tgrep is ~6x faster**
 
 ---
 
 ## torvalds/linux (94K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805547294)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805548476)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24811125540)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24811126603)
 
 - **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (93,931 files)
 - **Queries**: 102 (mix of literals, multi-word, and regex)
-- **Index build time**: ~41s (Linux), ~50s (Windows), ~144s (macOS)
+- **Index build time**: ~37s (Linux), ~77s (Windows), ~90s (macOS)
 - **Index size**: ~977 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 323,962 | 3,176.1 |
-| tgrep (client → serve) | 75,612 | 741.3 |
+| ripgrep | 319,356 | 3,130.9 |
+| tgrep (client → serve) | 77,352 | 758.4 |
 
 **tgrep is ~4x faster**
 
@@ -106,17 +106,17 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 343,684 | 3,369.5 |
-| tgrep (client → serve) | 165,523 | 1,622.8 |
+| ripgrep | 123,740 | 1,213.1 |
+| tgrep (client → serve) | 100,269 | 983.0 |
 
-**tgrep is ~2x faster**
+**tgrep is ~1.2x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 47,120 | 462.0 |
-| tgrep (client → serve) | 49,511 | 485.4 |
+| ripgrep | 36,599 | 358.8 |
+| tgrep (client → serve) | 49,765 | 487.9 |
 
 **~1x (comparable — Linux I/O cache narrows the gap on this repo)**
 
@@ -124,59 +124,59 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 ## rust-lang/rust (59K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805544808)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805546001)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24811123386)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24811124502)
 
-- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (59,267 files)
+- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (59,293 files)
 - **Queries**: 102 (mix of Rust patterns, macros, traits, and regex)
-- **Index build time**: ~7s (Linux), ~11s (Windows/macOS)
+- **Index build time**: ~7s (Linux), ~8s (Windows), ~9s (macOS)
 - **Index size**: ~189 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 203,367 | 1,993.8 |
-| tgrep (client → serve) | 19,362 | 189.8 |
+| ripgrep | 137,992 | 1,352.9 |
+| tgrep (client → serve) | 16,186 | 158.7 |
 
-**tgrep is ~10x faster**
+**tgrep is ~9x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 38,985 | 382.2 |
-| tgrep (client → serve) | 12,795 | 125.4 |
+| ripgrep | 42,115 | 412.9 |
+| tgrep (client → serve) | 10,941 | 107.3 |
 
-**tgrep is ~3x faster**
+**tgrep is ~4x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 13,909 | 136.4 |
-| tgrep (client → serve) | 9,709 | 95.2 |
+| ripgrep | 19,216 | 188.4 |
+| tgrep (client → serve) | 9,912 | 97.2 |
 
-**tgrep is ~1.4x faster**
+**tgrep is ~1.9x faster**
 
 ---
 
 ## kubernetes/kubernetes (29K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805542622)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805543634)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24811121029)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24811122255)
 
-- **Repo**: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (29,232 files)
+- **Repo**: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (29,242 files)
 - **Queries**: 97 (mix of Go patterns, Kubernetes API types, and regex)
-- **Index build time**: ~9s (Linux/macOS), ~9s (Windows)
+- **Index build time**: ~8s (Linux/macOS), ~8s (Windows)
 - **Index size**: ~203 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 95,187 | 981.3 |
-| tgrep (client → serve) | 13,253 | 136.6 |
+| ripgrep | 99,009 | 1,020.7 |
+| tgrep (client → serve) | 13,362 | 137.8 |
 
 **tgrep is ~7x faster**
 
@@ -184,38 +184,38 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 28,575 | 294.6 |
-| tgrep (client → serve) | 8,711 | 89.8 |
+| ripgrep | 24,786 | 255.5 |
+| tgrep (client → serve) | 6,402 | 66.0 |
 
-**tgrep is ~3x faster**
+**tgrep is ~4x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 15,659 | 161.4 |
-| tgrep (client → serve) | 8,505 | 87.7 |
+| ripgrep | 15,314 | 157.9 |
+| tgrep (client → serve) | 8,130 | 83.8 |
 
-**tgrep is ~1.8x faster**
+**tgrep is ~1.9x faster**
 
 ---
 
 ## golang/go (15K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24805540173)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24805541524)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/24811118882)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/24811120023)
 
 - **Repo**: [golang/go](https://github.com/golang/go) (15,302 files)
 - **Queries**: 103 (mix of Go stdlib patterns, testing, and regex)
-- **Index build time**: ~4s (Linux), ~5s (macOS), ~6s (Windows)
+- **Index build time**: ~4s (Linux), ~3s (macOS), ~4s (Windows)
 - **Index size**: ~105 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 62,542 | 607.2 |
-| tgrep (client → serve) | 7,500 | 72.8 |
+| ripgrep | 45,996 | 446.6 |
+| tgrep (client → serve) | 6,130 | 59.5 |
 
 **tgrep is ~8x faster**
 
@@ -223,31 +223,31 @@ tgrep runs in client/server mode: `tgrep serve` runs in the background, and the 
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 12,250 | 118.9 |
-| tgrep (client → serve) | 5,304 | 51.5 |
+| ripgrep | 12,587 | 122.2 |
+| tgrep (client → serve) | 2,893 | 28.1 |
 
-**tgrep is ~2.3x faster**
+**tgrep is ~4x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) |
 | --- | ---: | ---: |
-| ripgrep | 7,192 | 69.8 |
-| tgrep (client → serve) | 3,816 | 37.0 |
+| ripgrep | 7,276 | 70.6 |
+| tgrep (client → serve) | 3,958 | 38.4 |
 
-**tgrep is ~1.9x faster**
+**tgrep is ~1.8x faster**
 
 ---
 
 ## Key takeaways
 
 - tgrep's advantage grows with repo size — the trigram index eliminates scanning files that can't match
-- On the 494K-file Chromium repo, tgrep is up to **24x faster** (macOS) and **12x faster** (Windows)
-- On the 388K-file gecko-dev repo, tgrep is up to **90x faster** (macOS) and **28x faster** (Windows)
-- On the 94K-file Linux kernel, tgrep is **4x faster** on Windows, ~2x on macOS; on Linux x86_64 the two are comparable
-- On the 59K-file Rust repo, tgrep is **10x faster** on Windows, ~3x on macOS, ~1.4x on Linux
-- On the 29K-file Kubernetes repo, tgrep is **7x faster** on Windows, ~3x on macOS, ~1.8x on Linux
-- On the 15K-file Go repo, tgrep is **8x faster** on Windows, ~2x on macOS/Linux
-- On Windows, tgrep consistently shows the largest speedups (4–28x) due to slower Windows I/O
+- On the 494K-file Chromium repo, tgrep is up to **23x faster** (macOS) and **12x faster** (Windows)
+- On the 388K-file gecko-dev repo, tgrep is up to **65x faster** (macOS) and **30x faster** (Windows)
+- On the 94K-file Linux kernel, tgrep is **4x faster** on Windows; on Linux/macOS the two are comparable
+- On the 59K-file Rust repo, tgrep is **9x faster** on Windows, ~4x on macOS, ~2x on Linux
+- On the 29K-file Kubernetes repo, tgrep is **7x faster** on Windows, ~4x on macOS, ~2x on Linux
+- On the 15K-file Go repo, tgrep is **8x faster** on Windows, ~4x on macOS, ~2x on Linux
+- On Windows, tgrep consistently shows the largest speedups (4–30x) due to slower Windows I/O
 - On Linux, aggressive OS page caching often narrows the gap; tgrep is usually faster, but some repos (such as the Linux kernel on x86_64) can be comparable
 - Index build is a one-time cost; the server watches for file changes and updates incrementally

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ tgrep serve .            # start server (watches for file changes)
 tgrep "fn main" .        # instant — auto-connects to running server
 ```
 
-See [full benchmark results](BENCHMARKS.md) — up to **98x faster** than ripgrep on large repos.
+See [full benchmark results](BENCHMARKS.md) — up to **90x faster** than ripgrep on large repos.
 
 ### Benchmark highlights (avg latency per query, index pre-built)
 
 | Repo | Files | Platform | ripgrep | tgrep | Speedup |
 | --- | ---: | --- | ---: | ---: | ---: |
-| chromium | 493K | macOS arm64 | 60,835ms | 2,947ms | **21x** |
-| chromium | 493K | Windows | 25,678ms | 2,516ms | **10x** |
-| gecko-dev | 388K | macOS arm64 | 42,550ms | 436ms | **98x** |
-| gecko-dev | 388K | Windows | 15,083ms | 605ms | **25x** |
-| linux | 93K | Windows | 5,206ms | 1,284ms | **4x** |
-| rust | 59K | Windows | 1,805ms | 229ms | **8x** |
-| kubernetes | 29K | Windows | 1,490ms | 143ms | **10x** |
-| go | 15K | Windows | 614ms | 65ms | **9.5x** |
-| go | 15K | macOS arm64 | 118ms | 29ms | **4x** |
+| chromium | 494K | macOS arm64 | 69,311ms | 2,912ms | **24x** |
+| chromium | 494K | Windows | 29,127ms | 2,451ms | **12x** |
+| gecko-dev | 388K | macOS arm64 | 45,737ms | 508ms | **90x** |
+| gecko-dev | 388K | Windows | 18,866ms | 684ms | **28x** |
+| gecko-dev | 388K | Linux | 1,995ms | 274ms | **7x** |
+| linux | 94K | Windows | 3,176ms | 741ms | **4x** |
+| rust | 59K | Windows | 1,994ms | 190ms | **10x** |
+| kubernetes | 29K | Windows | 981ms | 137ms | **7x** |
+| go | 15K | Windows | 607ms | 73ms | **8x** |
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ tgrep serve .            # start server (watches for file changes)
 tgrep "fn main" .        # instant — auto-connects to running server
 ```
 
-See [full benchmark results](BENCHMARKS.md) — up to **90x faster** than ripgrep on large repos.
+See [full benchmark results](BENCHMARKS.md) — up to **65x faster** than ripgrep on large repos.
 
 ### Benchmark highlights (avg latency per query, index pre-built)
 
 | Repo | Files | Platform | ripgrep | tgrep | Speedup |
 | --- | ---: | --- | ---: | ---: | ---: |
-| chromium | 494K | macOS arm64 | 69,311ms | 2,912ms | **24x** |
-| chromium | 494K | Windows | 29,127ms | 2,451ms | **12x** |
-| gecko-dev | 388K | macOS arm64 | 45,737ms | 508ms | **90x** |
-| gecko-dev | 388K | Windows | 18,866ms | 684ms | **28x** |
-| gecko-dev | 388K | Linux | 1,995ms | 274ms | **7x** |
-| linux | 94K | Windows | 3,176ms | 741ms | **4x** |
-| rust | 59K | Windows | 1,994ms | 190ms | **10x** |
-| kubernetes | 29K | Windows | 981ms | 137ms | **7x** |
-| go | 15K | Windows | 607ms | 73ms | **8x** |
+| chromium | 494K | macOS arm64 | 71,540ms | 3,057ms | **23x** |
+| chromium | 494K | Windows | 28,286ms | 2,438ms | **12x** |
+| gecko-dev | 388K | macOS arm64 | 38,725ms | 592ms | **65x** |
+| gecko-dev | 388K | Windows | 16,787ms | 556ms | **30x** |
+| gecko-dev | 388K | Linux | 1,744ms | 284ms | **6x** |
+| linux | 94K | Windows | 3,131ms | 758ms | **4x** |
+| rust | 59K | Windows | 1,353ms | 159ms | **9x** |
+| kubernetes | 29K | Windows | 1,021ms | 138ms | **7x** |
+| go | 15K | Windows | 447ms | 60ms | **8x** |
 
 ## Architecture
 

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -7,6 +7,7 @@
 ///   tgrep status [path]          Show index/server status
 mod glob_filter;
 mod index;
+mod matching;
 mod output;
 mod search;
 mod serve;

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -1,6 +1,6 @@
-/// Shared matching logic used by both the server (serve.rs) and the local
-/// search path (search.rs). Extracts the core line-matching and context-window
-/// algorithms so both callers avoid duplicating them.
+//! Shared matching logic used by both the server (serve.rs) and the local
+//! search path (search.rs). Extracts the core line-matching and context-window
+//! algorithms so both callers avoid duplicating them.
 
 /// Find indices of matching lines in `lines`, respecting `invert_match` and
 /// `max_count`. Returns the indices into the `lines` slice.

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -10,6 +10,9 @@ pub fn find_match_indices(
     invert_match: bool,
     max_count: Option<usize>,
 ) -> Vec<usize> {
+    if max_count == Some(0) {
+        return Vec::new();
+    }
     let mut indices = Vec::new();
     for (i, line) in lines.iter().enumerate() {
         let is_match = re.is_match(line);

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -1,0 +1,58 @@
+/// Shared matching logic used by both the server (serve.rs) and the local
+/// search path (search.rs). Extracts the core line-matching and context-window
+/// algorithms so both callers avoid duplicating them.
+
+/// Find indices of matching lines in `lines`, respecting `invert_match` and
+/// `max_count`. Returns the indices into the `lines` slice.
+pub fn find_match_indices(
+    lines: &[&str],
+    re: &regex::Regex,
+    invert_match: bool,
+    max_count: Option<usize>,
+) -> Vec<usize> {
+    let mut indices = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        let is_match = re.is_match(line);
+        let include = if invert_match { !is_match } else { is_match };
+        if include {
+            indices.push(i);
+            if let Some(max) = max_count
+                && indices.len() >= max
+            {
+                break;
+            }
+        }
+    }
+    indices
+}
+
+/// Expand match indices into the full set of line indices to display,
+/// including context lines. Returns a sorted, deduplicated set.
+pub fn expand_context_window(
+    match_indices: &[usize],
+    total_lines: usize,
+    before: usize,
+    after: usize,
+) -> std::collections::BTreeSet<usize> {
+    let mut printed = std::collections::BTreeSet::new();
+    for &mi in match_indices {
+        let start = mi.saturating_sub(before);
+        let end = (mi + after + 1).min(total_lines);
+        for j in start..end {
+            printed.insert(j);
+        }
+    }
+    printed
+}
+
+/// Extract match content — full line or only the matched portions.
+pub fn match_content(line: &str, re: &regex::Regex, only_matching: bool) -> String {
+    if only_matching {
+        re.find_iter(line)
+            .map(|m| m.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        line.to_string()
+    }
+}

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -483,27 +483,14 @@ fn search_file_content(
     let after = opts.after_ctx();
     let has_context = before > 0 || after > 0;
 
-    // Find matching line indices
-    let mut match_indices: Vec<usize> = Vec::new();
-    for (i, line) in lines.iter().enumerate() {
-        let is_match = re.is_match(line);
-        let include = if opts.invert_match {
-            !is_match
-        } else {
-            is_match
-        };
-        if include {
-            match_indices.push(i);
-            if opts.quiet || opts.files_without_match {
-                break;
-            }
-            if let Some(max) = opts.max_count
-                && match_indices.len() >= max
-            {
-                break;
-            }
-        }
-    }
+    // Find matching line indices (use max_count of 1 for quiet/files_without_match)
+    let effective_max = if opts.quiet || opts.files_without_match {
+        Some(1)
+    } else {
+        opts.max_count
+    };
+    let match_indices =
+        crate::matching::find_match_indices(&lines, re, opts.invert_match, effective_max);
 
     if match_indices.is_empty() {
         return Ok(false);
@@ -526,17 +513,10 @@ fn search_file_content(
 
     // Build set of lines to output (matches + context)
     if has_context {
-        let mut printed: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
-        let mut is_match_line: std::collections::HashSet<usize> = std::collections::HashSet::new();
-
-        for &mi in &match_indices {
-            is_match_line.insert(mi);
-            let ctx_start = mi.saturating_sub(before);
-            let ctx_end = (mi + after + 1).min(lines.len());
-            for j in ctx_start..ctx_end {
-                printed.insert(j);
-            }
-        }
+        let printed =
+            crate::matching::expand_context_window(&match_indices, lines.len(), before, after);
+        let is_match_line: std::collections::HashSet<usize> =
+            match_indices.iter().copied().collect();
 
         let mut prev_line: Option<usize> = None;
         for &li in &printed {
@@ -548,7 +528,7 @@ fn search_file_content(
             }
 
             if is_match_line.contains(&li) {
-                let content = match_content(lines[li], re, opts.only_matching);
+                let content = crate::matching::match_content(lines[li], re, opts.only_matching);
                 let column = re.find(lines[li]).map(|m| m.start() + 1);
                 writer.write_match(&Match {
                     file: rel_path.to_string(),
@@ -567,7 +547,7 @@ fn search_file_content(
         }
     } else {
         for &mi in &match_indices {
-            let content = match_content(lines[mi], re, opts.only_matching);
+            let content = crate::matching::match_content(lines[mi], re, opts.only_matching);
             let column = re.find(lines[mi]).map(|m| m.start() + 1);
             writer.write_match(&Match {
                 file: rel_path.to_string(),
@@ -579,18 +559,6 @@ fn search_file_content(
     }
 
     Ok(true)
-}
-
-/// Extract match content — full line or only the matched portion.
-fn match_content(line: &str, re: &regex::Regex, only_matching: bool) -> String {
-    if only_matching {
-        re.find_iter(line)
-            .map(|m| m.as_str())
-            .collect::<Vec<_>>()
-            .join("\n")
-    } else {
-        line.to_string()
-    }
 }
 
 pub fn build_combined_regex(

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -81,6 +81,17 @@ fn try_acquire_server_lock(index_dir: &Path) -> Result<File> {
     }
 }
 
+/// Lock ordering (acquire in this order to avoid deadlocks):
+///
+///   1. `snapshot_gate` — coordinates watcher mutations with publish cycle
+///   2. `publish_lock`  — serializes on-disk index publication
+///   3. `index`         — guards the in-memory HybridIndex (read-heavy)
+///   4. `cache`         — guards the file content LRU cache
+///   5. `file_stamps`   — guards per-file mtime/size stamps
+///
+/// `flushing` is an AtomicBool, not a lock — no ordering constraint.
+/// Searches only acquire `index` (read) and `cache` (read then write);
+/// they never take `snapshot_gate` or `publish_lock`.
 struct ServerState {
     index: RwLock<HybridIndex>,
     cache: RwLock<LruCache<String, Arc<String>>>,
@@ -339,13 +350,20 @@ fn process_request(request: &str, state: &ServerState) -> String {
     }
 }
 
-fn handle_search(
-    id: Option<serde_json::Value>,
-    params: &serde_json::Value,
-    state: &ServerState,
-) -> String {
-    let start = Instant::now();
+/// Parsed and validated search request parameters.
+struct SearchRequest {
+    pattern: String,
+    case_insensitive: bool,
+    regex: regex::Regex,
+    plan: query::QueryPlan,
+    glob_filter: crate::glob_filter::GlobFilter,
+    file_type: Option<String>,
+    opts: SearchOpts,
+}
 
+/// Parse and validate all search parameters from a JSON-RPC request.
+/// Returns Err(String) with an error message suitable for json_rpc_error on failure.
+fn parse_search_params(params: &serde_json::Value) -> std::result::Result<SearchRequest, String> {
     let pattern = params.get("pattern").and_then(|p| p.as_str()).unwrap_or("");
     let extra_patterns: Vec<String> = params
         .get("extra_patterns")
@@ -381,10 +399,8 @@ fn handle_search(
                 .collect()
         })
         .unwrap_or_default();
-    let glob_filter = match crate::glob_filter::GlobFilter::new(&glob_filter_strs) {
-        Ok(f) => f,
-        Err(e) => return json_rpc_error(id, -32602, &format!("{e}")),
-    };
+    let glob_filter =
+        crate::glob_filter::GlobFilter::new(&glob_filter_strs).map_err(|e| format!("{e}"))?;
     let file_type = params
         .get("file_type")
         .and_then(|t| t.as_str())
@@ -420,26 +436,59 @@ fn handle_search(
     let mut all_patterns = vec![pattern.to_string()];
     all_patterns.extend(extra_patterns);
 
-    let re = match crate::search::build_combined_regex(
+    let regex = crate::search::build_combined_regex(
         &all_patterns,
         case_insensitive,
         fixed_string,
         word_boundary,
         multiline,
-    ) {
-        Ok(r) => r,
-        Err(e) => return json_rpc_error(id, -32602, &format!("{e}")),
-    };
+    )
+    .map_err(|e| format!("{e}"))?;
 
     // Build query plan from primary pattern for index filtering
     let plan = if fixed_string {
         query::build_literal_plan(pattern, case_insensitive)
     } else {
-        match query::build_query_plan(pattern, case_insensitive) {
-            Ok(p) => p,
-            Err(e) => return json_rpc_error(id, -32602, &e),
-        }
+        query::build_query_plan(pattern, case_insensitive)?
     };
+
+    Ok(SearchRequest {
+        pattern: pattern.to_string(),
+        case_insensitive,
+        regex,
+        plan,
+        glob_filter,
+        file_type,
+        opts: SearchOpts {
+            files_only,
+            invert_match,
+            only_matching,
+            max_count,
+            before_context,
+            after_context,
+        },
+    })
+}
+
+fn handle_search(
+    id: Option<serde_json::Value>,
+    params: &serde_json::Value,
+    state: &ServerState,
+) -> String {
+    let start = Instant::now();
+
+    let req = match parse_search_params(params) {
+        Ok(r) => r,
+        Err(e) => return json_rpc_error(id, -32602, &e),
+    };
+
+    let re = req.regex;
+    let plan = req.plan;
+    let glob_filter = req.glob_filter;
+    let file_type = req.file_type;
+    let opts = req.opts;
+    let pattern = req.pattern;
+    let case_insensitive = req.case_insensitive;
 
     // Collect candidates and their paths/full_paths while holding the index lock briefly
     let t_index = Instant::now();
@@ -489,11 +538,12 @@ fn handle_search(
             .collect();
 
         // Log filter breakdown when raw candidates are dropped to zero
+        let glob_active = !glob_filter.is_empty();
         if raw_count > 0 && filtered.is_empty() {
             eprintln!(
                 "[trace] filter: raw={raw_count} no_path={no_path_count} \
                  type_filtered={type_filtered_count} glob_filtered={glob_filtered_count} \
-                 file_type={file_type:?} glob_values={glob_filter_strs:?} \
+                 file_type={file_type:?} glob_active={glob_active} \
                  sample_rejected={first_glob_rejected:?}",
             );
         }
@@ -567,15 +617,7 @@ fn handle_search(
     };
     let resolve_ms = t_resolve.elapsed().as_secs_f64() * 1000.0;
 
-    let has_context = before_context > 0 || after_context > 0;
-    let opts = SearchOpts {
-        files_only,
-        invert_match,
-        only_matching,
-        max_count,
-        before_context,
-        after_context,
-    };
+    let has_context = opts.before_context > 0 || opts.after_context > 0;
 
     // Parallel regex matching across candidate files
     let t_search = Instant::now();
@@ -633,25 +675,8 @@ fn search_file_matches(
     };
 
     let lines: Vec<&str> = content.lines().collect();
-
-    // Find matching line indices
-    let mut match_indices: Vec<usize> = Vec::new();
-    for (i, line) in lines.iter().enumerate() {
-        let is_match = re.is_match(line);
-        let include = if opts.invert_match {
-            !is_match
-        } else {
-            is_match
-        };
-        if include {
-            match_indices.push(i);
-            if let Some(max) = effective_max
-                && match_indices.len() >= max
-            {
-                break;
-            }
-        }
-    }
+    let match_indices =
+        crate::matching::find_match_indices(&lines, re, opts.invert_match, effective_max);
 
     if match_indices.is_empty() {
         return Vec::new();
@@ -660,27 +685,19 @@ fn search_file_matches(
     let has_context = opts.before_context > 0 || opts.after_context > 0;
 
     if has_context {
+        let printed = crate::matching::expand_context_window(
+            &match_indices,
+            lines.len(),
+            opts.before_context,
+            opts.after_context,
+        );
+        let is_match_line: std::collections::HashSet<usize> =
+            match_indices.iter().copied().collect();
+
         let mut results = Vec::new();
-        let mut printed = std::collections::BTreeSet::new();
-        let mut is_match_line = std::collections::HashSet::new();
-        for &mi in &match_indices {
-            is_match_line.insert(mi);
-            let ctx_start = mi.saturating_sub(opts.before_context);
-            let ctx_end = (mi + opts.after_context + 1).min(lines.len());
-            for j in ctx_start..ctx_end {
-                printed.insert(j);
-            }
-        }
         for &li in &printed {
             if is_match_line.contains(&li) {
-                let mc = if opts.only_matching {
-                    re.find_iter(lines[li])
-                        .map(|m| m.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                } else {
-                    lines[li].to_string()
-                };
+                let mc = crate::matching::match_content(lines[li], re, opts.only_matching);
                 let col = re.find(lines[li]).map(|m| m.start() + 1);
                 let mut entry = serde_json::json!({
                     "type": "match",
@@ -706,14 +723,7 @@ fn search_file_matches(
         match_indices
             .iter()
             .map(|&mi| {
-                let mc = if opts.only_matching {
-                    re.find_iter(lines[mi])
-                        .map(|m| m.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                } else {
-                    lines[mi].to_string()
-                };
+                let mc = crate::matching::match_content(lines[mi], re, opts.only_matching);
                 let col = re.find(lines[mi]).map(|m| m.start() + 1);
                 let mut entry = serde_json::json!({
                     "type": "match",

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -127,7 +127,7 @@ fn write_index_files(
     root: &Path,
     paths: &[&str],
     inverted: &HashMap<u32, Vec<PostingEntry>>,
-    meta_override: Option<Box<dyn FnOnce(&mut IndexMeta)>>,
+    complete: Option<bool>,
 ) -> Result<()> {
     std::fs::create_dir_all(index_dir)?;
 
@@ -180,8 +180,8 @@ fn write_index_files(
         paths.len() as u64,
         sorted_trigrams.len() as u64,
     );
-    if let Some(f) = meta_override {
-        f(&mut meta);
+    if let Some(c) = complete {
+        meta.complete = c;
     }
     meta.save(index_dir)?;
 
@@ -198,15 +198,7 @@ pub fn write_index_from_snapshot(
     complete: bool,
 ) -> Result<()> {
     let borrowed: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
-    write_index_files(
-        index_dir,
-        root,
-        &borrowed,
-        inverted,
-        Some(Box::new(move |meta| {
-            meta.complete = complete;
-        })),
-    )
+    write_index_files(index_dir, root, &borrowed, inverted, Some(complete))
 }
 
 /// Internal: write v2 index with masks.

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -47,7 +47,7 @@ pub fn build_index(
     // 8KB read per file — we're already reading the full file anyway.
     eprintln!("Extracting trigrams...");
     let binary_skipped = std::sync::atomic::AtomicUsize::new(0);
-    let file_data: Vec<(String, Vec<(u32, TrigramMasks)>)> = walk
+    let file_data: Vec<(String, HashMap<u32, TrigramMasks>)> = walk
         .files
         .par_iter()
         .filter_map(|path| {
@@ -61,14 +61,8 @@ pub fn build_index(
                 .unwrap_or(path)
                 .to_string_lossy()
                 .replace('\\', "/");
-            // Extract trigrams with masks from both original and lowercased content
-            let mut tri_masks = trigram::extract_with_masks(&data);
-            let lower = data.to_ascii_lowercase();
-            if lower != data {
-                let lower_tris = trigram::extract_with_masks(&lower);
-                tri_masks.extend(lower_tris);
-            }
-            Some((rel, tri_masks))
+            let per_tri = trigram::extract_merged_masks(&data);
+            Some((rel, per_tri))
         })
         .collect();
     let extra_binary = binary_skipped.into_inner();
@@ -84,20 +78,11 @@ pub fn build_index(
     // trigram → Vec<(file_id, loc_mask, next_mask)>
     let mut inverted: HashMap<u32, Vec<PostingEntry>> = HashMap::new();
 
-    for (id, (path, tri_masks)) in file_data.iter().enumerate() {
+    for (id, (path, per_tri)) in file_data.iter().enumerate() {
         let file_id = id as u32;
         file_id_map.push((file_id, path.clone()));
 
-        // Merge masks per trigram for this file (a trigram may appear from
-        // both original and lowercase extraction)
-        let mut per_tri: HashMap<u32, TrigramMasks> = HashMap::new();
-        for &(tri, masks) in tri_masks {
-            let entry = per_tri.entry(tri).or_default();
-            entry.loc_mask |= masks.loc_mask;
-            entry.next_mask |= masks.next_mask;
-        }
-
-        for (tri, masks) in per_tri {
+        for (&tri, masks) in per_tri {
             inverted.entry(tri).or_default().push(PostingEntry {
                 file_id,
                 loc_mask: masks.loc_mask,
@@ -132,21 +117,24 @@ pub fn default_index_dir(root: &Path) -> std::path::PathBuf {
 /// Write the on-disk index from a pre-computed snapshot (paths + inverted index).
 /// This allows the caller to snapshot under a brief lock, then write without holding it.
 ///
-/// Preserves mask data (loc_mask/next_mask) from the snapshot so Bloom-filter
-/// optimizations survive flush cycles.
-pub fn write_index_from_snapshot(
-    root: &Path,
+/// Internal: write the on-disk index files (index.bin, lookup.bin, files.bin, meta.json).
+///
+/// Both `write_index_v2` and `write_index_from_snapshot` delegate to this
+/// function after preparing their parameters. `paths` provides the file
+/// list (IDs are assigned by position: 0, 1, 2, …).
+fn write_index_files(
     index_dir: &Path,
+    root: &Path,
     paths: &[String],
     inverted: &HashMap<u32, Vec<PostingEntry>>,
-    complete: bool,
+    meta_override: Option<Box<dyn FnOnce(&mut IndexMeta)>>,
 ) -> Result<()> {
     std::fs::create_dir_all(index_dir)?;
 
     let mut sorted_trigrams: Vec<u32> = inverted.keys().copied().collect();
     sorted_trigrams.sort_unstable();
 
-    // Write index.bin — v2 posting entries with masks preserved from snapshot.
+    // Write index.bin — v2 posting entries with masks
     let mut postings_file =
         std::io::BufWriter::new(std::fs::File::create(index_dir.join("index.bin"))?);
     let mut lookup_entries: Vec<LookupEntry> = Vec::with_capacity(sorted_trigrams.len());
@@ -185,17 +173,39 @@ pub fn write_index_from_snapshot(
     }
     files_file.flush()?;
 
-    // Write meta.json (version 2 for mask-aware format)
-    let root = std::fs::canonicalize(root)?;
-    let mut meta_obj = IndexMeta::new(
-        &root.to_string_lossy(),
+    // Write meta.json
+    let canon_root = std::fs::canonicalize(root)?;
+    let mut meta = IndexMeta::new(
+        &canon_root.to_string_lossy(),
         paths.len() as u64,
         sorted_trigrams.len() as u64,
     );
-    meta_obj.complete = complete;
-    meta_obj.save(index_dir)?;
+    if let Some(f) = meta_override {
+        f(&mut meta);
+    }
+    meta.save(index_dir)?;
 
     Ok(())
+}
+
+/// Preserves mask data (loc_mask/next_mask) from the snapshot so Bloom-filter
+/// optimizations survive flush cycles.
+pub fn write_index_from_snapshot(
+    root: &Path,
+    index_dir: &Path,
+    paths: &[String],
+    inverted: &HashMap<u32, Vec<PostingEntry>>,
+    complete: bool,
+) -> Result<()> {
+    write_index_files(
+        index_dir,
+        root,
+        paths,
+        inverted,
+        Some(Box::new(move |meta| {
+            meta.complete = complete;
+        })),
+    )
 }
 
 /// Internal: write v2 index with masks.
@@ -205,57 +215,12 @@ fn write_index_v2(
     file_id_map: &[(u32, String)],
     inverted: &HashMap<u32, Vec<PostingEntry>>,
 ) -> Result<()> {
-    let mut sorted_trigrams: Vec<u32> = inverted.keys().copied().collect();
-    sorted_trigrams.sort_unstable();
-
     eprintln!(
         "Writing index ({} trigrams, {} files)...",
-        sorted_trigrams.len(),
+        inverted.len(),
         file_id_map.len()
     );
 
-    let mut postings_file =
-        std::io::BufWriter::new(std::fs::File::create(index_dir.join("index.bin"))?);
-    let mut lookup_entries: Vec<LookupEntry> = Vec::with_capacity(sorted_trigrams.len());
-    let mut offset: u64 = 0;
-
-    for &tri in &sorted_trigrams {
-        let posting_list = inverted.get(&tri).unwrap();
-        let length = posting_list.len() as u32;
-
-        lookup_entries.push(LookupEntry {
-            trigram: tri,
-            offset,
-            length,
-        });
-
-        for entry in posting_list {
-            postings_file.write_all(&entry.encode())?;
-        }
-        offset += length as u64 * ondisk::POSTING_ENTRY_SIZE as u64;
-    }
-    postings_file.flush()?;
-
-    let mut lookup_file =
-        std::io::BufWriter::new(std::fs::File::create(index_dir.join("lookup.bin"))?);
-    for entry in &lookup_entries {
-        lookup_file.write_all(&entry.encode())?;
-    }
-    lookup_file.flush()?;
-
-    let mut files_file =
-        std::io::BufWriter::new(std::fs::File::create(index_dir.join("files.bin"))?);
-    for (id, path) in file_id_map {
-        files_file.write_all(&ondisk::encode_file_entry(*id, path)?)?;
-    }
-    files_file.flush()?;
-
-    let meta = IndexMeta::new(
-        &root.to_string_lossy(),
-        file_id_map.len() as u64,
-        sorted_trigrams.len() as u64,
-    );
-    meta.save(index_dir)?;
-
-    Ok(())
+    let paths: Vec<String> = file_id_map.iter().map(|(_, p)| p.clone()).collect();
+    write_index_files(index_dir, root, &paths, inverted, None)
 }

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -125,7 +125,7 @@ pub fn default_index_dir(root: &Path) -> std::path::PathBuf {
 fn write_index_files(
     index_dir: &Path,
     root: &Path,
-    paths: &[String],
+    paths: &[&str],
     inverted: &HashMap<u32, Vec<PostingEntry>>,
     meta_override: Option<Box<dyn FnOnce(&mut IndexMeta)>>,
 ) -> Result<()> {
@@ -197,10 +197,11 @@ pub fn write_index_from_snapshot(
     inverted: &HashMap<u32, Vec<PostingEntry>>,
     complete: bool,
 ) -> Result<()> {
+    let borrowed: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
     write_index_files(
         index_dir,
         root,
-        paths,
+        &borrowed,
         inverted,
         Some(Box::new(move |meta| {
             meta.complete = complete;
@@ -221,6 +222,6 @@ fn write_index_v2(
         file_id_map.len()
     );
 
-    let paths: Vec<String> = file_id_map.iter().map(|(_, p)| p.clone()).collect();
+    let paths: Vec<&str> = file_id_map.iter().map(|(_, p)| p.as_str()).collect();
     write_index_files(index_dir, root, &paths, inverted, None)
 }

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -122,10 +122,10 @@ pub fn default_index_dir(root: &Path) -> std::path::PathBuf {
 /// Both `write_index_v2` and `write_index_from_snapshot` delegate to this
 /// function after preparing their parameters. `paths` provides the file
 /// list (IDs are assigned by position: 0, 1, 2, …).
-fn write_index_files(
+fn write_index_files<S: AsRef<str>>(
     index_dir: &Path,
     root: &Path,
-    paths: &[&str],
+    paths: &[S],
     inverted: &HashMap<u32, Vec<PostingEntry>>,
     complete: Option<bool>,
 ) -> Result<()> {
@@ -169,7 +169,7 @@ fn write_index_files(
     let mut files_file =
         std::io::BufWriter::new(std::fs::File::create(index_dir.join("files.bin"))?);
     for (id, path) in paths.iter().enumerate() {
-        files_file.write_all(&ondisk::encode_file_entry(id as u32, path)?)?;
+        files_file.write_all(&ondisk::encode_file_entry(id as u32, path.as_ref())?)?;
     }
     files_file.flush()?;
 
@@ -197,8 +197,7 @@ pub fn write_index_from_snapshot(
     inverted: &HashMap<u32, Vec<PostingEntry>>,
     complete: bool,
 ) -> Result<()> {
-    let borrowed: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
-    write_index_files(index_dir, root, &borrowed, inverted, Some(complete))
+    write_index_files(index_dir, root, paths, inverted, Some(complete))
 }
 
 /// Internal: write v2 index with masks.

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -97,20 +97,23 @@ impl HybridIndex {
         Ok(())
     }
 
+    /// Check whether a reader file ID is still active (not deleted or
+    /// overridden by the live overlay).
+    fn reader_entry_active(&self, reader: &IndexReader, file_id: u32) -> bool {
+        if let Some(path) = reader.file_path(file_id) {
+            !self.live.is_deleted(path) && !self.live_has_path(path)
+        } else {
+            false
+        }
+    }
+
     /// Look up candidate file IDs for a trigram, merging reader + overlay.
     pub fn lookup_trigram(&self, trigram: u32) -> Vec<u32> {
         let reader = self.reader();
         let mut reader_ids = reader.lookup_trigram(trigram);
         let live_ids = self.live.lookup_trigram(trigram);
 
-        // Filter out reader IDs for files that are deleted or overridden in overlay
-        reader_ids.retain(|&fid| {
-            if let Some(path) = reader.file_path(fid) {
-                !self.live.is_deleted(path) && !self.live_has_path(path)
-            } else {
-                false
-            }
-        });
+        reader_ids.retain(|&fid| self.reader_entry_active(&reader, fid));
 
         reader_ids.extend(live_ids);
         reader_ids
@@ -122,13 +125,7 @@ impl HybridIndex {
         let mut reader_entries = reader.lookup_trigram_with_masks(trigram);
         let live_entries = self.live.lookup_trigram_with_masks(trigram);
 
-        reader_entries.retain(|e| {
-            if let Some(path) = reader.file_path(e.file_id) {
-                !self.live.is_deleted(path) && !self.live_has_path(path)
-            } else {
-                false
-            }
-        });
+        reader_entries.retain(|e| self.reader_entry_active(&reader, e.file_id));
 
         reader_entries.extend(live_entries);
         reader_entries
@@ -152,13 +149,7 @@ impl HybridIndex {
         let mut ids: Vec<u32> = reader
             .all_file_ids()
             .into_iter()
-            .filter(|&fid| {
-                if let Some(path) = reader.file_path(fid) {
-                    !self.live.is_deleted(path) && !self.live_has_path(path)
-                } else {
-                    false
-                }
-            })
+            .filter(|&fid| self.reader_entry_active(&reader, fid))
             .collect();
         ids.extend(self.live.all_file_ids());
         ids
@@ -201,13 +192,7 @@ impl HybridIndex {
         let mut ids: Vec<u32> = reader
             .all_file_ids()
             .into_iter()
-            .filter(|&fid| {
-                if let Some(path) = reader.file_path(fid) {
-                    !self.live.is_deleted(path) && !self.live_has_path(path)
-                } else {
-                    false
-                }
-            })
+            .filter(|&fid| self.reader_entry_active(reader, fid))
             .collect();
         ids.extend(self.live.all_file_ids());
         ids
@@ -240,13 +225,7 @@ impl HybridIndex {
         let mut reader_ids = reader.lookup_trigram(trigram);
         let live_ids = self.live.lookup_trigram(trigram);
 
-        reader_ids.retain(|&fid| {
-            if let Some(path) = reader.file_path(fid) {
-                !self.live.is_deleted(path) && !self.live_has_path(path)
-            } else {
-                false
-            }
-        });
+        reader_ids.retain(|&fid| self.reader_entry_active(reader, fid));
 
         reader_ids.extend(live_ids);
         reader_ids
@@ -262,13 +241,7 @@ impl HybridIndex {
         let mut reader_entries = reader.lookup_trigram_with_masks(trigram);
         let live_entries = self.live.lookup_trigram_with_masks(trigram);
 
-        reader_entries.retain(|e| {
-            if let Some(path) = reader.file_path(e.file_id) {
-                !self.live.is_deleted(path) && !self.live_has_path(path)
-            } else {
-                false
-            }
-        });
+        reader_entries.retain(|e| self.reader_entry_active(reader, e.file_id));
 
         reader_entries.extend(live_entries);
         reader_entries

--- a/tgrep-core/src/live.rs
+++ b/tgrep-core/src/live.rs
@@ -73,29 +73,7 @@ impl LiveIndex {
     /// (e.g. the file watcher) can do the heavy work without blocking
     /// concurrent searches.
     pub fn compute_trigram_masks(content: &[u8]) -> HashMap<u32, trigram::TrigramMasks> {
-        let tri_masks = trigram::extract_with_masks(content);
-
-        let mut per_tri: HashMap<u32, trigram::TrigramMasks> = HashMap::new();
-        for &(tri, m) in tri_masks.iter() {
-            let entry = per_tri.entry(tri).or_default();
-            entry.loc_mask |= m.loc_mask;
-            entry.next_mask |= m.next_mask;
-        }
-
-        // Skip the lowercase pass when content is already ASCII-lowercase —
-        // it would just re-emit the same trigrams. Mirrors the on-disk
-        // builder's optimization so watcher-driven reindexes don't pay for
-        // a redundant full scan + allocation on lowercase-heavy files.
-        let lower = content.to_ascii_lowercase();
-        if lower != content {
-            let lower_tri_masks = trigram::extract_with_masks(&lower);
-            for &(tri, m) in lower_tri_masks.iter() {
-                let entry = per_tri.entry(tri).or_default();
-                entry.loc_mask |= m.loc_mask;
-                entry.next_mask |= m.next_mask;
-            }
-        }
-        per_tri
+        trigram::extract_merged_masks(content)
     }
 
     /// Commit a pre-computed set of (trigram, masks) entries for a file.

--- a/tgrep-core/src/trigram.rs
+++ b/tgrep-core/src/trigram.rs
@@ -118,6 +118,32 @@ pub fn check_next_byte(masks: &TrigramMasks, next_byte: u8) -> bool {
     masks.next_mask & next_bit(next_byte) != 0
 }
 
+/// Extract trigrams with masks from both original and lowercased content,
+/// merging masks per trigram. This is the standard extraction used by both
+/// the on-disk builder and the live index overlay.
+pub fn extract_merged_masks(content: &[u8]) -> HashMap<TrigramHash, TrigramMasks> {
+    let tri_masks = extract_with_masks(content);
+
+    let mut per_tri: HashMap<TrigramHash, TrigramMasks> = HashMap::new();
+    for &(tri, m) in tri_masks.iter() {
+        let entry = per_tri.entry(tri).or_default();
+        entry.loc_mask |= m.loc_mask;
+        entry.next_mask |= m.next_mask;
+    }
+
+    let lower = content.to_ascii_lowercase();
+    if lower != content {
+        let lower_tri_masks = extract_with_masks(&lower);
+        for &(tri, m) in lower_tri_masks.iter() {
+            let entry = per_tri.entry(tri).or_default();
+            entry.loc_mask |= m.loc_mask;
+            entry.next_mask |= m.next_mask;
+        }
+    }
+
+    per_tri
+}
+
 /// Extract trigrams from a string pattern (for query planning).
 pub fn extract_from_literal(s: &str) -> Vec<TrigramHash> {
     extract(s.as_bytes())

--- a/tgrep-core/src/trigram.rs
+++ b/tgrep-core/src/trigram.rs
@@ -239,4 +239,68 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_extract_merged_masks_ors_across_cases() {
+        // "Hello" produces trigrams for original ("Hel","ell","llo") and
+        // lowercase ("hel","ell","llo"). "ell"/"llo" appear in both passes
+        // so their masks should be OR'd together. The lowercase pass adds
+        // the new trigram "hel".
+        let merged = extract_merged_masks(b"Hello");
+
+        // "hel" only comes from lowercase pass
+        let hel = hash(b'h', b'e', b'l');
+        assert!(merged.contains_key(&hel), "should contain lowercase trigram 'hel'");
+
+        // "Hel" only comes from original pass
+        let big_hel = hash(b'H', b'e', b'l');
+        assert!(
+            merged.contains_key(&big_hel),
+            "should contain original trigram 'Hel'"
+        );
+
+        // "ell" appears in both passes — masks should be superset
+        let ell = hash(b'e', b'l', b'l');
+        let merged_ell = merged.get(&ell).unwrap();
+
+        let orig_masks = extract_with_masks(b"Hello");
+        let orig_ell = orig_masks
+            .iter()
+            .find(|(h, _)| *h == ell)
+            .map(|(_, m)| *m)
+            .unwrap();
+
+        let lower_masks = extract_with_masks(b"hello");
+        let lower_ell = lower_masks
+            .iter()
+            .find(|(h, _)| *h == ell)
+            .map(|(_, m)| *m)
+            .unwrap();
+
+        assert_eq!(
+            merged_ell.loc_mask,
+            orig_ell.loc_mask | lower_ell.loc_mask,
+            "loc_mask should be OR of both passes"
+        );
+        assert_eq!(
+            merged_ell.next_mask,
+            orig_ell.next_mask | lower_ell.next_mask,
+            "next_mask should be OR of both passes"
+        );
+    }
+
+    #[test]
+    fn test_extract_merged_masks_all_lowercase_no_dup() {
+        // All-lowercase input: lowercase pass should be skipped (content == lower).
+        // Result should match a single extract_with_masks pass.
+        let merged = extract_merged_masks(b"abcde");
+        let single = extract_with_masks(b"abcde");
+
+        assert_eq!(merged.len(), single.len());
+        for &(tri, masks) in &single {
+            let m = merged.get(&tri).unwrap();
+            assert_eq!(m.loc_mask, masks.loc_mask);
+            assert_eq!(m.next_mask, masks.next_mask);
+        }
+    }
 }

--- a/tgrep-core/src/trigram.rs
+++ b/tgrep-core/src/trigram.rs
@@ -124,11 +124,9 @@ pub fn check_next_byte(masks: &TrigramMasks, next_byte: u8) -> bool {
 pub fn extract_merged_masks(content: &[u8]) -> HashMap<TrigramHash, TrigramMasks> {
     let tri_masks = extract_with_masks(content);
 
-    let mut per_tri: HashMap<TrigramHash, TrigramMasks> = HashMap::new();
-    for &(tri, m) in tri_masks.iter() {
-        let entry = per_tri.entry(tri).or_default();
-        entry.loc_mask |= m.loc_mask;
-        entry.next_mask |= m.next_mask;
+    let mut per_tri: HashMap<TrigramHash, TrigramMasks> = HashMap::with_capacity(tri_masks.len());
+    for (tri, m) in tri_masks {
+        per_tri.insert(tri, m);
     }
 
     let lower = content.to_ascii_lowercase();
@@ -250,7 +248,10 @@ mod tests {
 
         // "hel" only comes from lowercase pass
         let hel = hash(b'h', b'e', b'l');
-        assert!(merged.contains_key(&hel), "should contain lowercase trigram 'hel'");
+        assert!(
+            merged.contains_key(&hel),
+            "should contain lowercase trigram 'hel'"
+        );
 
         // "Hel" only comes from original pass
         let big_hel = hash(b'H', b'e', b'l');

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -15,6 +15,20 @@ const BINARY_EXTENSIONS: &[&str] = &[
     "sqlite", "sqlite3",
 ];
 
+/// Number of parallel walker threads (capped at 12 to avoid diminishing returns).
+fn walker_thread_count() -> usize {
+    std::thread::available_parallelism().map_or(4, |n| n.get().min(12))
+}
+
+/// Check if a directory entry should be skipped based on exclude list.
+fn should_skip_dir(entry: &ignore::DirEntry, exclude_dirs: &[String]) -> bool {
+    !exclude_dirs.is_empty()
+        && entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| exclude_dirs.iter().any(|d| d == name))
+}
+
 pub struct WalkResult {
     pub files: Vec<PathBuf>,
     pub skipped_binary: usize,
@@ -58,7 +72,7 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
         .git_ignore(!opts.no_ignore)
         .git_global(!opts.no_ignore)
         .git_exclude(!opts.no_ignore)
-        .threads(std::thread::available_parallelism().map_or(4, |n| n.get().min(12)))
+        .threads(walker_thread_count())
         .build_parallel();
 
     walker.run(|| {
@@ -75,12 +89,8 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
                 }
             };
 
-            // Skip excluded directories and their subtrees
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                if let Some(name) = entry.file_name().to_str()
-                    && !exclude.is_empty()
-                    && exclude.iter().any(|d| d == name)
-                {
+                if should_skip_dir(&entry, &exclude) {
                     return ignore::WalkState::Skip;
                 }
                 return ignore::WalkState::Continue;
@@ -136,7 +146,7 @@ pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String]) -> Vec<FileMeta>
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
-        .threads(std::thread::available_parallelism().map_or(4, |n| n.get().min(12)))
+        .threads(walker_thread_count())
         .build_parallel();
 
     walker.run(|| {
@@ -149,10 +159,7 @@ pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String]) -> Vec<FileMeta>
             };
 
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                if let Some(name) = entry.file_name().to_str()
-                    && !exclude.is_empty()
-                    && exclude.iter().any(|d| d == name)
-                {
+                if should_skip_dir(&entry, &exclude) {
                     return ignore::WalkState::Skip;
                 }
                 return ignore::WalkState::Continue;


### PR DESCRIPTION
## Summary

Consolidates code duplication and improves organization across the codebase, addressing 7 of 8 refactoring items from issue #77.

## Changes

### R1: Shared matching module
- New `tgrep-cli/src/matching.rs` with `find_match_indices()`, `expand_context_window()`, `match_content()`
- Both `serve.rs` and `search.rs` now delegate to this shared module instead of duplicating ~200 lines of matching logic

### R2: Builder index-writing helper
- Extracted `write_index_files()` in `builder.rs`, eliminating duplicate index-writing logic between `write_index_v2` and `write_index_from_snapshot`

### R3: Trigram extraction consolidation
- Added `extract_merged_masks()` in `trigram.rs` — consolidates the original+lowercase+merge pattern used by both builder and live index
- `extract()` keeps its own optimized implementation (avoids HashMap/mask overhead in hot paths)

### R4: Hybrid filter predicate
- Extracted `reader_entry_active()` predicate in `hybrid.rs`, replacing 6 duplicate filter closures across lookup functions

### R5: Walker helpers
- Extracted `walker_thread_count()` and `should_skip_dir()` in `walker.rs`, shared by both `walk_dir` and `walk_file_metadata`

### R6: handle_search decomposition
- Extracted `SearchRequest` struct and `parse_search_params()` function from the ~70-line param parsing block in `handle_search()`

### R7: Lock ordering documentation
- Added lock hierarchy comment on `ServerState` documenting acquisition order: `snapshot_gate > publish_lock > index > cache > file_stamps`

### R8: Skipped
- 5 HashMaps in `LiveIndex` serve genuinely different lookup patterns (trigram→fileIDs, (trigram,file)→masks, fileID→path, path→fileID, deleted paths) — this is multiple indexes over the same logical data, not accidental duplication

## Impact
- **Net -14 lines** (263 insertions, 277 deletions)
- 9 files changed across `tgrep-core` and `tgrep-cli`
- All ~110 tests pass

Fixes #77