### PR TITLE
Limit tgrep CPU usage to half capacity

### DIFF
--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -10,6 +10,8 @@ pub fn run(
     include_hidden: bool,
     exclude_dirs: &[String],
 ) -> Result<()> {
-    builder::build_index(root, index_path, include_hidden, exclude_dirs)?;
+    let root = std::fs::canonicalize(root)?;
+    crate::repo_guard::ensure_can_recursively_walk(&root, "index")?;
+    builder::build_index(&root, index_path, include_hidden, exclude_dirs)?;
     Ok(())
 }

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -9,6 +9,7 @@ mod glob_filter;
 mod index;
 mod matching;
 mod output;
+mod repo_guard;
 mod search;
 mod serve;
 mod status;

--- a/tgrep-cli/src/repo_guard.rs
+++ b/tgrep-cli/src/repo_guard.rs
@@ -1,0 +1,139 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+const MICROSOFT_REMOTE_MARKERS: &[&str] = &[
+    "dev.azure.com/microsoft",
+    "microsoft.visualstudio.com",
+    "ssh.dev.azure.com:v3/microsoft",
+    "github.com/microsoft",
+];
+
+pub(crate) fn ensure_can_recursively_walk(root: &Path, operation: &str) -> Result<()> {
+    if root.is_file() || !is_windows_os_repo_root(root) {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "refusing to recursively enumerate the Windows OS repo at `{}` for `{operation}`. \
+         Pass a narrower subdirectory or file path instead.",
+        root.display()
+    );
+}
+
+fn is_windows_os_repo_root(root: &Path) -> bool {
+    let Some(config_path) = git_config_path(root) else {
+        return false;
+    };
+
+    let Ok(config) = std::fs::read_to_string(config_path) else {
+        return false;
+    };
+
+    config.lines().any(|line| {
+        line.trim_start()
+            .strip_prefix("url")
+            .and_then(|rest| rest.trim_start().strip_prefix('='))
+            .is_some_and(|url| is_windows_os_remote(url.trim()))
+    })
+}
+
+fn git_config_path(root: &Path) -> Option<PathBuf> {
+    let dot_git = root.join(".git");
+    if dot_git.is_dir() {
+        return Some(dot_git.join("config"));
+    }
+
+    let git_file = std::fs::read_to_string(&dot_git).ok()?;
+    let git_dir = git_file
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("gitdir:"))?
+        .trim();
+    let git_dir = PathBuf::from(git_dir);
+    let git_dir = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        root.join(git_dir)
+    };
+    Some(git_dir.join("config"))
+}
+
+fn is_windows_os_remote(url: &str) -> bool {
+    let normalized = url
+        .trim_end_matches(".git")
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+
+    if !MICROSOFT_REMOTE_MARKERS
+        .iter()
+        .any(|marker| normalized.contains(marker))
+    {
+        return false;
+    }
+
+    normalized.contains("/os/_git/os")
+        || normalized.contains("ssh.dev.azure.com:v3/microsoft/os/os")
+        || normalized.contains("github.com/microsoft/windows")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_git_config(root: &Path, remote_url: &str) {
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(
+            root.join(".git").join("config"),
+            format!("[remote \"origin\"]\n    url = {remote_url}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn detects_windows_os_azure_devops_remote() {
+        let dir = TempDir::new().unwrap();
+        write_git_config(
+            dir.path(),
+            "https://microsoft.visualstudio.com/DefaultCollection/OS/_git/OS",
+        );
+
+        assert!(is_windows_os_repo_root(dir.path()));
+    }
+
+    #[test]
+    fn ignores_non_windows_os_remote() {
+        let dir = TempDir::new().unwrap();
+        write_git_config(dir.path(), "https://github.com/microsoft/tgrep");
+
+        assert!(!is_windows_os_repo_root(dir.path()));
+    }
+
+    #[test]
+    fn ignores_non_microsoft_os_remote() {
+        let dir = TempDir::new().unwrap();
+        write_git_config(dir.path(), "https://dev.azure.com/example/OS/_git/OS");
+
+        assert!(!is_windows_os_repo_root(dir.path()));
+    }
+
+    #[test]
+    fn guard_allows_files_inside_windows_os_repo() {
+        let dir = TempDir::new().unwrap();
+        write_git_config(dir.path(), "https://dev.azure.com/microsoft/OS/_git/OS");
+        let file = dir.path().join("readme.txt");
+        fs::write(&file, "hello").unwrap();
+
+        ensure_can_recursively_walk(&file, "search").unwrap();
+    }
+
+    #[test]
+    fn guard_rejects_windows_os_repo_root() {
+        let dir = TempDir::new().unwrap();
+        write_git_config(dir.path(), "https://dev.azure.com/microsoft/OS/_git/OS");
+
+        let err = ensure_can_recursively_walk(dir.path(), "count-files").unwrap_err();
+        assert!(err.to_string().contains("Windows OS repo"));
+    }
+}

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -178,6 +178,7 @@ pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
         return Ok(());
     }
 
+    crate::repo_guard::ensure_can_recursively_walk(&root, "--files")?;
     let walk = walker::walk_dir(
         &root,
         &walker::WalkOptions {
@@ -499,6 +500,7 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
         return Ok(had_matches);
     }
 
+    crate::repo_guard::ensure_can_recursively_walk(root, "search")?;
     let walk = walker::walk_dir(
         root,
         &walker::WalkOptions {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -174,6 +174,7 @@ pub fn run(
 ) -> Result<()> {
     let serve_start = Instant::now();
     let root = std::fs::canonicalize(root)?;
+    crate::repo_guard::ensure_can_recursively_walk(&root, "serve")?;
     let index_dir = index_path
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| builder::default_index_dir(&root));

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -645,12 +645,16 @@ fn handle_search(
 
     // Parallel regex matching across candidate files
     let t_search = Instant::now();
-    let per_file: std::result::Result<Vec<Vec<serde_json::Value>>, String> = candidate_contents
-        .par_iter()
-        .map(|(rel_path, content)| {
-            search_file_matches(rel_path, content, &matcher, &opts).map_err(|e| format!("{e}"))
-        })
-        .collect();
+    let per_file: std::result::Result<Vec<Vec<serde_json::Value>>, String> =
+        tgrep_core::parallel::install(|| {
+            candidate_contents
+                .par_iter()
+                .map(|(rel_path, content)| {
+                    search_file_matches(rel_path, content, &matcher, &opts)
+                        .map_err(|e| format!("{e}"))
+                })
+                .collect()
+        });
     let matches: Vec<serde_json::Value> = match per_file {
         Ok(per_file) => per_file.into_iter().flatten().collect(),
         Err(e) => return json_rpc_error(id, -32603, &e),
@@ -1440,27 +1444,29 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // Phase 2: Process new files in parallel batches
     for (batch_idx, batch) in new_files.chunks(BATCH_SIZE).enumerate() {
         // Parallel: read files + extract trigrams (no locks held)
-        let batch_results: Vec<(String, Vec<u32>)> = batch
-            .par_iter()
-            .filter_map(|path| {
-                let data = std::fs::read(path).ok()?;
-                if tgrep_core::trigram::is_binary(&data) {
-                    return None;
-                }
-                let rel_path = path
-                    .strip_prefix(root)
-                    .unwrap_or(path)
-                    .to_string_lossy()
-                    .replace('\\', "/");
+        let batch_results: Vec<(String, Vec<u32>)> = tgrep_core::parallel::install(|| {
+            batch
+                .par_iter()
+                .filter_map(|path| {
+                    let data = std::fs::read(path).ok()?;
+                    if tgrep_core::trigram::is_binary(&data) {
+                        return None;
+                    }
+                    let rel_path = path
+                        .strip_prefix(root)
+                        .unwrap_or(path)
+                        .to_string_lossy()
+                        .replace('\\', "/");
 
-                let mut trigrams = tgrep_core::trigram::extract(&data);
-                let lower = data.to_ascii_lowercase();
-                if lower != data {
-                    trigrams.extend(tgrep_core::trigram::extract(&lower));
-                }
-                Some((rel_path, trigrams))
-            })
-            .collect();
+                    let mut trigrams = tgrep_core::trigram::extract(&data);
+                    let lower = data.to_ascii_lowercase();
+                    if lower != data {
+                        trigrams.extend(tgrep_core::trigram::extract(&lower));
+                    }
+                    Some((rel_path, trigrams))
+                })
+                .collect()
+        });
 
         // Sequential: insert into LiveIndex (brief write lock per batch)
         {

--- a/tgrep-cli/src/walkcount.rs
+++ b/tgrep-cli/src/walkcount.rs
@@ -7,6 +7,7 @@ use tgrep_core::walker::{self, WalkOptions};
 
 pub fn run(root: &Path, include_hidden: bool, no_ignore: bool) -> Result<()> {
     let root = std::fs::canonicalize(root)?;
+    crate::repo_guard::ensure_can_recursively_walk(&root, "count-files")?;
     let start = Instant::now();
 
     let walk = walker::walk_dir(

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -723,6 +723,24 @@ fn count_files_skips_binary() {
     assert!(stderr.contains("1 binary skipped"));
 }
 
+#[test]
+fn count_files_rejects_windows_os_repo_root() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join(".git")).unwrap();
+    fs::write(
+        dir.path().join(".git").join("config"),
+        "[remote \"origin\"]\n    url = https://dev.azure.com/microsoft/OS/_git/OS\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("file.txt"), "hello\n").unwrap();
+
+    tgrep()
+        .args(["count-files", dir.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Windows OS repo"));
+}
+
 // ─── --exclude (index) ─────────────────────────────────────────────
 
 /// Create a fixture with subdirectories to test --exclude during indexing.

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -63,23 +63,26 @@ pub fn build_index(
     let mut postings: Vec<TrigramPosting> = Vec::new();
 
     for batch in walk.files.chunks(INDEX_BUILD_BATCH_SIZE) {
-        let batch_data: Vec<(String, HashMap<u32, TrigramMasks>)> = batch
-            .par_iter()
-            .filter_map(|path| {
-                let data = std::fs::read(path).ok()?;
-                if trigram::is_binary(&data) {
-                    binary_skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    return None;
-                }
-                let rel = path
-                    .strip_prefix(&root)
-                    .unwrap_or(path)
-                    .to_string_lossy()
-                    .replace('\\', "/");
-                let per_tri = trigram::extract_merged_masks(&data);
-                Some((rel, per_tri))
-            })
-            .collect();
+        let batch_data: Vec<(String, HashMap<u32, TrigramMasks>)> =
+            crate::parallel::install(|| {
+                batch
+                    .par_iter()
+                    .filter_map(|path| {
+                        let data = std::fs::read(path).ok()?;
+                        if trigram::is_binary(&data) {
+                            binary_skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            return None;
+                        }
+                        let rel = path
+                            .strip_prefix(&root)
+                            .unwrap_or(path)
+                            .to_string_lossy()
+                            .replace('\\', "/");
+                        let per_tri = trigram::extract_merged_masks(&data);
+                        Some((rel, per_tri))
+                    })
+                    .collect()
+            });
 
         for (path, per_tri) in batch_data {
             let file_id = file_id_map.len() as u32;

--- a/tgrep-core/src/lib.rs
+++ b/tgrep-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod hybrid;
 pub mod live;
 pub mod meta;
 pub(crate) mod ondisk;
+pub mod parallel;
 pub mod query;
 pub mod reader;
 pub mod trigram;

--- a/tgrep-core/src/meta.rs
+++ b/tgrep-core/src/meta.rs
@@ -91,25 +91,27 @@ pub fn read_filestamps(index_dir: &Path) -> Result<HashMap<String, FileStamp>> {
 pub fn collect_filestamps(root: &Path, paths: &[String]) -> HashMap<String, FileStamp> {
     use rayon::prelude::*;
 
-    paths
-        .par_iter()
-        .filter_map(|rel_path| {
-            let full_path = root.join(rel_path);
-            std::fs::metadata(&full_path).ok().map(|metadata| {
-                let mtime = metadata
-                    .modified()
-                    .ok()
-                    .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0);
-                (
-                    rel_path.clone(),
-                    FileStamp {
-                        mtime,
-                        size: metadata.len(),
-                    },
-                )
+    crate::parallel::install(|| {
+        paths
+            .par_iter()
+            .filter_map(|rel_path| {
+                let full_path = root.join(rel_path);
+                std::fs::metadata(&full_path).ok().map(|metadata| {
+                    let mtime = metadata
+                        .modified()
+                        .ok()
+                        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0);
+                    (
+                        rel_path.clone(),
+                        FileStamp {
+                            mtime,
+                            size: metadata.len(),
+                        },
+                    )
+                })
             })
-        })
-        .collect()
+            .collect()
+    })
 }

--- a/tgrep-core/src/parallel.rs
+++ b/tgrep-core/src/parallel.rs
@@ -5,9 +5,9 @@ use std::sync::OnceLock;
 /// Maximum walker threads before applying the CPU-capacity limit.
 pub const MAX_WALKER_THREADS: usize = 12;
 
-static CPU_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+static CPU_POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
 
-/// Number of worker threads allowed for CPU-intensive work.
+/// Maximum concurrent threads allowed for CPU-intensive work.
 ///
 /// This is half of the available logical CPU capacity, rounded down so tgrep
 /// does not exceed half capacity on machines with an odd CPU count. A single
@@ -28,17 +28,46 @@ where
     OP: FnOnce() -> R + Send,
     R: Send,
 {
-    cpu_pool().install(op)
+    match cpu_pool() {
+        Some(pool) => pool.install(op),
+        None => op(),
+    }
 }
 
-fn cpu_pool() -> &'static rayon::ThreadPool {
-    CPU_POOL.get_or_init(|| {
+fn cpu_pool() -> Option<&'static rayon::ThreadPool> {
+    CPU_POOL
+        .get_or_init(|| {
+            let allowed_threads = worker_threads();
+            if allowed_threads == 1 {
+                return None;
+            }
+
+            // `ThreadPool::install` may run work on the caller too, so reserve
+            // one slot for that thread and keep total CPU work within the cap.
+            let pool_threads = allowed_threads - 1;
+            Some(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(pool_threads)
+                    .thread_name(|index| format!("tgrep-worker-{index}"))
+                    .build()
+                    .expect("failed to initialize tgrep worker thread pool"),
+            )
+        })
+        .as_ref()
+}
+
+#[cfg(test)]
+fn build_cpu_pool_for_allowed_threads(allowed_threads: usize) -> Option<rayon::ThreadPool> {
+    if allowed_threads == 1 {
+        return None;
+    }
+
+    Some(
         rayon::ThreadPoolBuilder::new()
-            .num_threads(worker_threads())
-            .thread_name(|index| format!("tgrep-worker-{index}"))
+            .num_threads(allowed_threads - 1)
             .build()
-            .expect("failed to initialize tgrep worker thread pool")
-    })
+            .unwrap(),
+    )
 }
 
 fn available_threads() -> usize {
@@ -75,5 +104,13 @@ mod tests {
         assert_eq!(capped_half_cpu_threads(23, MAX_WALKER_THREADS), 11);
         assert_eq!(capped_half_cpu_threads(8, MAX_WALKER_THREADS), 4);
         assert_eq!(capped_half_cpu_threads(2, MAX_WALKER_THREADS), 1);
+    }
+
+    #[test]
+    fn cpu_pool_reserves_one_thread_for_install_caller() {
+        assert!(build_cpu_pool_for_allowed_threads(1).is_none());
+
+        let pool = build_cpu_pool_for_allowed_threads(4).unwrap();
+        assert_eq!(pool.current_num_threads(), 3);
     }
 }

--- a/tgrep-core/src/parallel.rs
+++ b/tgrep-core/src/parallel.rs
@@ -1,0 +1,79 @@
+//! Shared parallelism limits for CPU-intensive tgrep work.
+
+use std::sync::OnceLock;
+
+/// Maximum walker threads before applying the CPU-capacity limit.
+pub const MAX_WALKER_THREADS: usize = 12;
+
+static CPU_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+
+/// Number of worker threads allowed for CPU-intensive work.
+///
+/// This is half of the available logical CPU capacity, rounded down so tgrep
+/// does not exceed half capacity on machines with an odd CPU count. A single
+/// worker is kept as the minimum so tgrep remains usable on one-CPU systems.
+pub fn worker_threads() -> usize {
+    half_cpu_threads(available_threads())
+}
+
+/// Number of walker threads after applying both the walker-specific cap and
+/// the process-wide CPU-capacity limit.
+pub fn walker_threads() -> usize {
+    capped_half_cpu_threads(available_threads(), MAX_WALKER_THREADS)
+}
+
+/// Run CPU-intensive Rayon work on tgrep's capped shared thread pool.
+pub fn install<OP, R>(op: OP) -> R
+where
+    OP: FnOnce() -> R + Send,
+    R: Send,
+{
+    cpu_pool().install(op)
+}
+
+fn cpu_pool() -> &'static rayon::ThreadPool {
+    CPU_POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(worker_threads())
+            .thread_name(|index| format!("tgrep-worker-{index}"))
+            .build()
+            .expect("failed to initialize tgrep worker thread pool")
+    })
+}
+
+fn available_threads() -> usize {
+    std::thread::available_parallelism().map_or(1, |threads| threads.get())
+}
+
+fn half_cpu_threads(available: usize) -> usize {
+    (available / 2).max(1)
+}
+
+fn capped_half_cpu_threads(available: usize, cap: usize) -> usize {
+    half_cpu_threads(available).min(cap.max(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_thread_count_uses_floor_half_with_one_thread_minimum() {
+        assert_eq!(half_cpu_threads(0), 1);
+        assert_eq!(half_cpu_threads(1), 1);
+        assert_eq!(half_cpu_threads(2), 1);
+        assert_eq!(half_cpu_threads(3), 1);
+        assert_eq!(half_cpu_threads(4), 2);
+        assert_eq!(half_cpu_threads(5), 2);
+        assert_eq!(half_cpu_threads(8), 4);
+    }
+
+    #[test]
+    fn walker_thread_count_applies_half_limit_before_walker_cap() {
+        assert_eq!(capped_half_cpu_threads(32, MAX_WALKER_THREADS), 12);
+        assert_eq!(capped_half_cpu_threads(24, MAX_WALKER_THREADS), 12);
+        assert_eq!(capped_half_cpu_threads(23, MAX_WALKER_THREADS), 11);
+        assert_eq!(capped_half_cpu_threads(8, MAX_WALKER_THREADS), 4);
+        assert_eq!(capped_half_cpu_threads(2, MAX_WALKER_THREADS), 1);
+    }
+}

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -15,9 +15,10 @@ const BINARY_EXTENSIONS: &[&str] = &[
     "sqlite", "sqlite3",
 ];
 
-/// Number of parallel walker threads (capped at 12 to avoid diminishing returns).
+/// Number of parallel walker threads, capped by tgrep's CPU-capacity limit and
+/// by a walker-specific maximum to avoid diminishing returns.
 fn walker_thread_count() -> usize {
-    std::thread::available_parallelism().map_or(4, |n| n.get().min(12))
+    crate::parallel::walker_threads()
 }
 
 /// Check if a directory entry should be skipped based on exclude list.


### PR DESCRIPTION
## Summary
- add a shared capped Rayon thread pool sized to half of available logical CPUs
- apply the same half-cap to parallel filesystem walking, preserving the existing 12-thread walker ceiling
- wrap CPU-heavy indexing, filestamp collection, background indexing, and server matching work in the capped pool

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace