### PR TITLE
Defer watcher gitignore matcher during serve startup

### DIFF
--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -84,10 +84,11 @@ fn try_acquire_server_lock(index_dir: &Path) -> Result<File> {
 /// Lock ordering (acquire in this order to avoid deadlocks):
 ///
 ///   1. `snapshot_gate` — coordinates watcher mutations with publish cycle
-///   2. `publish_lock`  — serializes on-disk index publication
-///   3. `index`         — guards the in-memory HybridIndex (read-heavy)
-///   4. `cache`         — guards the file content LRU cache
-///   5. `file_stamps`   — guards per-file mtime/size stamps
+///   2. `gitignore`     — guards the watcher matcher; drop before file/index work
+///   3. `publish_lock`  — serializes on-disk index publication
+///   4. `index`         — guards the in-memory HybridIndex (read-heavy)
+///   5. `cache`         — guards the file content LRU cache
+///   6. `file_stamps`   — guards per-file mtime/size stamps
 ///
 /// `flushing` is an AtomicBool, not a lock — no ordering constraint.
 /// Searches only acquire `index` (read) and `cache` (read then write);
@@ -108,6 +109,8 @@ struct ServerState {
     index_progress: std::sync::atomic::AtomicU64,
     /// Total files discovered for indexing.
     index_total: std::sync::atomic::AtomicU64,
+    /// True when file watching is enabled for this server.
+    watch_enabled: bool,
     /// Directories to exclude from indexing.
     exclude_dirs: Vec<String>,
     /// Serializes on-disk index publication across all publishers
@@ -147,10 +150,11 @@ struct ServerState {
     /// Gitignore matcher used by the file watcher to drop events for
     /// paths the initial walk would have skipped via the `ignore` crate
     /// (`.gitignore`, `.git/info/exclude`, global gitignore, etc.).
-    /// Built once at startup; `None` if the matcher could not be built
-    /// (in which case the watcher just falls back to its hidden / exclude
-    /// filtering and accepts that gitignored files may be reindexed).
-    gitignore: Option<tgrep_core::gitignore::Gitignore>,
+    /// Built asynchronously after the server starts so large repos don't block
+    /// `serve ready` on a full-tree `.gitignore` discovery walk. `None` while
+    /// loading or if no matcher could be built; during that window the watcher
+    /// falls back to hidden / exclude filtering.
+    gitignore: RwLock<Option<tgrep_core::gitignore::Gitignore>>,
 }
 
 struct SearchOpts {
@@ -220,19 +224,12 @@ pub fn run(
         flushing: std::sync::atomic::AtomicBool::new(false),
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
+        watch_enabled: !no_watch,
         exclude_dirs: exclude_dirs.to_vec(),
         publish_lock: Mutex::new(()),
         file_stamps: RwLock::new(tgrep_core::meta::read_filestamps(&index_dir).unwrap_or_default()),
         snapshot_gate: RwLock::new(()),
-        // Only pay the cost of walking the tree to gather .gitignore
-        // rules when we'll actually use them — i.e. when the file watcher
-        // is enabled. With --no-watch the matcher would just sit unused
-        // but we'd still have eaten a full-tree walk at startup.
-        gitignore: if no_watch {
-            None
-        } else {
-            tgrep_core::gitignore::build_matcher(&root)
-        },
+        gitignore: RwLock::new(None),
     });
 
     // Bind TCP listener on a random port
@@ -268,6 +265,9 @@ pub fn run(
         let stale_index_dir = index_dir.clone();
         thread::spawn(move || {
             background_refresh_stale(&stale_state, &stale_root, &stale_index_dir);
+            if stale_state.watch_enabled {
+                build_gitignore_matcher_after_ready(&stale_state, &stale_root);
+            }
         });
     }
 
@@ -310,6 +310,19 @@ pub fn run(
     }
 
     Ok(())
+}
+
+fn build_gitignore_matcher_after_ready(state: &ServerState, root: &Path) {
+    let start = Instant::now();
+    eprintln!("[trace] gitignore matcher build started...");
+    let matcher = tgrep_core::gitignore::build_matcher(root);
+    let has_matcher = matcher.is_some();
+    *state.gitignore.write().unwrap() = matcher;
+    eprintln!(
+        "[trace] gitignore matcher build complete in {:.1}ms{}",
+        start.elapsed().as_secs_f64() * 1000.0,
+        if has_matcher { "" } else { " (no rules found)" }
+    );
 }
 
 fn handle_connection(stream: TcpStream, state: &ServerState) -> Result<()> {
@@ -921,7 +934,11 @@ fn handle_fs_event(state: &ServerState, root: &Path, event: &Event) {
         // files the initial walk would have skipped — most notably
         // hidden directories like `.git/`, which fire frequent
         // `index.lock`/HEAD/refs writes during normal git operations.
-        if should_skip_watcher_path(&rel_path, &state.exclude_dirs, state.gitignore.as_ref()) {
+        let should_skip = {
+            let gitignore = state.gitignore.read().unwrap();
+            should_skip_watcher_path(&rel_path, &state.exclude_dirs, gitignore.as_ref())
+        };
+        if should_skip {
             continue;
         }
 
@@ -1356,10 +1373,24 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         root,
         &WalkOptions {
             include_hidden: false,
+            collect_gitignore_files: state.watch_enabled,
             exclude_dirs: state.exclude_dirs.clone(),
             ..Default::default()
         },
     );
+
+    if state.watch_enabled {
+        let start = Instant::now();
+        let matcher = walker::build_gitignore_matcher_from_files(root, &walk.gitignore_files);
+        let has_matcher = matcher.is_some();
+        *state.gitignore.write().unwrap() = matcher;
+        eprintln!(
+            "[trace] gitignore matcher built from index walk in {:.1}ms ({} .gitignore files{})",
+            start.elapsed().as_secs_f64() * 1000.0,
+            walk.gitignore_files.len(),
+            if has_matcher { "" } else { ", no rules found" }
+        );
+    }
 
     // Filter out already-indexed files
     let new_files: Vec<_> = if skip_paths.is_empty() {

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -31,6 +31,7 @@ fn should_skip_dir(entry: &ignore::DirEntry, exclude_dirs: &[String]) -> bool {
 
 pub struct WalkResult {
     pub files: Vec<PathBuf>,
+    pub gitignore_files: Vec<PathBuf>,
     pub skipped_binary: usize,
     pub skipped_error: usize,
 }
@@ -40,6 +41,8 @@ pub struct WalkOptions {
     pub include_hidden: bool,
     pub no_ignore: bool,
     pub search_binary: bool,
+    /// Collect `.gitignore` file paths encountered during the walk.
+    pub collect_gitignore_files: bool,
     /// Directory names to exclude from walking (e.g., "vendor", "third_party").
     pub exclude_dirs: Vec<String>,
 }
@@ -62,22 +65,32 @@ fn is_binary_extension(path: &Path) -> bool {
 /// avoiding an extra 8KB read per file during the walk.
 pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
     let files = std::sync::Mutex::new(Vec::new());
+    let gitignore_files = std::sync::Mutex::new(Vec::new());
     let skipped_binary = std::sync::atomic::AtomicUsize::new(0);
     let skipped_error = std::sync::atomic::AtomicUsize::new(0);
     let exclude_dirs: std::sync::Arc<Vec<String>> = std::sync::Arc::new(opts.exclude_dirs.clone());
     let search_binary = opts.search_binary;
+    let include_hidden = opts.include_hidden;
+    let collect_gitignore_files = opts.collect_gitignore_files;
+    let root = root.to_path_buf();
 
-    let walker = WalkBuilder::new(root)
-        .hidden(!opts.include_hidden)
+    let mut builder = WalkBuilder::new(&root);
+    builder
+        // When collecting .gitignore paths, keep hidden entries visible to the
+        // walker and apply hidden filtering below so .gitignore files are seen
+        // while hidden directories/files still match normal index behavior.
+        .hidden(!include_hidden && !collect_gitignore_files)
         .git_ignore(!opts.no_ignore)
         .git_global(!opts.no_ignore)
         .git_exclude(!opts.no_ignore)
-        .threads(walker_thread_count())
-        .build_parallel();
+        .threads(walker_thread_count());
+    let walker = builder.build_parallel();
 
     walker.run(|| {
         let exclude = exclude_dirs.clone();
+        let root = root.clone();
         let files = &files;
+        let gitignore_files = &gitignore_files;
         let skipped_binary = &skipped_binary;
         let skipped_error = &skipped_error;
         Box::new(move |entry| {
@@ -90,6 +103,16 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
             };
 
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                if collect_gitignore_files
+                    && entry.path() != root
+                    && !include_hidden
+                    && entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|name| name.starts_with('.'))
+                {
+                    return ignore::WalkState::Skip;
+                }
                 if should_skip_dir(&entry, &exclude) {
                     return ignore::WalkState::Skip;
                 }
@@ -101,6 +124,23 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
             }
 
             let path = entry.path();
+
+            if collect_gitignore_files && entry.file_name() == ".gitignore" {
+                gitignore_files.lock().unwrap().push(path.to_path_buf());
+                if !include_hidden {
+                    return ignore::WalkState::Continue;
+                }
+            }
+
+            if collect_gitignore_files
+                && !include_hidden
+                && entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with('.'))
+            {
+                return ignore::WalkState::Continue;
+            }
 
             if !search_binary {
                 if is_binary_extension(path) {
@@ -123,9 +163,35 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
 
     WalkResult {
         files: files.into_inner().unwrap(),
+        gitignore_files: gitignore_files.into_inner().unwrap(),
         skipped_binary: skipped_binary.into_inner(),
         skipped_error: skipped_error.into_inner(),
     }
+}
+
+/// Build a point-query gitignore matcher from `.gitignore` files discovered by
+/// an existing walk, avoiding a second full-tree discovery pass.
+pub fn build_gitignore_matcher_from_files(
+    root: &Path,
+    gitignore_files: &[PathBuf],
+) -> Option<crate::gitignore::Gitignore> {
+    use ignore::gitignore::GitignoreBuilder;
+
+    let mut builder = GitignoreBuilder::new(root);
+
+    let info_exclude = root.join(".git").join("info").join("exclude");
+    if info_exclude.is_file() {
+        let _ = builder.add(&info_exclude);
+    }
+
+    for path in gitignore_files {
+        if path.is_file() {
+            let _ = builder.add(path);
+        }
+    }
+
+    let gi = builder.build().ok()?;
+    if gi.is_empty() { None } else { Some(gi) }
 }
 
 /// Filesystem metadata for a single file (no content read).
@@ -331,6 +397,103 @@ mod tests {
         );
         let names = sorted_filenames(&result, &root);
         assert!(!names.iter().any(|n| n.starts_with("vendor/")));
+    }
+
+    #[test]
+    fn walk_dir_can_collect_gitignore_files_without_indexing_them() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("testdata");
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        fs::write(root.join("src").join(".gitignore"), "*.tmp\n").unwrap();
+        fs::write(root.join("src").join("main.rs"), "fn main() {}\n").unwrap();
+
+        let result = walk_dir(
+            &root,
+            &WalkOptions {
+                collect_gitignore_files: true,
+                ..Default::default()
+            },
+        );
+        let names = sorted_filenames(&result, &root);
+        let mut gitignores: Vec<_> = result
+            .gitignore_files
+            .iter()
+            .map(|p| {
+                p.strip_prefix(&root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        gitignores.sort();
+
+        assert_eq!(names, vec!["src/main.rs"]);
+        assert_eq!(gitignores, vec![".gitignore", "src/.gitignore"]);
+    }
+
+    #[test]
+    fn walk_dir_collects_and_indexes_gitignore_when_hidden_included() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("testdata");
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        fs::write(root.join("src").join("main.rs"), "fn main() {}\n").unwrap();
+
+        let result = walk_dir(
+            &root,
+            &WalkOptions {
+                include_hidden: true,
+                collect_gitignore_files: true,
+                ..Default::default()
+            },
+        );
+        let names = sorted_filenames(&result, &root);
+        let gitignores: Vec<_> = result
+            .gitignore_files
+            .iter()
+            .map(|p| {
+                p.strip_prefix(&root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        assert_eq!(names, vec![".gitignore", "src/main.rs"]);
+        assert_eq!(gitignores, vec![".gitignore"]);
+    }
+
+    #[test]
+    fn build_gitignore_matcher_from_discovered_files() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("testdata");
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        fs::write(root.join("src").join(".gitignore"), "*.tmp\n").unwrap();
+
+        let walk = walk_dir(
+            &root,
+            &WalkOptions {
+                collect_gitignore_files: true,
+                ..Default::default()
+            },
+        );
+        let gi = build_gitignore_matcher_from_files(&root, &walk.gitignore_files)
+            .expect("matcher should build from discovered .gitignore files");
+
+        assert!(
+            gi.matched_path_or_any_parents("build/output.log", false)
+                .is_ignore()
+        );
+        assert!(
+            gi.matched_path_or_any_parents("src/cache.tmp", false)
+                .is_ignore()
+        );
+        assert!(
+            !gi.matched_path_or_any_parents("src/main.rs", false)
+                .is_ignore()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make `tgrep serve` report ready before expensive watcher gitignore matcher construction
- collect `.gitignore` files during the parallel initial index walk and publish the watcher matcher from those discovered files
- keep the async post-ready full matcher build only for already-complete indexes where no initial walk runs

## Validation
- `git --no-pager diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --workspace`