### PR TITLE
Rebuild corrupt index on serve startup

### DIFF
--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -183,6 +183,7 @@ pub fn run(
     let _lock_file = try_acquire_server_lock(&index_dir)?;
 
     let has_index = index_dir.join("lookup.bin").exists();
+    let mut needs_build = !has_index;
 
     if !has_index {
         // Create an empty on-disk index so HybridIndex can open it.
@@ -193,7 +194,17 @@ pub fn run(
 
     // Open the hybrid index (may be empty or partial from a previous checkpoint)
     let index_start = Instant::now();
-    let hybrid = HybridIndex::open(&index_dir, &root)?;
+    let hybrid = match HybridIndex::open(&index_dir, &root) {
+        Ok(hybrid) => hybrid,
+        Err(e) if has_index => {
+            eprintln!("[trace] existing index failed to load ({e}); rebuilding in background");
+            std::fs::create_dir_all(&index_dir)?;
+            create_empty_index(&index_dir)?;
+            needs_build = true;
+            HybridIndex::open(&index_dir, &root)?
+        }
+        Err(e) => return Err(e.into()),
+    };
     let existing_files = hybrid.num_files();
 
     // Check meta.json complete flag to decide whether to rebuild
@@ -201,7 +212,7 @@ pub fn run(
         .map(|m| m.complete)
         .unwrap_or(false);
 
-    let needs_build = !has_index || !index_complete;
+    let needs_build = needs_build || !index_complete;
 
     eprintln!(
         "[trace] opened index: {} files, {} trigrams in {:.1}ms{}",

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -6,6 +6,9 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 /// Create a temp directory with a few source files for testing.
@@ -52,6 +55,17 @@ fn fixture_path(dir: &TempDir) -> String {
 
 fn tgrep() -> Command {
     Command::cargo_bin("tgrep").unwrap()
+}
+
+fn send_rpc_request(port: u16, request: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    writeln!(stream, "{request}")?;
+    stream.flush()?;
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader.read_line(&mut response)?;
+    Ok(response)
 }
 
 // ─── Multiple and normalized path arguments ───────────────────────────
@@ -882,17 +896,75 @@ fn serve_rebuilds_when_existing_index_is_corrupted() {
         .spawn()
         .unwrap();
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    while !index_dir.join("serve.json").exists() {
+    let serve_json = index_dir.join("serve.json");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let port = loop {
         if let Some(status) = server.try_wait().unwrap() {
-            panic!("server exited before rebuilding corrupted index: {status}");
+            panic!("server exited before recovering corrupted index: {status}");
         }
         assert!(
-            std::time::Instant::now() < deadline,
+            Instant::now() < deadline,
             "server did not start after corrupted index recovery"
         );
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        if let Ok(data) = fs::read_to_string(&serve_json)
+            && let Ok(info) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(port) = info.get("port").and_then(|v| v.as_u64())
+            && TcpStream::connect(format!("127.0.0.1:{port}")).is_ok()
+        {
+            break port as u16;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        assert!(
+            Instant::now() < deadline,
+            "server did not finish rebuilding corrupted index"
+        );
+        let response = send_rpc_request(port, r#"{"jsonrpc":"2.0","method":"status","id":0}"#)
+            .expect("status request failed");
+        let status: serde_json::Value =
+            serde_json::from_str(&response).expect("invalid status JSON");
+        let indexing = status
+            .pointer("/result/indexing")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        if !indexing {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
     }
+
+    let search_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "search",
+        "id": 1,
+        "params": { "pattern": "hello" }
+    })
+    .to_string();
+    let response = send_rpc_request(port, &search_request).expect("search request failed");
+    let search: serde_json::Value = serde_json::from_str(&response).expect("invalid search JSON");
+    assert!(
+        search.get("error").is_none(),
+        "search returned error: {search}"
+    );
+    assert_eq!(
+        search
+            .pointer("/result/num_matches")
+            .and_then(|v| v.as_u64()),
+        Some(1)
+    );
+    assert!(
+        search
+            .pointer("/result/matches")
+            .and_then(|v| v.as_array())
+            .is_some_and(|matches| matches.iter().any(|m| m
+                .get("file")
+                .and_then(|v| v.as_str())
+                .is_some_and(|path| path == "hello.txt"))),
+        "expected rebuilt index to find hello.txt, got: {search}"
+    );
 
     server.kill().ok();
     let output = server.wait_with_output().unwrap();

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -854,3 +854,52 @@ fn serve_rejects_second_server_on_same_index() {
     server1.kill().ok();
     server1.wait().ok();
 }
+
+#[test]
+fn serve_rebuilds_when_existing_index_is_corrupted() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("hello.txt"), "hello world").unwrap();
+
+    let index_dir = dir.path().join("idx");
+    fs::create_dir_all(&index_dir).unwrap();
+    fs::write(index_dir.join("lookup.bin"), vec![0u8; 15]).unwrap();
+    fs::write(index_dir.join("index.bin"), vec![0u8; 6]).unwrap();
+    fs::write(index_dir.join("files.bin"), b"").unwrap();
+
+    let tgrep_bin = assert_cmd::cargo::cargo_bin("tgrep");
+    let mut server = std::process::Command::new(&tgrep_bin)
+        .args([
+            "serve",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--no-watch",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !index_dir.join("serve.json").exists() {
+        if let Some(status) = server.try_wait().unwrap() {
+            panic!("server exited before rebuilding corrupted index: {status}");
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "server did not start after corrupted index recovery"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    server.kill().ok();
+    let output = server.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("existing index failed to load")
+            && stderr.contains("rebuilding in background"),
+        "expected corrupted-index recovery trace, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- recover from existing index load failures during `tgrep serve` startup
- replace the bad on-disk index with an empty incomplete skeleton and trigger background rebuild
- add integration coverage for malformed `lookup.bin` recovery

## Validation
- `cargo test -p tgrep-cli serve_rebuilds_when_existing_index_is_corrupted -- --nocapture`
- `cargo fmt --all -- --check && cargo test --workspace && cargo clippy -- -D warnings`
- final `cargo fmt --all -- --check`