### PR TITLE
Make the auto-save mutation threshold configurable (--auto-save-mutations)

### DIFF
--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -245,6 +245,13 @@ enum Command {
         /// Exclude directories from indexing (can be specified multiple times).
         #[arg(long = "exclude", action = clap::ArgAction::Append)]
         exclude: Vec<String>,
+
+        /// Number of accumulated index mutations that triggers a background
+        /// save. Higher values reduce save frequency (and the pauses they
+        /// cause during heavy churn) at the cost of more unsaved work if the
+        /// process is killed. Defaults to 5000.
+        #[arg(long = "auto-save-mutations", value_name = "N", value_parser = clap::value_parser!(u32).range(1..))]
+        auto_save_mutations: Option<u32>,
     },
 
     /// Search for a pattern.
@@ -341,6 +348,7 @@ fn main() {
             max_memory_mb,
             max_cpu_percent,
             exclude,
+            auto_save_mutations,
         }) => {
             let memory_cap = max_memory_mb
                 .map(|mb| mb.saturating_mul(1024 * 1024))
@@ -353,6 +361,7 @@ fn main() {
                 &exclude,
                 memory_cap,
                 index_threads,
+                auto_save_mutations,
             )
         }
         Some(Command::Search {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -25,6 +25,8 @@ use tgrep_core::hybrid::HybridIndex;
 use tgrep_core::query;
 
 const CACHE_CAPACITY: usize = 50_000;
+/// Default mutation count that triggers a background save (override with
+/// `--auto-save-mutations`).
 const AUTO_SAVE_MUTATIONS: u32 = 5000;
 const AUTO_SAVE_INTERVAL: Duration = Duration::from_secs(600); // 10 minutes
 
@@ -165,6 +167,10 @@ struct ServerState {
     /// Number of worker threads used for the parallel file-reading/trigram
     /// extraction during the initial build. Caps indexing CPU usage.
     index_threads: usize,
+    /// Number of accumulated in-memory mutations that triggers a background
+    /// save. Higher values reduce save frequency (and the pauses they cause)
+    /// at the cost of more unsaved work if the process is killed.
+    auto_save_mutations: u32,
 }
 
 struct SearchOpts {
@@ -183,8 +189,10 @@ pub fn run(
     exclude_dirs: &[String],
     memory_cap_bytes: u64,
     index_threads: usize,
+    auto_save_mutations: Option<u32>,
 ) -> Result<()> {
     let serve_start = Instant::now();
+    let auto_save_mutations = auto_save_mutations.unwrap_or(AUTO_SAVE_MUTATIONS);
     let root = std::fs::canonicalize(root)?;
     let index_dir = index_path
         .map(|p| p.to_path_buf())
@@ -255,6 +263,7 @@ pub fn run(
         gitignore: RwLock::new(None),
         memory_cap_bytes,
         index_threads,
+        auto_save_mutations,
     });
 
     // Bind TCP listener on a random port
@@ -1075,7 +1084,7 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
         };
 
         let elapsed = last_save.elapsed();
-        if dirty >= AUTO_SAVE_MUTATIONS || (dirty > 0 && elapsed >= AUTO_SAVE_INTERVAL) {
+        if dirty >= state.auto_save_mutations || (dirty > 0 && elapsed >= AUTO_SAVE_INTERVAL) {
             let save_start = Instant::now();
             eprintln!("[trace] auto-save: {dirty} mutations, saving...");
 


### PR DESCRIPTION
## Summary

`tgrep serve` auto-saves the in-memory index to disk once a fixed **5000** accumulated mutations pile up (`AUTO_SAVE_MUTATIONS`). Under sustained filesystem churn — a large VCS sync, a big build, mass file operations — that threshold is crossed repeatedly, firing frequent full-index saves that each briefly pause indexing.

## Change

Expose the threshold as `--auto-save-mutations <N>` on `serve` (default unchanged at 5000), threaded through `ServerState` to the auto-save loop. Raising it reduces save frequency during heavy churn, trading a larger unsaved-work window (recovered by the stale check on next start) for fewer mid-activity pauses.

`cargo fmt --all --check`, `cargo clippy --all-targets`, and `cargo test` pass.
