### PR TITLE
Fix tgrep ripgrep compatibility issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +235,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -795,6 +821,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "fancy-regex",
  "fs2",
  "globset",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ simultaneously.
 
 ```bash
 tgrep "pattern" .                 # basic regex search
+tgrep "pattern" file1.rs file2.rs # search multiple files/paths
 tgrep "TODO|FIXME" .              # alternations
+tgrep '\w+(?!_test)' .            # PCRE-style lookahead fallback
 tgrep "error" . -i                # case-insensitive
 tgrep "error" . -S                # smart-case (auto if all lowercase)
 tgrep -F "Vec<T>" .               # literal string
@@ -131,6 +133,7 @@ tgrep "pattern" . -L              # files that DON'T match
 tgrep "pattern" . --no-filename   # suppress filenames
 tgrep "pattern" . -N              # suppress line numbers
 tgrep --files .                   # list searchable files
+tgrep --files src/main.rs         # list a single file if searchable
 tgrep --files -t rust .           # list Rust files only
 tgrep --type-list                 # show all file types
 ```

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4", features = ["derive"] }
 notify = "7"
 rayon = "1"
 regex = "1"
+fancy-regex = "0.14"
 lru = "0.16.3"
 fs2 = "0.4.3"
 globset = "0.4.18"

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -34,9 +34,9 @@ struct Cli {
     #[arg(global = false)]
     pattern: Option<String>,
 
-    /// Root directory to search.
-    #[arg(global = false, default_value = ".")]
-    path: PathBuf,
+    /// Root directories or files to search.
+    #[arg(global = false, value_name = "PATH", num_args = 0..)]
+    paths: Vec<String>,
 
     // ── Matching ──────────────────────────────────────
     /// Case-insensitive matching.
@@ -235,9 +235,9 @@ enum Command {
         /// The regex pattern to search for.
         pattern: String,
 
-        /// Root directory to search.
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Root directories or files to search.
+        #[arg(value_name = "PATH", num_args = 0..)]
+        paths: Vec<String>,
     },
 
     /// Show index and server status.
@@ -325,16 +325,16 @@ fn main() {
         }) => serve::run(&path, cli.index_path.as_deref(), no_watch, &exclude),
         Some(Command::Search {
             ref pattern,
-            ref path,
-        }) => run_search(&cli, pattern.clone(), path),
+            ref paths,
+        }) => run_search(&cli, pattern.clone(), paths),
         Some(Command::Status { path }) => status::run(&path, cli.index_path.as_deref()),
         Some(Command::CountFiles { path }) => walkcount::run(&path, cli.hidden, cli.no_ignore),
         None => {
             if cli.list_files {
                 let opts = cli.build_search_opts(String::new());
-                search::list_files(&cli.path, &opts)
+                list_files(&cli.paths, &opts)
             } else if let Some(pattern) = cli.pattern.clone() {
-                run_search(&cli, pattern, &cli.path)
+                run_search(&cli, pattern, &cli.paths)
             } else {
                 eprintln!("Usage: tgrep <pattern> [path]");
                 eprintln!("       tgrep index [path]");
@@ -352,14 +352,69 @@ fn main() {
     }
 }
 
-fn run_search(cli: &Cli, pattern: String, path: &std::path::Path) -> anyhow::Result<()> {
+fn normalize_search_paths(paths: &[String]) -> Vec<PathBuf> {
+    if paths.is_empty() {
+        return vec![PathBuf::from(".")];
+    }
+
+    paths
+        .iter()
+        .map(|path| {
+            let mut trimmed = path.trim();
+            loop {
+                let unquoted = trimmed
+                    .strip_prefix('"')
+                    .and_then(|s| s.strip_suffix('"'))
+                    .or_else(|| {
+                        trimmed
+                            .strip_prefix('\'')
+                            .and_then(|s| s.strip_suffix('\''))
+                    });
+                match unquoted {
+                    Some(inner) => trimmed = inner.trim(),
+                    None => break,
+                }
+            }
+            PathBuf::from(trimmed)
+        })
+        .collect()
+}
+
+fn list_files(paths: &[String], opts: &search::SearchOptions) -> anyhow::Result<()> {
+    for path in normalize_search_paths(paths) {
+        if !path.exists() {
+            continue;
+        }
+        search::list_files(&path, opts)?;
+    }
+    Ok(())
+}
+
+fn run_search(cli: &Cli, pattern: String, paths: &[String]) -> anyhow::Result<()> {
     let opts = cli.build_search_opts(pattern);
-    match search::run(path, cli.index_path.as_deref(), &opts) {
-        Ok(true) => process::exit(0),
-        Ok(false) => process::exit(1),
-        Err(e) => {
-            eprintln!("tgrep: {e}");
-            process::exit(2);
+    let mut had_matches = false;
+
+    for path in normalize_search_paths(paths) {
+        if !path.exists() {
+            continue;
+        }
+        match search::run(&path, cli.index_path.as_deref(), &opts) {
+            Ok(true) => {
+                had_matches = true;
+                if opts.quiet {
+                    process::exit(0);
+                }
+            }
+            Ok(false) => {}
+            Err(e) => {
+                eprintln!("tgrep: {e}");
+                process::exit(2);
+            }
         }
     }
+
+    if had_matches {
+        process::exit(0);
+    }
+    process::exit(1);
 }

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -332,14 +332,16 @@ fn main() {
         None => {
             if cli.list_files {
                 let opts = cli.build_search_opts(String::new());
-                list_files(&cli.paths, &opts)
+                let paths = list_files_paths(&cli);
+                list_files(&paths, &opts)
             } else if let Some(pattern) = cli.pattern.clone() {
                 run_search(&cli, pattern, &cli.paths)
             } else {
-                eprintln!("Usage: tgrep <pattern> [path]");
+                eprintln!("Usage: tgrep <pattern> [PATH ...]");
                 eprintln!("       tgrep index [path]");
                 eprintln!("       tgrep serve [path]");
                 eprintln!("       tgrep status [path]");
+                eprintln!("Search defaults to the current directory when no path is provided.");
                 eprintln!("Run `tgrep --help` for full usage.");
                 process::exit(2);
             }
@@ -378,6 +380,15 @@ fn normalize_search_paths(paths: &[String]) -> Vec<PathBuf> {
             PathBuf::from(trimmed)
         })
         .collect()
+}
+
+fn list_files_paths(cli: &Cli) -> Vec<String> {
+    let mut paths = Vec::new();
+    if let Some(pattern) = cli.pattern.clone() {
+        paths.push(pattern);
+    }
+    paths.extend(cli.paths.iter().cloned());
+    paths
 }
 
 fn list_files(paths: &[String], opts: &search::SearchOptions) -> anyhow::Result<()> {

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -2,33 +2,6 @@
 //! search path (search.rs). Extracts the core line-matching and context-window
 //! algorithms so both callers avoid duplicating them.
 
-/// Find indices of matching lines in `lines`, respecting `invert_match` and
-/// `max_count`. Returns the indices into the `lines` slice.
-pub fn find_match_indices(
-    lines: &[&str],
-    re: &regex::Regex,
-    invert_match: bool,
-    max_count: Option<usize>,
-) -> Vec<usize> {
-    if max_count == Some(0) {
-        return Vec::new();
-    }
-    let mut indices = Vec::new();
-    for (i, line) in lines.iter().enumerate() {
-        let is_match = re.is_match(line);
-        let include = if invert_match { !is_match } else { is_match };
-        if include {
-            indices.push(i);
-            if let Some(max) = max_count
-                && indices.len() >= max
-            {
-                break;
-            }
-        }
-    }
-    indices
-}
-
 /// Expand match indices into the full set of line indices to display,
 /// including context lines. Returns a sorted, deduplicated set.
 pub fn expand_context_window(

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -166,6 +166,21 @@ pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
         Err(e) => return Err(e.into()),
     };
     let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob)?;
+
+    if root.is_file() {
+        let rel_path = root
+            .file_name()
+            .map(|name| name.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|| root.to_string_lossy().replace('\\', "/"));
+
+        if passes_filters(&rel_path, &glob_filter, &opts.file_type) {
+            let mut writer = OutputWriter::new(opts.make_output_config());
+            writer.write_file(&rel_path)?;
+            writer.flush()?;
+        }
+        return Ok(());
+    }
+
     let walk = walker::walk_dir(
         &root,
         &walker::WalkOptions {

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -18,6 +18,57 @@ use tgrep_core::walker;
 use crate::output::{ColorMode, ContextLine, Match, OutputConfig, OutputWriter};
 use crate::serve::ServerInfo;
 
+enum SearchMatcher {
+    Standard(regex::Regex),
+    Fancy(fancy_regex::Regex),
+}
+
+impl SearchMatcher {
+    fn is_standard(&self) -> bool {
+        matches!(self, SearchMatcher::Standard(_))
+    }
+
+    fn is_match(&self, line: &str) -> Result<bool> {
+        match self {
+            SearchMatcher::Standard(re) => Ok(re.is_match(line)),
+            SearchMatcher::Fancy(re) => re
+                .is_match(line)
+                .map_err(|e| anyhow::anyhow!("regex match error: {e}")),
+        }
+    }
+
+    fn find_start(&self, line: &str) -> Result<Option<usize>> {
+        match self {
+            SearchMatcher::Standard(re) => Ok(re.find(line).map(|m| m.start())),
+            SearchMatcher::Fancy(re) => re
+                .find(line)
+                .map(|m| m.map(|m| m.start()))
+                .map_err(|e| anyhow::anyhow!("regex match error: {e}")),
+        }
+    }
+
+    fn match_content(&self, line: &str, only_matching: bool) -> Result<String> {
+        if !only_matching {
+            return Ok(line.to_string());
+        }
+
+        match self {
+            SearchMatcher::Standard(re) => Ok(crate::matching::match_content(line, re, true)),
+            SearchMatcher::Fancy(re) => {
+                let mut matches = Vec::new();
+                for m in re.find_iter(line) {
+                    matches.push(
+                        m.map_err(|e| anyhow::anyhow!("regex match error: {e}"))?
+                            .as_str()
+                            .to_string(),
+                    );
+                }
+                Ok(matches.join("\n"))
+            }
+        }
+    }
+}
+
 pub struct SearchOptions {
     pub pattern: String,
     pub extra_patterns: Vec<String>,
@@ -109,7 +160,11 @@ impl SearchOptions {
 
 /// List files that would be searched (--files mode).
 pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
-    let root = std::fs::canonicalize(root)?;
+    let root = match std::fs::canonicalize(root) {
+        Ok(root) => root,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
     let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob)?;
     let walk = walker::walk_dir(
         &root,
@@ -143,7 +198,11 @@ pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
 }
 
 pub fn run(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) -> Result<bool> {
-    let root = std::fs::canonicalize(root)?;
+    let root = match std::fs::canonicalize(root) {
+        Ok(root) => root,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
     let index_dir = index_path
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| builder::default_index_dir(&root));
@@ -299,7 +358,7 @@ fn search_local_index(
     let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob)?;
 
     let all_patterns = opts.all_patterns()?;
-    let re = build_combined_regex(
+    let matcher = build_search_matcher(
         &all_patterns,
         ci,
         opts.fixed_string,
@@ -307,8 +366,10 @@ fn search_local_index(
         opts.multiline,
     )?;
 
-    // Build query plan from primary pattern
-    let plan = if opts.fixed_string {
+    // Build query plan from primary pattern when the accelerated regex engine supports it.
+    let plan = if !matcher.is_standard() {
+        QueryPlan::MatchAll
+    } else if opts.fixed_string {
         query::build_literal_plan(&opts.pattern, ci)
     } else {
         query::build_query_plan(&opts.pattern, ci).map_err(|e| anyhow::anyhow!("{e}"))?
@@ -350,7 +411,7 @@ fn search_local_index(
             Err(_) => continue,
         };
 
-        let matched = search_file_content(&content, &re, &rel_path, opts, &mut writer)?;
+        let matched = search_file_content(&content, &matcher, &rel_path, opts, &mut writer)?;
         if matched {
             if !opts.files_without_match {
                 had_matches = true;
@@ -403,7 +464,7 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
     );
 
     let all_patterns = opts.all_patterns()?;
-    let re = build_combined_regex(
+    let matcher = build_search_matcher(
         &all_patterns,
         ci,
         opts.fixed_string,
@@ -437,7 +498,7 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
             Err(_) => continue,
         };
 
-        let matched = search_file_content(&content, &re, &rel_path, opts, &mut writer)?;
+        let matched = search_file_content(&content, &matcher, &rel_path, opts, &mut writer)?;
         if matched {
             if !opts.files_without_match {
                 had_matches = true;
@@ -473,7 +534,7 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
 /// Returns true if any matches were found.
 fn search_file_content(
     content: &str,
-    re: &regex::Regex,
+    matcher: &SearchMatcher,
     rel_path: &str,
     opts: &SearchOptions,
     writer: &mut OutputWriter,
@@ -489,8 +550,7 @@ fn search_file_content(
     } else {
         opts.max_count
     };
-    let match_indices =
-        crate::matching::find_match_indices(&lines, re, opts.invert_match, effective_max);
+    let match_indices = find_match_indices(&lines, matcher, opts.invert_match, effective_max)?;
 
     if match_indices.is_empty() {
         return Ok(false);
@@ -528,8 +588,8 @@ fn search_file_content(
             }
 
             if is_match_line.contains(&li) {
-                let content = crate::matching::match_content(lines[li], re, opts.only_matching);
-                let column = re.find(lines[li]).map(|m| m.start() + 1);
+                let content = matcher.match_content(lines[li], opts.only_matching)?;
+                let column = matcher.find_start(lines[li])?.map(|start| start + 1);
                 writer.write_match(&Match {
                     file: rel_path.to_string(),
                     line_number: li + 1,
@@ -547,8 +607,8 @@ fn search_file_content(
         }
     } else {
         for &mi in &match_indices {
-            let content = crate::matching::match_content(lines[mi], re, opts.only_matching);
-            let column = re.find(lines[mi]).map(|m| m.start() + 1);
+            let content = matcher.match_content(lines[mi], opts.only_matching)?;
+            let column = matcher.find_start(lines[mi])?.map(|start| start + 1);
             writer.write_match(&Match {
                 file: rel_path.to_string(),
                 line_number: mi + 1,
@@ -568,7 +628,50 @@ pub fn build_combined_regex(
     word_boundary: bool,
     multiline: bool,
 ) -> Result<regex::Regex> {
-    let combined = if patterns.len() == 1 {
+    let combined = combine_patterns(patterns, fixed_string, word_boundary);
+
+    build_regex(&combined, case_insensitive, multiline)
+}
+
+fn build_search_matcher(
+    patterns: &[String],
+    case_insensitive: bool,
+    fixed_string: bool,
+    word_boundary: bool,
+    multiline: bool,
+) -> Result<SearchMatcher> {
+    let combined = combine_patterns(patterns, fixed_string, word_boundary);
+
+    match build_regex(&combined, case_insensitive, multiline) {
+        Ok(re) => Ok(SearchMatcher::Standard(re)),
+        Err(regex_err) if !fixed_string => {
+            let mut flags = String::new();
+            if case_insensitive {
+                flags.push('i');
+            }
+            if multiline {
+                flags.push('m');
+                flags.push('s');
+            }
+            let fancy_pattern = if flags.is_empty() {
+                combined
+            } else {
+                format!("(?{flags}:{combined})")
+            };
+            fancy_regex::Regex::new(&fancy_pattern)
+                .map(SearchMatcher::Fancy)
+                .map_err(|fancy_err| {
+                    anyhow::anyhow!(
+                        "regex error: {regex_err}; PCRE-style fallback failed: {fancy_err}"
+                    )
+                })
+        }
+        Err(regex_err) => Err(regex_err),
+    }
+}
+
+fn combine_patterns(patterns: &[String], fixed_string: bool, word_boundary: bool) -> String {
+    if patterns.len() == 1 {
         let mut p = if fixed_string {
             regex::escape(&patterns[0])
         } else {
@@ -594,9 +697,11 @@ pub fn build_combined_regex(
             })
             .collect();
         format!("(?:{})", parts.join("|"))
-    };
+    }
+}
 
-    RegexBuilder::new(&combined)
+fn build_regex(combined: &str, case_insensitive: bool, multiline: bool) -> Result<regex::Regex> {
+    RegexBuilder::new(combined)
         .case_insensitive(case_insensitive)
         .multi_line(multiline)
         .dot_matches_new_line(multiline)
@@ -605,6 +710,31 @@ pub fn build_combined_regex(
         .nest_limit(250)
         .build()
         .map_err(|e| anyhow::anyhow!("regex error: {e}"))
+}
+
+fn find_match_indices(
+    lines: &[&str],
+    matcher: &SearchMatcher,
+    invert_match: bool,
+    max_count: Option<usize>,
+) -> Result<Vec<usize>> {
+    if max_count == Some(0) {
+        return Ok(Vec::new());
+    }
+    let mut indices = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        let is_match = matcher.is_match(line)?;
+        let include = if invert_match { !is_match } else { is_match };
+        if include {
+            indices.push(i);
+            if let Some(max) = max_count
+                && indices.len() >= max
+            {
+                break;
+            }
+        }
+    }
+    Ok(indices)
 }
 
 fn passes_filters(

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -18,17 +18,17 @@ use tgrep_core::walker;
 use crate::output::{ColorMode, ContextLine, Match, OutputConfig, OutputWriter};
 use crate::serve::ServerInfo;
 
-enum SearchMatcher {
+pub(crate) enum SearchMatcher {
     Standard(regex::Regex),
     Fancy(fancy_regex::Regex),
 }
 
 impl SearchMatcher {
-    fn is_standard(&self) -> bool {
+    pub(crate) fn is_standard(&self) -> bool {
         matches!(self, SearchMatcher::Standard(_))
     }
 
-    fn is_match(&self, line: &str) -> Result<bool> {
+    pub(crate) fn is_match(&self, line: &str) -> Result<bool> {
         match self {
             SearchMatcher::Standard(re) => Ok(re.is_match(line)),
             SearchMatcher::Fancy(re) => re
@@ -37,7 +37,7 @@ impl SearchMatcher {
         }
     }
 
-    fn find_start(&self, line: &str) -> Result<Option<usize>> {
+    pub(crate) fn find_start(&self, line: &str) -> Result<Option<usize>> {
         match self {
             SearchMatcher::Standard(re) => Ok(re.find(line).map(|m| m.start())),
             SearchMatcher::Fancy(re) => re
@@ -47,7 +47,7 @@ impl SearchMatcher {
         }
     }
 
-    fn match_content(&self, line: &str, only_matching: bool) -> Result<String> {
+    pub(crate) fn match_content(&self, line: &str, only_matching: bool) -> Result<String> {
         if !only_matching {
             return Ok(line.to_string());
         }
@@ -168,10 +168,7 @@ pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
     let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob)?;
 
     if root.is_file() {
-        let rel_path = root
-            .file_name()
-            .map(|name| name.to_string_lossy().replace('\\', "/"))
-            .unwrap_or_else(|| root.to_string_lossy().replace('\\', "/"));
+        let rel_path = explicit_file_display_path(&root);
 
         if passes_filters(&rel_path, &glob_filter, &opts.file_type) {
             let mut writer = OutputWriter::new(opts.make_output_config());
@@ -461,23 +458,6 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
     let start = Instant::now();
     let glob_filter = crate::glob_filter::GlobFilter::new(&opts.glob)?;
 
-    // If root is a file, walk its parent and filter to just that file
-    let (walk_root, single_file) = if root.is_file() {
-        let parent = root.parent().unwrap_or(root);
-        (parent.to_path_buf(), Some(root.to_path_buf()))
-    } else {
-        (root.to_path_buf(), None)
-    };
-
-    let walk = walker::walk_dir(
-        &walk_root,
-        &walker::WalkOptions {
-            include_hidden: opts.hidden,
-            no_ignore: opts.no_ignore,
-            ..Default::default()
-        },
-    );
-
     let all_patterns = opts.all_patterns()?;
     let matcher = build_search_matcher(
         &all_patterns,
@@ -490,16 +470,47 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
     let mut writer = OutputWriter::new(opts.make_output_config());
     let mut had_matches = false;
 
-    for path in &walk.files {
-        // If we're searching a single file, skip everything else
-        if let Some(ref sf) = single_file
-            && path != sf
-        {
-            continue;
+    if root.is_file() {
+        let rel_path = explicit_file_display_path(root);
+        if passes_filters(&rel_path, &glob_filter, &opts.file_type) {
+            let content = std::fs::read_to_string(root)?;
+            let matched = search_file_content(&content, &matcher, &rel_path, opts, &mut writer)?;
+            if matched {
+                if !opts.files_without_match {
+                    had_matches = true;
+                }
+            } else if opts.files_without_match {
+                if !opts.quiet {
+                    writer.write_file(&rel_path)?;
+                }
+                had_matches = true;
+            }
         }
 
+        if opts.stats {
+            let elapsed = start.elapsed();
+            eprintln!(
+                "Brute-force search completed in {:.1}ms (1 files)",
+                elapsed.as_secs_f64() * 1000.0,
+            );
+        }
+
+        writer.flush()?;
+        return Ok(had_matches);
+    }
+
+    let walk = walker::walk_dir(
+        root,
+        &walker::WalkOptions {
+            include_hidden: opts.hidden,
+            no_ignore: opts.no_ignore,
+            ..Default::default()
+        },
+    );
+
+    for path in &walk.files {
         let rel_path = path
-            .strip_prefix(&walk_root)
+            .strip_prefix(root)
             .unwrap_or(path)
             .to_string_lossy()
             .replace('\\', "/");
@@ -636,19 +647,7 @@ fn search_file_content(
     Ok(true)
 }
 
-pub fn build_combined_regex(
-    patterns: &[String],
-    case_insensitive: bool,
-    fixed_string: bool,
-    word_boundary: bool,
-    multiline: bool,
-) -> Result<regex::Regex> {
-    let combined = combine_patterns(patterns, fixed_string, word_boundary);
-
-    build_regex(&combined, case_insensitive, multiline)
-}
-
-fn build_search_matcher(
+pub(crate) fn build_search_matcher(
     patterns: &[String],
     case_insensitive: bool,
     fixed_string: bool,
@@ -727,7 +726,7 @@ fn build_regex(combined: &str, case_insensitive: bool, multiline: bool) -> Resul
         .map_err(|e| anyhow::anyhow!("regex error: {e}"))
 }
 
-fn find_match_indices(
+pub(crate) fn find_match_indices(
     lines: &[&str],
     matcher: &SearchMatcher,
     invert_match: bool,
@@ -750,6 +749,16 @@ fn find_match_indices(
         }
     }
     Ok(indices)
+}
+
+fn explicit_file_display_path(path: &Path) -> String {
+    let display_path = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| std::fs::canonicalize(cwd).ok())
+        .and_then(|cwd| path.strip_prefix(cwd).ok().map(|p| p.to_path_buf()))
+        .unwrap_or_else(|| path.to_path_buf());
+
+    display_path.to_string_lossy().replace('\\', "/")
 }
 
 fn passes_filters(

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -354,7 +354,7 @@ fn process_request(request: &str, state: &ServerState) -> String {
 struct SearchRequest {
     pattern: String,
     case_insensitive: bool,
-    regex: regex::Regex,
+    matcher: crate::search::SearchMatcher,
     plan: query::QueryPlan,
     glob_filter: crate::glob_filter::GlobFilter,
     file_type: Option<String>,
@@ -436,7 +436,7 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
     let mut all_patterns = vec![pattern.to_string()];
     all_patterns.extend(extra_patterns);
 
-    let regex = crate::search::build_combined_regex(
+    let matcher = crate::search::build_search_matcher(
         &all_patterns,
         case_insensitive,
         fixed_string,
@@ -446,7 +446,9 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
     .map_err(|e| format!("{e}"))?;
 
     // Build query plan from primary pattern for index filtering
-    let plan = if fixed_string {
+    let plan = if !matcher.is_standard() {
+        query::QueryPlan::MatchAll
+    } else if fixed_string {
         query::build_literal_plan(pattern, case_insensitive)
     } else {
         query::build_query_plan(pattern, case_insensitive)?
@@ -455,7 +457,7 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
     Ok(SearchRequest {
         pattern: pattern.to_string(),
         case_insensitive,
-        regex,
+        matcher,
         plan,
         glob_filter,
         file_type,
@@ -482,7 +484,7 @@ fn handle_search(
         Err(e) => return json_rpc_error(id, -32602, &e),
     };
 
-    let re = req.regex;
+    let matcher = req.matcher;
     let plan = req.plan;
     let glob_filter = req.glob_filter;
     let file_type = req.file_type;
@@ -617,23 +619,17 @@ fn handle_search(
     };
     let resolve_ms = t_resolve.elapsed().as_secs_f64() * 1000.0;
 
-    let has_context = opts.before_context > 0 || opts.after_context > 0;
-
     // Parallel regex matching across candidate files
     let t_search = Instant::now();
-    let matches: Vec<serde_json::Value> = if has_context {
-        // Context mode: parallel search, order preserved by indexed par_iter
-        let per_file: Vec<Vec<serde_json::Value>> = candidate_contents
-            .par_iter()
-            .map(|(rel_path, content)| search_file_matches(rel_path, content, &re, &opts))
-            .collect();
-        per_file.into_iter().flatten().collect()
-    } else {
-        // No context: parallel search
-        candidate_contents
-            .par_iter()
-            .flat_map(|(rel_path, content)| search_file_matches(rel_path, content, &re, &opts))
-            .collect()
+    let per_file: std::result::Result<Vec<Vec<serde_json::Value>>, String> = candidate_contents
+        .par_iter()
+        .map(|(rel_path, content)| {
+            search_file_matches(rel_path, content, &matcher, &opts).map_err(|e| format!("{e}"))
+        })
+        .collect();
+    let matches: Vec<serde_json::Value> = match per_file {
+        Ok(per_file) => per_file.into_iter().flatten().collect(),
+        Err(e) => return json_rpc_error(id, -32603, &e),
     };
 
     let search_ms = t_search.elapsed().as_secs_f64() * 1000.0;
@@ -665,9 +661,9 @@ fn handle_search(
 fn search_file_matches(
     rel_path: &str,
     content: &str,
-    re: &regex::Regex,
+    matcher: &crate::search::SearchMatcher,
     opts: &SearchOpts,
-) -> Vec<serde_json::Value> {
+) -> anyhow::Result<Vec<serde_json::Value>> {
     let effective_max = if opts.files_only {
         Some(1)
     } else {
@@ -676,10 +672,10 @@ fn search_file_matches(
 
     let lines: Vec<&str> = content.lines().collect();
     let match_indices =
-        crate::matching::find_match_indices(&lines, re, opts.invert_match, effective_max);
+        crate::search::find_match_indices(&lines, matcher, opts.invert_match, effective_max)?;
 
     if match_indices.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let has_context = opts.before_context > 0 || opts.after_context > 0;
@@ -697,8 +693,8 @@ fn search_file_matches(
         let mut results = Vec::new();
         for &li in &printed {
             if is_match_line.contains(&li) {
-                let mc = crate::matching::match_content(lines[li], re, opts.only_matching);
-                let col = re.find(lines[li]).map(|m| m.start() + 1);
+                let mc = matcher.match_content(lines[li], opts.only_matching)?;
+                let col = matcher.find_start(lines[li])?.map(|start| start + 1);
                 let mut entry = serde_json::json!({
                     "type": "match",
                     "file": rel_path,
@@ -718,13 +714,13 @@ fn search_file_matches(
                 }));
             }
         }
-        results
+        Ok(results)
     } else {
         match_indices
             .iter()
             .map(|&mi| {
-                let mc = crate::matching::match_content(lines[mi], re, opts.only_matching);
-                let col = re.find(lines[mi]).map(|m| m.start() + 1);
+                let mc = matcher.match_content(lines[mi], opts.only_matching)?;
+                let col = matcher.find_start(lines[mi])?.map(|start| start + 1);
                 let mut entry = serde_json::json!({
                     "type": "match",
                     "file": rel_path,
@@ -734,7 +730,7 @@ fn search_file_matches(
                 if let Some(c) = col {
                     entry["column"] = serde_json::json!(c);
                 }
-                entry
+                Ok(entry)
             })
             .collect()
     }

--- a/tgrep-cli/tests/concurrent_search.rs
+++ b/tgrep-cli/tests/concurrent_search.rs
@@ -255,6 +255,32 @@ fn concurrent_different_searches() {
 }
 
 #[test]
+fn server_supports_negative_lookahead_fallback() {
+    let dir = setup_fixture();
+    let server = start_server(dir.path().join("src").as_path());
+
+    let req = search_request(1, r"alpha_handler(?!\()");
+    let resp = send_request(server.port, &req).expect("request failed");
+    let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+    assert!(v.get("error").is_none(), "got error: {v}");
+    assert_eq!(
+        v.pointer("/result/num_matches").and_then(|n| n.as_u64()),
+        Some(0)
+    );
+
+    let req = search_request(2, r"alpha_handler(?!_missing)");
+    let resp = send_request(server.port, &req).expect("request failed");
+    let v: serde_json::Value = serde_json::from_str(&resp).expect("invalid JSON");
+    assert!(v.get("error").is_none(), "got error: {v}");
+    assert!(
+        v.pointer("/result/num_matches")
+            .and_then(|n| n.as_u64())
+            .is_some_and(|count| count > 0),
+        "expected matches for lookahead fallback, got {v}"
+    );
+}
+
+#[test]
 fn concurrent_searches_with_different_options() {
     let dir = setup_fixture();
     let server = start_server(dir.path().join("src").as_path());

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -146,6 +146,37 @@ fn files_mode_accepts_single_file_path() {
         .stdout(predicate::str::contains("lib.rs").not());
 }
 
+#[test]
+fn files_mode_preserves_single_file_relative_path_for_globs() {
+    let dir = setup_fixture();
+
+    tgrep()
+        .current_dir(dir.path())
+        .args(["--files", "-g", "testdata/*", "testdata/hello.rs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("testdata/hello.rs"))
+        .stdout(predicate::str::contains("lib.rs").not());
+}
+
+#[test]
+fn explicit_file_search_bypasses_hidden_walk_filter() {
+    let dir = setup_fixture();
+    let hidden = dir.path().join("testdata").join(".hidden.rs");
+    fs::write(&hidden, "fn hidden_entry() {}\n").unwrap();
+
+    tgrep()
+        .args([
+            "--no-index",
+            "--no-heading",
+            "hidden_entry",
+            hidden.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".hidden.rs"));
+}
+
 // ─── --glob / -g (multiple) ───────────────────────────────────────────
 
 #[test]

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -54,6 +54,79 @@ fn tgrep() -> Command {
     Command::cargo_bin("tgrep").unwrap()
 }
 
+// ─── Multiple and normalized path arguments ───────────────────────────
+
+#[test]
+fn accepts_multiple_path_arguments() {
+    let dir = setup_fixture();
+    let root = dir.path().join("testdata");
+    let hello = root.join("hello.rs").to_str().unwrap().to_string();
+    let lib = root.join("lib.rs").to_str().unwrap().to_string();
+
+    tgrep()
+        .args(["--no-index", "--no-heading", "fn", &hello, &lib])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello.rs"))
+        .stdout(predicate::str::contains("lib.rs"));
+}
+
+#[test]
+fn strips_extra_quotes_from_path_argument() {
+    let dir = setup_fixture();
+    let quoted = format!("\"{}\"", fixture_path(&dir));
+
+    tgrep()
+        .args(["--no-index", "--no-heading", "fn main", &quoted])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello.rs"));
+}
+
+#[test]
+fn missing_path_is_treated_as_no_matches() {
+    let dir = setup_fixture();
+    let missing = dir
+        .path()
+        .join("testdata")
+        .join("does-not-exist.rs")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    tgrep()
+        .args(["--no-index", "--no-heading", "fn", &missing])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn supports_negative_lookahead_fallback() {
+    let dir = setup_fixture();
+
+    tgrep()
+        .args([
+            "--no-index",
+            "--no-heading",
+            "hello(?! world)",
+            &fixture_path(&dir),
+        ])
+        .assert()
+        .code(1);
+
+    tgrep()
+        .args([
+            "--no-index",
+            "--no-heading",
+            "hello(?! there)",
+            &fixture_path(&dir),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello world"));
+}
+
 // ─── --glob / -g (multiple) ───────────────────────────────────────────
 
 #[test]

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -127,6 +127,25 @@ fn supports_negative_lookahead_fallback() {
         .stdout(predicate::str::contains("hello world"));
 }
 
+#[test]
+fn files_mode_accepts_single_file_path() {
+    let dir = setup_fixture();
+    let hello = dir
+        .path()
+        .join("testdata")
+        .join("hello.rs")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    tgrep()
+        .args(["--files", &hello])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello.rs"))
+        .stdout(predicate::str::contains("lib.rs").not());
+}
+
 // ─── --glob / -g (multiple) ───────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- accept multiple search paths and normalize extra-quoted path arguments
- treat missing search paths as no matches instead of hard failures
- fall back to fancy-regex for unsupported Rust regex constructs like negative lookahead
- bump workspace version to 0.1.19

## Validation
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test --workspace
- git diff --check