### PR TITLE
feat: embed Windows VERSIONINFO in tgrep.exe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1054,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tgrep-core",
+ "winresource",
 ]
 
 [[package]]
@@ -1075,6 +1085,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1140,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -1342,6 +1397,22 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "toml",
+ "version_check",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -33,5 +33,5 @@ assert_cmd = "2"
 tempfile = "3"
 predicates = "3"
 
-[target.'cfg(windows)'.build-dependencies]
+[build-dependencies]
 winresource = "0.1"

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -33,5 +33,5 @@ assert_cmd = "2"
 tempfile = "3"
 predicates = "3"
 
-[build-dependencies]
+[target.'cfg(windows)'.build-dependencies]
 winresource = "0.1"

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -32,3 +32,6 @@ globset = "0.4.18"
 assert_cmd = "2"
 tempfile = "3"
 predicates = "3"
+
+[target.'cfg(windows)'.build-dependencies]
+winresource = "0.1"

--- a/tgrep-cli/build.rs
+++ b/tgrep-cli/build.rs
@@ -14,25 +14,34 @@ fn main() {
     // (e.g. x64 host -> arm64 target in OneBranch), #[cfg] would check the host
     // and skip VERSIONINFO embedding even though the output is a Windows .exe.
     // Reference: microsoft/vscode cli/build.rs uses the same pattern.
-    if std::env::var("CARGO_CFG_TARGET_OS")
-        .map(|os| os == "windows")
-        .unwrap_or(false)
-    {
-        let mut res = winresource::WindowsResource::new();
-        res.set("ProductName", "tgrep");
-        res.set(
-            "FileDescription",
-            "tgrep - trigram-indexed grep for large codebases",
-        );
-        res.set("CompanyName", "Microsoft Corporation");
-        res.set(
-            "LegalCopyright",
-            "Copyright (c) Microsoft Corporation. All rights reserved.",
-        );
-        res.set("InternalName", "tgrep");
-        res.set("OriginalFilename", "tgrep.exe");
-        // FileVersion and ProductVersion are auto-populated from Cargo.toml
-        // by winresource when not explicitly set.
-        res.compile().expect("Failed to compile Windows resources");
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
     }
+
+    compile_windows_resources();
+}
+
+#[cfg(not(windows))]
+fn compile_windows_resources() {
+    println!("cargo:warning=Skipping Windows VERSIONINFO resource: build host is not Windows");
+}
+
+#[cfg(windows)]
+fn compile_windows_resources() {
+    let mut res = winresource::WindowsResource::new();
+    res.set("ProductName", "tgrep");
+    res.set(
+        "FileDescription",
+        "tgrep - trigram-indexed grep for large codebases",
+    );
+    res.set("CompanyName", "Microsoft Corporation");
+    res.set(
+        "LegalCopyright",
+        "Copyright (c) Microsoft Corporation. All rights reserved.",
+    );
+    res.set("InternalName", "tgrep");
+    res.set("OriginalFilename", "tgrep.exe");
+    // FileVersion and ProductVersion are auto-populated from Cargo.toml
+    // by winresource when not explicitly set.
+    res.compile().expect("Failed to compile Windows resources");
 }

--- a/tgrep-cli/build.rs
+++ b/tgrep-cli/build.rs
@@ -1,0 +1,38 @@
+// Embed Windows VERSIONINFO resource into tgrep.exe.
+//
+// Without this, the signed binary has no ProductName, FileVersion, etc.
+// in the Windows "Properties → Details" tab.
+//
+// Reference implementations:
+//   - microsoft/vscode cli/build.rs (winresource)
+//   - microsoft/coreutils build.rs (winresource + manifest)
+//   - microsoft/python-environment-tools crates/pet/build.rs (winresource)
+
+fn main() {
+    // Use CARGO_CFG_TARGET_OS instead of #[cfg(target_os = "windows")] because
+    // build scripts run on the host OS, not the target. When cross-compiling
+    // (e.g. x64 host -> arm64 target in OneBranch), #[cfg] would check the host
+    // and skip VERSIONINFO embedding even though the output is a Windows .exe.
+    // Reference: microsoft/vscode cli/build.rs uses the same pattern.
+    if std::env::var("CARGO_CFG_TARGET_OS")
+        .map(|os| os == "windows")
+        .unwrap_or(false)
+    {
+        let mut res = winresource::WindowsResource::new();
+        res.set("ProductName", "tgrep");
+        res.set(
+            "FileDescription",
+            "tgrep - trigram-indexed grep for large codebases",
+        );
+        res.set("CompanyName", "Microsoft Corporation");
+        res.set(
+            "LegalCopyright",
+            "Copyright (c) Microsoft Corporation. All rights reserved.",
+        );
+        res.set("InternalName", "tgrep");
+        res.set("OriginalFilename", "tgrep.exe");
+        // FileVersion and ProductVersion are auto-populated from Cargo.toml
+        // by winresource when not explicitly set.
+        res.compile().expect("Failed to compile Windows resources");
+    }
+}


### PR DESCRIPTION
## Summary

Add Windows VERSIONINFO resource embedding so that signed 	grep.exe shows ProductName, FileVersion, CompanyName, etc. in the Windows "Properties → Details" tab.

## Problem

After OneBranch signing, 	grep.exe has a valid Authenticode signature but **no product metadata** (ProductName, FileVersion, etc. are all blank). This is because Rust binaries don't include Windows VERSIONINFO resources by default.

## Solution

- Add winresource as a Windows-only build dependency in 	grep-cli/Cargo.toml
- Create 	grep-cli/build.rs to embed VERSIONINFO with:
  - **ProductName**: tgrep
  - **FileDescription**: tgrep - trigram-indexed grep for large codebases
  - **CompanyName**: Microsoft Corporation
  - **LegalCopyright**: Copyright (c) Microsoft Corporation. All rights reserved.
  - **InternalName**: tgrep
  - **OriginalFilename**: tgrep.exe
  - **FileVersion** / **ProductVersion**: auto-populated from Cargo.toml

## Reference

Same pattern used by other Microsoft Rust projects:
- [microsoft/vscode](https://github.com/microsoft/vscode/blob/main/cli/build.rs) (winresource)
- [microsoft/coreutils](https://github.com/microsoft/coreutils/blob/main/build.rs) (winresource + manifest)
- [microsoft/python-environment-tools](https://github.com/microsoft/python-environment-tools/blob/main/crates/pet/build.rs) (winresource)

All three use OneBranch + onebranch.pipeline.signing@1 with ``external_distribution`` profile — same as tgrep.

## Changes

- 	grep-cli/Cargo.toml: add [target.'cfg(windows)'.build-dependencies] winresource = "0.1"
- 	grep-cli/build.rs: new file, embeds VERSIONINFO on Windows builds

## Testing

- No pipeline changes needed — VERSIONINFO is embedded at compile time
- OneBranch signing signs the final binary which already contains the resource
- Verify after next OneBranch build: right-click tgrep.exe → Properties → Details