### PR TITLE
Process watcher events off-thread to avoid dropping them during flushes

### DIFF
--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -245,6 +245,14 @@ enum Command {
         /// Exclude directories from indexing (can be specified multiple times).
         #[arg(long = "exclude", action = clap::ArgAction::Append)]
         exclude: Vec<String>,
+
+        /// Maximum number of pending file-change events the watcher buffers.
+        /// When exceeded (e.g. a large sync while a flush holds the index),
+        /// overflow triggers a reconciling stale refresh instead of unbounded
+        /// growth. Raise it to absorb bigger bursts without a refresh, at the
+        /// cost of more memory. Defaults to 16384.
+        #[arg(long = "watcher-queue-cap", value_name = "N", value_parser = parse_positive_usize)]
+        watcher_queue_cap: Option<usize>,
     },
 
     /// Search for a pattern.
@@ -322,6 +330,16 @@ impl Cli {
     }
 }
 
+/// Parse a CLI argument as a `usize` of at least 1. Parsing at the target's
+/// pointer width rejects values too large to fit rather than truncating them.
+fn parse_positive_usize(s: &str) -> Result<usize, String> {
+    match s.parse::<usize>() {
+        Ok(0) => Err("value must be at least 1".to_string()),
+        Ok(n) => Ok(n),
+        Err(_) => Err(format!("`{s}` is not a valid positive integer")),
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -341,6 +359,7 @@ fn main() {
             max_memory_mb,
             max_cpu_percent,
             exclude,
+            watcher_queue_cap,
         }) => {
             let memory_cap = max_memory_mb
                 .map(|mb| mb.saturating_mul(1024 * 1024))
@@ -353,6 +372,7 @@ fn main() {
                 &exclude,
                 memory_cap,
                 index_threads,
+                watcher_queue_cap,
             )
         }
         Some(Command::Search {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -27,6 +27,10 @@ use tgrep_core::query;
 const CACHE_CAPACITY: usize = 50_000;
 const AUTO_SAVE_MUTATIONS: u32 = 5000;
 const AUTO_SAVE_INTERVAL: Duration = Duration::from_secs(600); // 10 minutes
+/// Default bound on the watcher's pending-event queue (override with
+/// `--watcher-queue-cap`). Caps memory when a flush holds the gate while events
+/// pour in; overflow triggers a reconciling stale refresh.
+const WATCHER_QUEUE_CAP: usize = 16_384;
 
 /// Server discovery info, written to `serve.json`.
 #[derive(Debug, Serialize, Deserialize)]
@@ -183,8 +187,10 @@ pub fn run(
     exclude_dirs: &[String],
     memory_cap_bytes: u64,
     index_threads: usize,
+    watcher_queue_cap: Option<usize>,
 ) -> Result<()> {
     let serve_start = Instant::now();
+    let watcher_queue_cap = watcher_queue_cap.unwrap_or(WATCHER_QUEUE_CAP);
     let root = std::fs::canonicalize(root)?;
     let index_dir = index_path
         .map(|p| p.to_path_buf())
@@ -270,12 +276,13 @@ pub fn run(
 
     eprintln!(
         "[trace] serve ready in {:.1}ms. TCP on port {}. Cache: max {} entries. \
-         Memory cap: {} MB. Index threads: {}.",
+         Memory cap: {} MB. Index threads: {}. Watcher queue cap: {}.",
         serve_start.elapsed().as_secs_f64() * 1000.0,
         port,
         CACHE_CAPACITY,
         memory_cap_bytes / (1024 * 1024),
         index_threads,
+        watcher_queue_cap,
     );
 
     // If no pre-existing index, build into the LiveIndex in background
@@ -306,7 +313,7 @@ pub fn run(
     } else {
         let watcher_state = Arc::clone(&state);
         let watcher_root = root.clone();
-        start_file_watcher(watcher_state, &watcher_root)
+        start_file_watcher(watcher_state, &watcher_root, &index_dir, watcher_queue_cap)
     };
 
     // Set up graceful shutdown
@@ -818,14 +825,61 @@ fn handle_reload(id: Option<serde_json::Value>, state: &ServerState) -> String {
     }
 }
 
-fn start_file_watcher(state: Arc<ServerState>, root: &Path) -> Option<RecommendedWatcher> {
+fn start_file_watcher(
+    state: Arc<ServerState>,
+    root: &Path,
+    index_dir: &Path,
+    queue_cap: usize,
+) -> Option<RecommendedWatcher> {
+    use std::sync::mpsc::{RecvTimeoutError, TrySendError};
+
     let root_path = root.to_path_buf();
-    let state_clone = Arc::clone(&state);
+    let index_dir = index_dir.to_path_buf();
+
+    // The callback only enqueues events; a worker thread drains the queue and
+    // runs `handle_fs_event`. The callback must return promptly (the OS event
+    // buffer drops events if it is slow), but `handle_fs_event` blocks on
+    // `snapshot_gate` for the duration of a flush. Queuing lets events that
+    // arrive during a flush wait in memory rather than being dropped.
+    //
+    // The queue is bounded so a long flush under heavy churn can't grow it
+    // without limit. On overflow the callback sets `overflowed` rather than
+    // blocking; once the flush releases the gate the worker runs a stale
+    // refresh, reconciling any events dropped while the queue was full.
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Event>(queue_cap);
+    let overflowed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    {
+        let worker_state = Arc::clone(&state);
+        let worker_root = root_path.clone();
+        let worker_overflowed = Arc::clone(&overflowed);
+        thread::spawn(move || {
+            loop {
+                match rx.recv_timeout(Duration::from_secs(1)) {
+                    Ok(event) => handle_fs_event(&worker_state, &worker_root, &event),
+                    Err(RecvTimeoutError::Timeout) => {}
+                    Err(RecvTimeoutError::Disconnected) => break,
+                }
+                if worker_overflowed.swap(false, Ordering::Relaxed) {
+                    eprintln!("[trace] watcher queue overflowed; reconciling with a stale refresh");
+                    background_refresh_stale(&worker_state, &worker_root, &index_dir);
+                }
+            }
+        });
+    }
 
     let mut watcher = match notify::recommended_watcher(
         move |result: std::result::Result<Event, notify::Error>| {
             if let Ok(event) = result {
-                handle_fs_event(&state_clone, &root_path, &event);
+                // Non-blocking hand-off to the worker thread.
+                match tx.try_send(event) {
+                    Ok(()) => {}
+                    // Queue full: flag for a reconciling refresh instead of
+                    // blocking the callback (which would overflow the OS buffer).
+                    Err(TrySendError::Full(_)) => overflowed.store(true, Ordering::Relaxed),
+                    Err(TrySendError::Disconnected(_)) => {
+                        eprintln!("[trace] warning: watcher worker stopped; event dropped");
+                    }
+                }
             }
         },
     ) {
@@ -1216,22 +1270,25 @@ fn create_empty_index(index_dir: &Path) -> Result<()> {
 /// Compares stored filestamps against current filesystem metadata, then upserts
 /// changed/new files and removes deleted files from the LiveIndex.
 fn background_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &Path) {
-    use tgrep_core::meta::{self, FileStamp};
+    use tgrep_core::meta::FileStamp;
     use tgrep_core::walker;
 
     let start = Instant::now();
     eprintln!("[trace] stale check: comparing index against filesystem...");
 
-    // Load stored per-file stamps from last index write
-    let old_stamps = match meta::read_filestamps(index_dir) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("[trace] stale check: no filestamps found ({e}), skipping");
-            return;
-        }
-    };
+    // Baseline the diff on the persisted per-file stamps, then overlay the
+    // in-memory stamps. The on-disk set is the complete snapshot from the last
+    // flush; the in-memory set carries the freshest updates applied since.
+    // Merging keeps the baseline complete — so an incomplete in-memory map does
+    // not misread existing files as new — while still reflecting mid-session
+    // changes that an overflow-triggered refresh must repair (on-disk stamps
+    // lag until the next flush).
+    let mut old_stamps = tgrep_core::meta::read_filestamps(index_dir).unwrap_or_default();
+    for (path, stamp) in state.file_stamps.read().unwrap().iter() {
+        old_stamps.insert(path.clone(), stamp.clone());
+    }
     if old_stamps.is_empty() {
-        eprintln!("[trace] stale check: no filestamps found, skipping");
+        eprintln!("[trace] stale check: no filestamps yet, skipping");
         return;
     }
 


### PR DESCRIPTION
## Summary

The file watcher's `notify` callback ran `handle_fs_event` inline. That handler takes `snapshot_gate.read()`, which an index flush / auto-save holds in write mode for the entire flush — seconds to minutes on large repositories. Blocking the callback that long overflows the OS event buffer, so filesystem changes made during a flush are silently dropped and the index drifts out of sync until the next restart.

## Change

Move event processing to a dedicated worker thread fed by an `mpsc` channel. The `notify` callback now only enqueues events, so it always returns promptly and the OS buffer keeps draining. Events that arrive while a flush holds the gate wait in the in-memory queue and are processed once the flush completes — no events are lost.

`cargo fmt --all --check`, `cargo clippy --all-targets`, and `cargo test` pass.
