### PR TITLE
Add p4ignore.ini support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "0.1.21"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.21"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.21"
+version = "1.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Prints the count to stdout (scriptable) and details to stderr:
 | `-0, --null` | NUL byte filename separator (for xargs) |
 | `--trim` | Trim leading/trailing whitespace |
 | `--hidden` | Include hidden files and directories |
-| `--no-ignore` | Don't respect .gitignore files |
+| `--no-ignore` | Don't respect `.gitignore` or `p4ignore.ini` files |
 | `-u` | Unrestricted: `-u` = no-ignore, `-uu` = +hidden |
 | `--no-index` | Skip index, grep all files |
 | `--exclude <DIR>` | Exclude directory from indexing (repeatable) |
@@ -223,7 +223,8 @@ Prints the count to stdout (scriptable) and details to stderr:
 
 ## How It Works
 
-1. **Indexing** — walks the repo (respecting `.gitignore`), skips binary files
+1. **Indexing** — walks the repo (respecting `.gitignore` and root-level
+   `p4ignore.ini`), skips binary files
    by extension (50+ formats) and content check (first 8KB), extracts all
    overlapping 3-byte trigrams from each text file in parallel (rayon), and
    writes a compact binary inverted index. Full builds stream sorted posting
@@ -269,7 +270,7 @@ tgrep/
 │   └── src/
 │       ├── trigram.rs            # Trigram extraction & hashing
 │       ├── filetypes.rs          # File type definitions (rust, py, js, …)
-│       ├── walker.rs             # .gitignore-aware file traversal
+│       ├── walker.rs             # Git/Perforce ignore-aware file traversal
 │       ├── ondisk.rs             # On-disk binary format
 │       ├── builder.rs            # Index construction (parallel via rayon)
 │       ├── reader.rs             # Mmap'd index reader

--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -8,8 +8,9 @@ pub fn run(
     root: &Path,
     index_path: Option<&Path>,
     include_hidden: bool,
+    no_ignore: bool,
     exclude_dirs: &[String],
 ) -> Result<()> {
-    builder::build_index(root, index_path, include_hidden, exclude_dirs)?;
+    builder::build_index(root, index_path, include_hidden, no_ignore, exclude_dirs)?;
     Ok(())
 }

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -191,7 +191,7 @@ struct Cli {
     #[arg(long = "hidden", global = true)]
     hidden: bool,
 
-    /// Don't respect .gitignore files.
+    /// Don't respect .gitignore or p4ignore.ini files.
     #[arg(long = "no-ignore", global = true)]
     no_ignore: bool,
 

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -362,12 +362,14 @@ fn main() {
             serve::run(
                 &path,
                 cli.index_path.as_deref(),
-                no_watch,
-                &exclude,
-                memory_cap,
-                index_threads,
-                no_ignore,
-                auto_save_mutations,
+                serve::ServeOptions {
+                    no_watch,
+                    exclude_dirs: &exclude,
+                    memory_cap_bytes: memory_cap,
+                    index_threads,
+                    no_ignore,
+                    auto_save_mutations,
+                },
             )
         }
         Some(Command::Search {

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -324,6 +324,7 @@ impl Cli {
 
 fn main() {
     let cli = Cli::parse();
+    let no_ignore = cli.no_ignore || cli.unrestricted >= 1;
 
     // Handle --type-list
     if cli.type_list {
@@ -332,9 +333,13 @@ fn main() {
     }
 
     let result = match cli.command {
-        Some(Command::Index { path, exclude, .. }) => {
-            index::run(&path, cli.index_path.as_deref(), cli.hidden, &exclude)
-        }
+        Some(Command::Index { path, exclude, .. }) => index::run(
+            &path,
+            cli.index_path.as_deref(),
+            cli.hidden,
+            no_ignore,
+            &exclude,
+        ),
         Some(Command::Serve {
             path,
             no_watch,
@@ -353,6 +358,7 @@ fn main() {
                 &exclude,
                 memory_cap,
                 index_threads,
+                no_ignore,
             )
         }
         Some(Command::Search {
@@ -360,7 +366,7 @@ fn main() {
             ref paths,
         }) => run_search(&cli, pattern.clone(), paths),
         Some(Command::Status { path }) => status::run(&path, cli.index_path.as_deref()),
-        Some(Command::CountFiles { path }) => walkcount::run(&path, cli.hidden, cli.no_ignore),
+        Some(Command::CountFiles { path }) => walkcount::run(&path, cli.hidden, no_ignore),
         None => {
             if cli.list_files {
                 let opts = cli.build_search_opts(String::new());

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -191,16 +191,24 @@ struct SearchOpts {
     after_context: usize,
 }
 
-pub fn run(
-    root: &Path,
-    index_path: Option<&Path>,
-    no_watch: bool,
-    exclude_dirs: &[String],
-    memory_cap_bytes: u64,
-    index_threads: usize,
-    no_ignore: bool,
-    auto_save_mutations: Option<u32>,
-) -> Result<()> {
+pub struct ServeOptions<'a> {
+    pub no_watch: bool,
+    pub exclude_dirs: &'a [String],
+    pub memory_cap_bytes: u64,
+    pub index_threads: usize,
+    pub no_ignore: bool,
+    pub auto_save_mutations: Option<u32>,
+}
+
+pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) -> Result<()> {
+    let ServeOptions {
+        no_watch,
+        exclude_dirs,
+        memory_cap_bytes,
+        index_threads,
+        no_ignore,
+        auto_save_mutations,
+    } = options;
     let serve_start = Instant::now();
     let auto_save_mutations = auto_save_mutations.unwrap_or(AUTO_SAVE_MUTATIONS);
     let root = std::fs::canonicalize(root)?;

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -113,8 +113,8 @@ struct ServerState {
     /// An ignore file changed during the initial build and requires a
     /// reconciliation after the build publishes.
     ignore_rules_dirty: std::sync::atomic::AtomicBool,
-    /// Serializes asynchronous ignore-rule rebuild and reconciliation work.
-    ignore_refresh_lock: Mutex<()>,
+    /// Ensures a burst of ignore-file events uses at most one refresh worker.
+    ignore_refresh_scheduled: std::sync::atomic::AtomicBool,
     /// Progress: number of files indexed so far.
     index_progress: std::sync::atomic::AtomicU64,
     /// Total files discovered for indexing.
@@ -272,7 +272,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         indexing: std::sync::atomic::AtomicBool::new(needs_build),
         flushing: std::sync::atomic::AtomicBool::new(false),
         ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
-        ignore_refresh_lock: Mutex::new(()),
+        ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
         watch_enabled: !no_watch,
@@ -956,27 +956,45 @@ fn should_skip_watcher_path(
     false
 }
 
-fn is_ignore_rules_file(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name == ".gitignore" || name == "p4ignore.ini")
+fn is_ignore_rules_file(root: &Path, path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some(".gitignore")
+        || path == root.join(tgrep_core::gitignore::P4IGNORE_FILENAME)
 }
 
 fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
-    thread::spawn(move || {
-        let _refresh = state.ignore_refresh_lock.lock().unwrap();
-        if !state.ignore_rules_dirty.swap(false, Ordering::SeqCst) {
-            return;
-        }
+    if state
+        .ignore_refresh_scheduled
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
 
-        build_gitignore_matcher_after_ready(&state, &root);
-        let indexed_paths = {
-            let index = state.index.read().unwrap();
-            let mut paths = index.reader_paths();
-            paths.extend(index.live.overlay_paths());
-            paths
-        };
-        background_refresh_stale(&state, &root, &state.index_dir, Some(&indexed_paths));
+    thread::spawn(move || {
+        loop {
+            if state.ignore_rules_dirty.swap(false, Ordering::SeqCst) {
+                build_gitignore_matcher_after_ready(&state, &root);
+                let indexed_paths = {
+                    let index = state.index.read().unwrap();
+                    let mut paths = index.reader_paths();
+                    paths.extend(index.live.overlay_paths());
+                    paths
+                };
+                background_refresh_stale(&state, &root, &state.index_dir, Some(&indexed_paths));
+            }
+
+            state
+                .ignore_refresh_scheduled
+                .store(false, Ordering::SeqCst);
+            if !state.ignore_rules_dirty.load(Ordering::SeqCst)
+                || state
+                    .ignore_refresh_scheduled
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_err()
+            {
+                break;
+            }
+        }
     });
 }
 
@@ -991,8 +1009,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         return;
     }
 
-    let ignore_rules_changed =
-        !state.no_ignore && event.paths.iter().any(|path| is_ignore_rules_file(path));
+    let ignore_rules_changed = !state.no_ignore
+        && event
+            .paths
+            .iter()
+            .any(|path| is_ignore_rules_file(root, path));
     if ignore_rules_changed {
         state.ignore_rules_dirty.store(true, Ordering::SeqCst);
         if state.indexing.load(Ordering::SeqCst) {
@@ -2339,10 +2360,27 @@ mod tests {
 
     #[test]
     fn identifies_live_ignore_rule_changes() {
-        assert!(is_ignore_rules_file(Path::new("nested/.gitignore")));
-        assert!(is_ignore_rules_file(Path::new("p4ignore.ini")));
-        assert!(!is_ignore_rules_file(Path::new(".git/info/exclude")));
-        assert!(!is_ignore_rules_file(Path::new("src/main.rs")));
+        let root = Path::new("workspace");
+        assert!(is_ignore_rules_file(
+            root,
+            Path::new("workspace/nested/.gitignore")
+        ));
+        assert!(is_ignore_rules_file(
+            root,
+            Path::new("workspace/p4ignore.ini")
+        ));
+        assert!(!is_ignore_rules_file(
+            root,
+            Path::new("workspace/nested/p4ignore.ini")
+        ));
+        assert!(!is_ignore_rules_file(
+            root,
+            Path::new("workspace/.git/info/exclude")
+        ));
+        assert!(!is_ignore_rules_file(
+            root,
+            Path::new("workspace/src/main.rs")
+        ));
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -108,6 +108,11 @@ struct ServerState {
     /// from kicking off a redundant parallel snapshot while the bulk
     /// flush (or stale-refresh flush) is still executing.
     flushing: std::sync::atomic::AtomicBool,
+    /// An ignore file changed during the initial build and requires a
+    /// reconciliation after the build publishes.
+    ignore_rules_dirty: std::sync::atomic::AtomicBool,
+    /// Serializes asynchronous ignore-rule rebuild and reconciliation work.
+    ignore_refresh_lock: Mutex<()>,
     /// Progress: number of files indexed so far.
     index_progress: std::sync::atomic::AtomicU64,
     /// Total files discovered for indexing.
@@ -116,6 +121,10 @@ struct ServerState {
     watch_enabled: bool,
     /// Directories to exclude from indexing.
     exclude_dirs: Vec<String>,
+    /// Disable all source-control ignore files for every server discovery path.
+    no_ignore: bool,
+    /// On-disk index directory used by live ignore-rule reconciliation.
+    index_dir: PathBuf,
     /// Serializes on-disk index publication across all publishers
     /// (auto-save, checkpoint, flush). Held across
     /// `move_staged_files` + `IndexReader::open` + `swap_reader` so
@@ -157,7 +166,7 @@ struct ServerState {
     /// `serve ready` on a full-tree `.gitignore` discovery walk. `None` while
     /// loading or if no matcher could be built; during that window the watcher
     /// falls back to hidden / exclude filtering.
-    gitignore: RwLock<Option<tgrep_core::gitignore::Gitignore>>,
+    gitignore: RwLock<Option<tgrep_core::gitignore::IgnoreMatcher>>,
     /// Maximum RSS budget (bytes). When the process exceeds this during the
     /// initial build, the indexer flushes the overlay to disk and continues so
     /// peak memory stays bounded while still producing a complete index.
@@ -183,6 +192,7 @@ pub fn run(
     exclude_dirs: &[String],
     memory_cap_bytes: u64,
     index_threads: usize,
+    no_ignore: bool,
 ) -> Result<()> {
     let serve_start = Instant::now();
     let root = std::fs::canonicalize(root)?;
@@ -245,10 +255,14 @@ pub fn run(
         watcher_active: std::sync::atomic::AtomicBool::new(false),
         indexing: std::sync::atomic::AtomicBool::new(needs_build),
         flushing: std::sync::atomic::AtomicBool::new(false),
+        ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
+        ignore_refresh_lock: Mutex::new(()),
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
         watch_enabled: !no_watch,
         exclude_dirs: exclude_dirs.to_vec(),
+        no_ignore,
+        index_dir: index_dir.clone(),
         publish_lock: Mutex::new(()),
         file_stamps: RwLock::new(tgrep_core::meta::read_filestamps(&index_dir).unwrap_or_default()),
         snapshot_gate: RwLock::new(()),
@@ -292,8 +306,8 @@ pub fn run(
         let stale_root = root.clone();
         let stale_index_dir = index_dir.clone();
         thread::spawn(move || {
-            background_refresh_stale(&stale_state, &stale_root, &stale_index_dir);
-            if stale_state.watch_enabled {
+            background_refresh_stale(&stale_state, &stale_root, &stale_index_dir, None);
+            if stale_state.watch_enabled && !stale_state.no_ignore {
                 build_gitignore_matcher_after_ready(&stale_state, &stale_root);
             }
         });
@@ -341,6 +355,10 @@ pub fn run(
 }
 
 fn build_gitignore_matcher_after_ready(state: &ServerState, root: &Path) {
+    if state.no_ignore {
+        *state.gitignore.write().unwrap() = None;
+        return;
+    }
     let start = Instant::now();
     eprintln!("[trace] gitignore matcher build started...");
     let matcher = tgrep_core::gitignore::build_matcher(root);
@@ -797,11 +815,16 @@ fn handle_status(id: Option<serde_json::Value>, state: &ServerState) -> String {
 }
 
 fn handle_reload(id: Option<serde_json::Value>, state: &ServerState) -> String {
-    let index_dir = builder::default_index_dir(&state.root);
+    let index_dir = state.index_dir.clone();
 
     // Rebuild from disk
-    if let Err(e) = builder::build_index(&state.root, Some(&index_dir), false, &state.exclude_dirs)
-    {
+    if let Err(e) = builder::build_index(
+        &state.root,
+        Some(&index_dir),
+        false,
+        state.no_ignore,
+        &state.exclude_dirs,
+    ) {
         return json_rpc_error(id, -32000, &format!("rebuild failed: {e}"));
     }
 
@@ -876,7 +899,7 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path) -> Option<Recommende
 fn should_skip_watcher_path(
     rel_path: &str,
     exclude_dirs: &[String],
-    gitignore: Option<&tgrep_core::gitignore::Gitignore>,
+    gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
 ) -> bool {
     // Single streaming pass over path components — no Vec allocation
     // on the hot watcher path. The hidden-component check applies to
@@ -908,8 +931,7 @@ fn should_skip_watcher_path(
         // Notify usually fires per-file events anyway, and gitignore
         // rules that target dirs would have already skipped the dir's
         // contents via `matched_path_or_any_parents`.
-        let m = gi.matched_path_or_any_parents(rel_path, /* is_dir = */ false);
-        if m.is_ignore() {
+        if gi.is_ignored(Path::new(rel_path), false) {
             return true;
         }
     }
@@ -917,21 +939,55 @@ fn should_skip_watcher_path(
     false
 }
 
-fn handle_fs_event(state: &ServerState, root: &Path, event: &Event) {
-    use tgrep_core::meta::FileStamp;
+fn is_ignore_rules_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == ".gitignore" || name == "p4ignore.ini")
+}
 
-    // Skip file events while the initial background index build is in progress —
-    // the indexer will pick up all files itself, and the watcher would just
-    // cause duplicate reindex work.
-    if state.indexing.load(Ordering::SeqCst) {
-        return;
-    }
+fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
+    thread::spawn(move || {
+        let _refresh = state.ignore_refresh_lock.lock().unwrap();
+        if !state.ignore_rules_dirty.swap(false, Ordering::SeqCst) {
+            return;
+        }
+
+        build_gitignore_matcher_after_ready(&state, &root);
+        let indexed_paths = {
+            let index = state.index.read().unwrap();
+            let mut paths = index.reader_paths();
+            paths.extend(index.live.overlay_paths());
+            paths
+        };
+        background_refresh_stale(&state, &root, &state.index_dir, Some(&indexed_paths));
+    });
+}
+
+fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
+    use tgrep_core::meta::FileStamp;
 
     let dominated_kinds = matches!(
         event.kind,
         EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
     );
     if !dominated_kinds {
+        return;
+    }
+
+    let ignore_rules_changed =
+        !state.no_ignore && event.paths.iter().any(|path| is_ignore_rules_file(path));
+    if ignore_rules_changed {
+        state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+        if state.indexing.load(Ordering::SeqCst) {
+            return;
+        }
+        schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+        return;
+    }
+
+    // Skip ordinary file events while the initial background index build is in
+    // progress. The indexer will pick up those files itself.
+    if state.indexing.load(Ordering::SeqCst) {
         return;
     }
 
@@ -1215,7 +1271,52 @@ fn create_empty_index(index_dir: &Path) -> Result<()> {
 /// Detect files that changed while the server was not running.
 /// Compares stored filestamps against current filesystem metadata, then upserts
 /// changed/new files and removes deleted files from the LiveIndex.
-fn background_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &Path) {
+fn classify_file_changes(
+    current_meta: &[tgrep_core::walker::FileMeta],
+    old_stamps: &std::collections::HashMap<String, tgrep_core::meta::FileStamp>,
+    indexed_paths: Option<&std::collections::HashSet<String>>,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    use tgrep_core::meta::FileStamp;
+
+    let mut current_set = std::collections::HashSet::with_capacity(current_meta.len());
+    let mut changed = Vec::new();
+    let mut added = Vec::new();
+
+    for fm in current_meta {
+        current_set.insert(fm.relative_path.clone());
+        let stamp = FileStamp {
+            mtime: fm.mtime,
+            size: fm.size,
+        };
+        if indexed_paths.is_some_and(|paths| !paths.contains(&fm.relative_path)) {
+            added.push(fm.relative_path.clone());
+            continue;
+        }
+        match old_stamps.get(&fm.relative_path) {
+            Some(old) if *old == stamp => {}
+            Some(_) => changed.push(fm.relative_path.clone()),
+            None => added.push(fm.relative_path.clone()),
+        }
+    }
+
+    let indexed_or_stamped_paths: Box<dyn Iterator<Item = &String>> = match indexed_paths {
+        Some(paths) => Box::new(paths.iter()),
+        None => Box::new(old_stamps.keys()),
+    };
+    let deleted = indexed_or_stamped_paths
+        .filter(|path| !current_set.contains(path.as_str()))
+        .cloned()
+        .collect();
+
+    (changed, added, deleted)
+}
+
+fn background_refresh_stale(
+    state: &Arc<ServerState>,
+    root: &Path,
+    index_dir: &Path,
+    indexed_paths: Option<&std::collections::HashSet<String>>,
+) {
     use tgrep_core::meta::{self, FileStamp};
     use tgrep_core::walker;
 
@@ -1230,48 +1331,17 @@ fn background_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &P
             return;
         }
     };
-    if old_stamps.is_empty() {
+    if old_stamps.is_empty() && indexed_paths.is_none() {
         eprintln!("[trace] stale check: no filestamps found, skipping");
         return;
     }
 
     // Walk filesystem metadata (no content reads)
-    let current_meta = walker::walk_file_metadata(root, &state.exclude_dirs);
+    let current_meta = walker::walk_file_metadata(root, &state.exclude_dirs, state.no_ignore);
     let walk_ms = start.elapsed().as_millis();
 
-    // Build lookup of current filesystem state
-    let mut current_set: std::collections::HashSet<String> =
-        std::collections::HashSet::with_capacity(current_meta.len());
-    let mut changed: Vec<String> = Vec::new();
-    let mut added: Vec<String> = Vec::new();
-
-    for fm in &current_meta {
-        current_set.insert(fm.relative_path.clone());
-        let stamp = FileStamp {
-            mtime: fm.mtime,
-            size: fm.size,
-        };
-        match old_stamps.get(&fm.relative_path) {
-            Some(old) if *old == stamp => {
-                // Unchanged — skip
-            }
-            Some(_) => {
-                // mtime or size differs — file changed
-                changed.push(fm.relative_path.clone());
-            }
-            None => {
-                // New file (not in previous index)
-                added.push(fm.relative_path.clone());
-            }
-        }
-    }
-
-    // Detect deleted files (in old stamps but not on filesystem)
-    let deleted: Vec<String> = old_stamps
-        .keys()
-        .filter(|p| !current_set.contains(p.as_str()))
-        .cloned()
-        .collect();
+    let (changed, added, deleted) =
+        classify_file_changes(&current_meta, &old_stamps, indexed_paths);
 
     let total_changes = changed.len() + added.len() + deleted.len();
     if total_changes == 0 {
@@ -1395,13 +1465,14 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         root,
         &WalkOptions {
             include_hidden: false,
-            collect_gitignore_files: state.watch_enabled,
+            no_ignore: state.no_ignore,
+            collect_gitignore_files: state.watch_enabled && !state.no_ignore,
             exclude_dirs: state.exclude_dirs.clone(),
             ..Default::default()
         },
     );
 
-    if state.watch_enabled {
+    if state.watch_enabled && !state.no_ignore {
         let start = Instant::now();
         let matcher = walker::build_gitignore_matcher_from_files(root, &walk.gitignore_files);
         let has_matcher = matcher.is_some();
@@ -1563,7 +1634,8 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // the index looks fully published but `filestamps.json` is missing — a
     // server kill in that window disables incremental stale detection on
     // the next start.
-    let walk_meta = tgrep_core::walker::walk_file_metadata(root, &state.exclude_dirs);
+    let walk_meta =
+        tgrep_core::walker::walk_file_metadata(root, &state.exclude_dirs, state.no_ignore);
     let stamps: std::collections::HashMap<String, tgrep_core::meta::FileStamp> = walk_meta
         .into_iter()
         .map(|fm| {
@@ -1621,6 +1693,10 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     if pruned {
         let mut index = state.index.write().unwrap();
         index.live.shrink_to_fit();
+    }
+
+    if state.ignore_rules_dirty.load(Ordering::SeqCst) {
+        schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
     }
 }
 
@@ -2242,6 +2318,47 @@ mod tests {
             &no_exclude,
             Some(&gi)
         ));
+    }
+
+    #[test]
+    fn identifies_live_ignore_rule_changes() {
+        assert!(is_ignore_rules_file(Path::new("nested/.gitignore")));
+        assert!(is_ignore_rules_file(Path::new("p4ignore.ini")));
+        assert!(!is_ignore_rules_file(Path::new(".git/info/exclude")));
+        assert!(!is_ignore_rules_file(Path::new("src/main.rs")));
+    }
+
+    #[test]
+    fn ignore_reconcile_compares_against_actual_indexed_paths() {
+        use std::collections::{HashMap, HashSet};
+        use tgrep_core::meta::FileStamp;
+        use tgrep_core::walker::FileMeta;
+
+        let current = vec![
+            FileMeta {
+                relative_path: "kept.txt".to_string(),
+                mtime: 1,
+                size: 10,
+            },
+            FileMeta {
+                relative_path: "newly-unignored.txt".to_string(),
+                mtime: 2,
+                size: 20,
+            },
+        ];
+        let stamps = HashMap::from([
+            ("kept.txt".to_string(), FileStamp { mtime: 1, size: 10 }),
+            (
+                "newly-unignored.txt".to_string(),
+                FileStamp { mtime: 2, size: 20 },
+            ),
+        ]);
+        let indexed = HashSet::from(["kept.txt".to_string(), "newly-ignored.txt".to_string()]);
+
+        let (changed, added, deleted) = classify_file_changes(&current, &stamps, Some(&indexed));
+        assert!(changed.is_empty());
+        assert_eq!(added, vec!["newly-unignored.txt"]);
+        assert_eq!(deleted, vec!["newly-ignored.txt"]);
     }
 
     #[test]

--- a/tgrep-core/benches/index_build.rs
+++ b/tgrep-core/benches/index_build.rs
@@ -39,7 +39,7 @@ fn create_high_diversity_repo(file_count: usize, bytes_per_file: usize) -> TempD
 
 fn build_index_once(root: &Path) {
     let index_dir = root.join(".tgrep_bench");
-    tgrep_core::builder::build_index(root, Some(&index_dir), false, &[]).unwrap();
+    tgrep_core::builder::build_index(root, Some(&index_dir), false, false, &[]).unwrap();
 }
 
 fn bench_index_build(c: &mut Criterion) {

--- a/tgrep-core/benches/query_execution.rs
+++ b/tgrep-core/benches/query_execution.rs
@@ -44,7 +44,7 @@ fn create_common_literal_index(file_count: usize) -> (tempfile::TempDir, IndexRe
         .unwrap();
     }
     let index_dir = dir.path().join(".tgrep_bench");
-    tgrep_core::builder::build_index(dir.path(), Some(&index_dir), false, &[]).unwrap();
+    tgrep_core::builder::build_index(dir.path(), Some(&index_dir), false, false, &[]).unwrap();
     let reader = IndexReader::open(&index_dir).unwrap();
     let plan = query::build_literal_plan("common_search_token", false);
     (dir, reader, plan)

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -27,6 +27,7 @@ pub fn build_index(
     root: &Path,
     index_dir: Option<&Path>,
     include_hidden: bool,
+    no_ignore: bool,
     exclude_dirs: &[String],
 ) -> Result<()> {
     let root = std::fs::canonicalize(root)?;
@@ -41,6 +42,7 @@ pub fn build_index(
         &root,
         &walker::WalkOptions {
             include_hidden,
+            no_ignore,
             exclude_dirs: exclude_dirs.to_vec(),
             ..Default::default()
         },
@@ -594,7 +596,7 @@ mod tests {
         std::fs::write(src.join("b.txt"), "needle two\nother content\n").unwrap();
 
         let index = tempfile::tempdir().unwrap();
-        build_index(repo.path(), Some(index.path()), false, &[]).unwrap();
+        build_index(repo.path(), Some(index.path()), false, false, &[]).unwrap();
 
         let reader = IndexReader::open(index.path()).unwrap();
         reader.validate_lookup().unwrap();
@@ -617,6 +619,39 @@ mod tests {
     }
 
     #[test]
+    fn build_index_no_ignore_includes_p4ignored_files() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("keep.txt"), "keep searchable\n").unwrap();
+        std::fs::write(repo.path().join("asset.txt"), "asset searchable\n").unwrap();
+        std::fs::write(repo.path().join("p4ignore.ini"), "asset.txt\n").unwrap();
+
+        let ignored_index = tempfile::tempdir().unwrap();
+        build_index(repo.path(), Some(ignored_index.path()), false, false, &[]).unwrap();
+        let ignored_reader = IndexReader::open(ignored_index.path()).unwrap();
+        assert!(
+            !(0..ignored_reader.num_files() as u32)
+                .filter_map(|id| ignored_reader.file_path(id))
+                .any(|path| path == "asset.txt")
+        );
+
+        let unrestricted_index = tempfile::tempdir().unwrap();
+        build_index(
+            repo.path(),
+            Some(unrestricted_index.path()),
+            false,
+            true,
+            &[],
+        )
+        .unwrap();
+        let unrestricted_reader = IndexReader::open(unrestricted_index.path()).unwrap();
+        assert!(
+            (0..unrestricted_reader.num_files() as u32)
+                .filter_map(|id| unrestricted_reader.file_path(id))
+                .any(|path| path == "asset.txt")
+        );
+    }
+
+    #[test]
     fn append_overlay_merges_new_files_into_complete_index() {
         use crate::live::LiveIndex;
 
@@ -628,7 +663,7 @@ mod tests {
         std::fs::write(src.join("b.txt"), "needle two\nother content\n").unwrap();
 
         let base_dir = tempfile::tempdir().unwrap();
-        build_index(repo.path(), Some(base_dir.path()), false, &[]).unwrap();
+        build_index(repo.path(), Some(base_dir.path()), false, false, &[]).unwrap();
         let base_reader = IndexReader::open(base_dir.path()).unwrap();
         assert_eq!(base_reader.num_files(), 2);
 

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -13,9 +13,37 @@ use std::path::Path;
 
 pub const P4IGNORE_FILENAME: &str = "p4ignore.ini";
 
+use ignore::Match;
 /// Re-export of `ignore::gitignore::Gitignore` so callers can hold a
 /// matcher without taking a direct dependency on the `ignore` crate.
 pub use ignore::gitignore::Gitignore;
+
+pub struct IgnoreMatcher {
+    local: Gitignore,
+    global: Gitignore,
+}
+
+impl IgnoreMatcher {
+    pub fn new(local: Gitignore, global: Gitignore) -> Option<Self> {
+        (!local.is_empty() || !global.is_empty()).then_some(Self { local, global })
+    }
+
+    pub fn is_ignored(&self, path: &Path, is_dir: bool) -> bool {
+        match self.local.matched_path_or_any_parents(path, is_dir) {
+            Match::Ignore(_) => true,
+            Match::Whitelist(_) => false,
+            Match::None => self
+                .global
+                .matched_path_or_any_parents(path, is_dir)
+                .is_ignore(),
+        }
+    }
+}
+
+pub fn build_global_matcher(root: &Path) -> Gitignore {
+    let builder = ignore::gitignore::GitignoreBuilder::new(root);
+    builder.build_global().0
+}
 
 fn p4ignore_lines(root: &Path) -> Option<(std::path::PathBuf, Vec<String>)> {
     let path = root.join(P4IGNORE_FILENAME);
@@ -111,7 +139,7 @@ pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
 /// Uses `WalkBuilder` to enumerate `.gitignore` files so we automatically
 /// skip the `.git` dir and gitignored subtrees while collecting rules.
 /// Returns `None` when no rules could be loaded.
-pub fn build_matcher(root: &Path) -> Option<Gitignore> {
+pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
     use ignore::gitignore::GitignoreBuilder;
 
     let mut builder = GitignoreBuilder::new(root);
@@ -166,8 +194,8 @@ pub fn build_matcher(root: &Path) -> Option<Gitignore> {
         }
     }
 
-    let gi = builder.build().ok()?;
-    if gi.is_empty() { None } else { Some(gi) }
+    let local = builder.build().ok()?;
+    IgnoreMatcher::new(local, build_global_matcher(root))
 }
 
 #[cfg(test)]
@@ -180,24 +208,30 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         std::fs::write(tmp.path().join(".gitignore"), "*.log\ntarget/\n").unwrap();
         let gi = build_matcher(tmp.path()).expect("matcher should build");
-        assert!(
-            gi.matched_path_or_any_parents("build/output.log", false)
-                .is_ignore()
-        );
-        assert!(
-            gi.matched_path_or_any_parents("target/release/foo", false)
-                .is_ignore()
-        );
-        assert!(
-            !gi.matched_path_or_any_parents("src/main.rs", false)
-                .is_ignore()
-        );
+        assert!(gi.is_ignored(Path::new("build/output.log"), false));
+        assert!(gi.is_ignored(Path::new("target/release/foo"), false));
+        assert!(!gi.is_ignored(Path::new("src/main.rs"), false));
     }
 
     #[test]
     fn returns_none_when_no_rules() {
         let tmp = TempDir::new().unwrap();
         assert!(build_matcher(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn local_whitelist_overrides_global_ignore() {
+        use ignore::gitignore::GitignoreBuilder;
+
+        let tmp = TempDir::new().unwrap();
+        let mut local = GitignoreBuilder::new(tmp.path());
+        local.add_line(None, "!keep.log").unwrap();
+        let mut global = GitignoreBuilder::new(tmp.path());
+        global.add_line(None, "*.log").unwrap();
+        let matcher = IgnoreMatcher::new(local.build().unwrap(), global.build().unwrap()).unwrap();
+
+        assert!(!matcher.is_ignored(Path::new("keep.log"), false));
+        assert!(matcher.is_ignored(Path::new("drop.log"), false));
     }
 
     #[test]

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -175,6 +175,9 @@ pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
             {
                 return false;
             }
+            if entry.file_name() == ".gitignore" {
+                return true;
+            }
 
             let Some(matcher) = &p4ignore else {
                 return true;
@@ -207,6 +210,7 @@ mod tests {
     fn builds_matcher_from_root_gitignore() {
         let tmp = TempDir::new().unwrap();
         std::fs::write(tmp.path().join(".gitignore"), "*.log\ntarget/\n").unwrap();
+        std::fs::write(tmp.path().join(P4IGNORE_FILENAME), ".gitignore\n").unwrap();
         let gi = build_matcher(tmp.path()).expect("matcher should build");
         assert!(gi.is_ignored(Path::new("build/output.log"), false));
         assert!(gi.is_ignored(Path::new("target/release/foo"), false));

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -1,10 +1,9 @@
-//! Point-query gitignore matching for paths.
+//! Point-query source-control ignore matching for paths.
 //!
-//! `walk_dir` / `walk_file_metadata` in `walker.rs` get gitignore behavior
-//! for free via `WalkBuilder::git_ignore(true)` — the rules are applied
+//! `walk_dir` / `walk_file_metadata` in `walker.rs` get ignore behavior
 //! inline as the walker descends. This module is for callers that *don't*
 //! walk and instead need to ask "given an arbitrary path, would the
-//! indexer have skipped it for gitignore reasons?".
+//! indexer have skipped it for ignore-file reasons?".
 //!
 //! The canonical caller is the file watcher in `tgrep-cli`, which has to
 //! answer that per `notify` event without re-walking.
@@ -12,16 +11,102 @@
 use ignore::WalkBuilder;
 use std::path::Path;
 
+pub const P4IGNORE_FILENAME: &str = "p4ignore.ini";
+
 /// Re-export of `ignore::gitignore::Gitignore` so callers can hold a
 /// matcher without taking a direct dependency on the `ignore` crate.
 pub use ignore::gitignore::Gitignore;
 
+fn p4ignore_lines(root: &Path) -> Option<(std::path::PathBuf, Vec<String>)> {
+    let path = root.join(P4IGNORE_FILENAME);
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let lines = contents
+        .lines()
+        .map(|line| line.replace('\\', "/"))
+        .filter(|line| !line.trim().is_empty() && !line.trim_start().starts_with('#'))
+        .collect();
+    Some((path, lines))
+}
+
+/// Add root-level `p4ignore.ini` rules to a gitignore-compatible builder.
+///
+/// Perforce ignore files commonly use Windows path separators. The `ignore`
+/// crate expects `/` in patterns on every platform, so normalize separators
+/// before adding each rule. Comments, globs, and `!` negations then retain
+/// their usual ignore-file semantics.
+pub fn add_p4ignore_rules(builder: &mut ignore::gitignore::GitignoreBuilder, root: &Path) -> bool {
+    let Some((path, lines)) = p4ignore_lines(root) else {
+        return false;
+    };
+
+    let mut added = false;
+    for line in lines {
+        if builder.add_line(Some(path.clone()), &line).is_ok() {
+            added = true;
+        }
+    }
+    added
+}
+
+pub struct P4IgnoreMatcher {
+    matcher: Gitignore,
+    reinclude_prefixes: Vec<String>,
+}
+
+impl P4IgnoreMatcher {
+    pub fn is_ignored(&self, relative: &Path, is_dir: bool) -> bool {
+        if is_dir {
+            let directory = relative.to_string_lossy().replace('\\', "/");
+            let directory = directory.trim_matches('/');
+            if self.reinclude_prefixes.iter().any(|prefix| {
+                prefix == directory
+                    || prefix
+                        .strip_prefix(directory)
+                        .is_some_and(|suffix| suffix.starts_with('/'))
+            }) {
+                return false;
+            }
+        }
+        self.matcher
+            .matched_path_or_any_parents(relative, is_dir)
+            .is_ignore()
+    }
+}
+
+/// Build a matcher containing only root-level `p4ignore.ini` rules.
+pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
+    use ignore::gitignore::GitignoreBuilder;
+
+    let (_, lines) = p4ignore_lines(root)?;
+    let mut builder = GitignoreBuilder::new(root);
+    if !add_p4ignore_rules(&mut builder, root) {
+        return None;
+    }
+    let matcher = builder.build().ok()?;
+    let reinclude_prefixes = lines
+        .iter()
+        .filter_map(|line| line.strip_prefix('!'))
+        .map(|pattern| pattern.trim_start_matches('/'))
+        .filter_map(|pattern| {
+            let literal_end = pattern.find(['*', '?', '[']).unwrap_or(pattern.len());
+            let literal = pattern[..literal_end].trim_end_matches('/');
+            (!literal.is_empty()).then(|| literal.to_string())
+        })
+        .collect();
+
+    (!matcher.is_empty()).then_some(P4IgnoreMatcher {
+        matcher,
+        reinclude_prefixes,
+    })
+}
+
 /// Build a `Gitignore` matcher rooted at `root`, mirroring the same
-/// gitignore semantics that `walker::walk_dir` / `walker::walk_file_metadata`
+/// ignore semantics that `walker::walk_dir` / `walker::walk_file_metadata`
 /// apply during iteration. Loads:
 ///   * `.git/info/exclude` (if present)
 ///   * every `.gitignore` file inside the tree
 ///   * the user's global gitignore (via `GitignoreBuilder`'s defaults)
+///   * root-level `p4ignore.ini`
 ///
 /// Uses `WalkBuilder` to enumerate `.gitignore` files so we automatically
 /// skip the `.git` dir and gitignored subtrees while collecting rules.
@@ -30,11 +115,14 @@ pub fn build_matcher(root: &Path) -> Option<Gitignore> {
     use ignore::gitignore::GitignoreBuilder;
 
     let mut builder = GitignoreBuilder::new(root);
+    let p4ignore = build_p4ignore_matcher(root).map(std::sync::Arc::new);
+    let match_root = root.to_path_buf();
 
     let info_exclude = root.join(".git").join("info").join("exclude");
     if info_exclude.is_file() {
         let _ = builder.add(&info_exclude);
     }
+    add_p4ignore_rules(&mut builder, root);
 
     // Walk to find every `.gitignore` file. We can't use `hidden(true)`
     // because `.gitignore` itself starts with `.` and would be filtered.
@@ -48,17 +136,28 @@ pub fn build_matcher(root: &Path) -> Option<Gitignore> {
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
-        .filter_entry(|entry| {
+        .filter_entry(move |entry| {
             // Allow files (we only care about .gitignore among them).
             // For directories, skip any that start with '.'.
-            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                !entry
+            if entry.file_type().is_some_and(|ft| ft.is_dir())
+                && entry
                     .file_name()
                     .to_str()
                     .is_some_and(|n| n.starts_with('.'))
-            } else {
-                true
+            {
+                return false;
             }
+
+            let Some(matcher) = &p4ignore else {
+                return true;
+            };
+            let Ok(relative) = entry.path().strip_prefix(&match_root) else {
+                return true;
+            };
+            !matcher.is_ignored(
+                relative,
+                entry.file_type().is_some_and(|kind| kind.is_dir()),
+            )
         })
         .build();
     for entry in walker.flatten() {
@@ -99,5 +198,38 @@ mod tests {
     fn returns_none_when_no_rules() {
         let tmp = TempDir::new().unwrap();
         assert!(build_matcher(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn builds_matcher_from_windows_style_p4ignore() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(P4IGNORE_FILENAME),
+            "# generated files\nDerivedDataCache\nBuild\\XboxOne\nbin\\*.xml\n*.pdb\n",
+        )
+        .unwrap();
+
+        let matcher = build_p4ignore_matcher(tmp.path()).expect("matcher should build");
+        assert!(matcher.is_ignored(Path::new("Game/DerivedDataCache/cache.dat"), false));
+        assert!(matcher.is_ignored(Path::new("Build/XboxOne/game.exe"), false));
+        assert!(matcher.is_ignored(Path::new("bin/generated.xml"), false));
+        assert!(matcher.is_ignored(Path::new("symbols/game.pdb"), false));
+        assert!(!matcher.is_ignored(Path::new("src/main.cpp"), false));
+    }
+
+    #[test]
+    fn p4ignore_reinclude_keeps_parent_directory_walkable() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(P4IGNORE_FILENAME),
+            "Build\\XboxOne\n!Build\\XboxOne\\*.template\n",
+        )
+        .unwrap();
+
+        let matcher = build_p4ignore_matcher(tmp.path()).expect("matcher should build");
+        assert!(!matcher.is_ignored(Path::new("Build"), true));
+        assert!(!matcher.is_ignored(Path::new("Build/XboxOne"), true));
+        assert!(matcher.is_ignored(Path::new("Build/XboxOne/game.exe"), false));
+        assert!(!matcher.is_ignored(Path::new("Build/XboxOne/game.template"), false));
     }
 }

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -73,6 +73,11 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
     let include_hidden = opts.include_hidden;
     let collect_gitignore_files = opts.collect_gitignore_files;
     let root = root.to_path_buf();
+    let p4ignore = (!opts.no_ignore)
+        .then(|| crate::gitignore::build_p4ignore_matcher(&root))
+        .flatten()
+        .map(std::sync::Arc::new);
+    let p4ignore_root = root.clone();
 
     let mut builder = WalkBuilder::new(&root);
     builder
@@ -83,6 +88,18 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
         .git_ignore(!opts.no_ignore)
         .git_global(!opts.no_ignore)
         .git_exclude(!opts.no_ignore)
+        .filter_entry(move |entry| {
+            let Some(matcher) = &p4ignore else {
+                return true;
+            };
+            let Ok(relative) = entry.path().strip_prefix(&p4ignore_root) else {
+                return true;
+            };
+            !matcher.is_ignored(
+                relative,
+                entry.file_type().is_some_and(|kind| kind.is_dir()),
+            )
+        })
         .threads(walker_thread_count());
     let walker = builder.build_parallel();
 
@@ -183,6 +200,7 @@ pub fn build_gitignore_matcher_from_files(
     if info_exclude.is_file() {
         let _ = builder.add(&info_exclude);
     }
+    crate::gitignore::add_p4ignore_rules(&mut builder, root);
 
     for path in gitignore_files {
         if path.is_file() {
@@ -206,12 +224,26 @@ pub struct FileMeta {
 pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String]) -> Vec<FileMeta> {
     let results = std::sync::Mutex::new(Vec::new());
     let exclude: std::sync::Arc<Vec<String>> = std::sync::Arc::new(exclude_dirs.to_vec());
+    let p4ignore = crate::gitignore::build_p4ignore_matcher(root).map(std::sync::Arc::new);
+    let match_root = root.to_path_buf();
 
     let walker = WalkBuilder::new(root)
         .hidden(true) // skip hidden by default
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
+        .filter_entry(move |entry| {
+            let Some(matcher) = &p4ignore else {
+                return true;
+            };
+            let Ok(relative) = entry.path().strip_prefix(&match_root) else {
+                return true;
+            };
+            !matcher.is_ignored(
+                relative,
+                entry.file_type().is_some_and(|kind| kind.is_dir()),
+            )
+        })
         .threads(walker_thread_count())
         .build_parallel();
 
@@ -511,5 +543,34 @@ mod tests {
                 .any(|f| f.relative_path.starts_with("vendor/"))
         );
         assert!(excluded.iter().any(|f| f.relative_path == "src/main.rs"));
+    }
+
+    #[test]
+    fn walks_respect_root_p4ignore() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+        fs::write(
+            root.join(crate::gitignore::P4IGNORE_FILENAME),
+            "vendor\nthird_party\\*.rs\n",
+        )
+        .unwrap();
+
+        let walk = walk_dir(&root, &WalkOptions::default());
+        let names = sorted_filenames(&walk, &root);
+        assert!(!names.iter().any(|name| name.starts_with("vendor/")));
+        assert!(!names.contains(&"third_party/lib.rs".to_string()));
+        assert!(names.contains(&"src/main.rs".to_string()));
+
+        let metadata = walk_file_metadata(&root, &[]);
+        assert!(
+            !metadata
+                .iter()
+                .any(|file| file.relative_path.starts_with("vendor/"))
+        );
+        assert!(
+            !metadata
+                .iter()
+                .any(|file| file.relative_path == "third_party/lib.rs")
+        );
     }
 }

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -89,6 +89,9 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
         .git_global(!opts.no_ignore)
         .git_exclude(!opts.no_ignore)
         .filter_entry(move |entry| {
+            if entry.file_name() == ".gitignore" {
+                return true;
+            }
             let Some(matcher) = &p4ignore else {
                 return true;
             };
@@ -440,6 +443,11 @@ mod tests {
         let root = tmp.path().join("testdata");
         fs::create_dir_all(root.join("src")).unwrap();
         fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        fs::write(
+            root.join(crate::gitignore::P4IGNORE_FILENAME),
+            ".gitignore\np4ignore.ini\n",
+        )
+        .unwrap();
         fs::write(root.join("src").join(".gitignore"), "*.tmp\n").unwrap();
         fs::write(root.join("src").join("main.rs"), "fn main() {}\n").unwrap();
 

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -191,7 +191,7 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
 pub fn build_gitignore_matcher_from_files(
     root: &Path,
     gitignore_files: &[PathBuf],
-) -> Option<crate::gitignore::Gitignore> {
+) -> Option<crate::gitignore::IgnoreMatcher> {
     use ignore::gitignore::GitignoreBuilder;
 
     let mut builder = GitignoreBuilder::new(root);
@@ -208,8 +208,8 @@ pub fn build_gitignore_matcher_from_files(
         }
     }
 
-    let gi = builder.build().ok()?;
-    if gi.is_empty() { None } else { Some(gi) }
+    let local = builder.build().ok()?;
+    crate::gitignore::IgnoreMatcher::new(local, crate::gitignore::build_global_matcher(root))
 }
 
 /// Filesystem metadata for a single file (no content read).
@@ -221,17 +221,20 @@ pub struct FileMeta {
 
 /// Walk a directory tree collecting only filesystem metadata (mtime, size).
 /// No file content is read — this is used for stale file detection on startup.
-pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String]) -> Vec<FileMeta> {
+pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String], no_ignore: bool) -> Vec<FileMeta> {
     let results = std::sync::Mutex::new(Vec::new());
     let exclude: std::sync::Arc<Vec<String>> = std::sync::Arc::new(exclude_dirs.to_vec());
-    let p4ignore = crate::gitignore::build_p4ignore_matcher(root).map(std::sync::Arc::new);
+    let p4ignore = (!no_ignore)
+        .then(|| crate::gitignore::build_p4ignore_matcher(root))
+        .flatten()
+        .map(std::sync::Arc::new);
     let match_root = root.to_path_buf();
 
     let walker = WalkBuilder::new(root)
         .hidden(true) // skip hidden by default
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
+        .git_ignore(!no_ignore)
+        .git_global(!no_ignore)
+        .git_exclude(!no_ignore)
         .filter_entry(move |entry| {
             let Some(matcher) = &p4ignore else {
                 return true;
@@ -514,18 +517,9 @@ mod tests {
         let gi = build_gitignore_matcher_from_files(&root, &walk.gitignore_files)
             .expect("matcher should build from discovered .gitignore files");
 
-        assert!(
-            gi.matched_path_or_any_parents("build/output.log", false)
-                .is_ignore()
-        );
-        assert!(
-            gi.matched_path_or_any_parents("src/cache.tmp", false)
-                .is_ignore()
-        );
-        assert!(
-            !gi.matched_path_or_any_parents("src/main.rs", false)
-                .is_ignore()
-        );
+        assert!(gi.is_ignored(Path::new("build/output.log"), false));
+        assert!(gi.is_ignored(Path::new("src/cache.tmp"), false));
+        assert!(!gi.is_ignored(Path::new("src/main.rs"), false));
     }
 
     #[test]
@@ -533,8 +527,8 @@ mod tests {
         let dir = setup_fixture();
         let root = dir.path().join("testdata");
 
-        let all = walk_file_metadata(&root, &[]);
-        let excluded = walk_file_metadata(&root, &["vendor".to_string()]);
+        let all = walk_file_metadata(&root, &[], false);
+        let excluded = walk_file_metadata(&root, &["vendor".to_string()], false);
 
         assert!(all.iter().any(|f| f.relative_path.starts_with("vendor/")));
         assert!(
@@ -561,7 +555,7 @@ mod tests {
         assert!(!names.contains(&"third_party/lib.rs".to_string()));
         assert!(names.contains(&"src/main.rs".to_string()));
 
-        let metadata = walk_file_metadata(&root, &[]);
+        let metadata = walk_file_metadata(&root, &[], false);
         assert!(
             !metadata
                 .iter()
@@ -571,6 +565,33 @@ mod tests {
             !metadata
                 .iter()
                 .any(|file| file.relative_path == "third_party/lib.rs")
+        );
+    }
+
+    #[test]
+    fn no_ignore_disables_p4ignore_for_walks_and_metadata() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+        fs::write(root.join(crate::gitignore::P4IGNORE_FILENAME), "vendor\n").unwrap();
+
+        let walk = walk_dir(
+            &root,
+            &WalkOptions {
+                no_ignore: true,
+                ..Default::default()
+            },
+        );
+        assert!(
+            sorted_filenames(&walk, &root)
+                .iter()
+                .any(|name| name == "vendor/dep.rs")
+        );
+
+        let metadata = walk_file_metadata(&root, &[], true);
+        assert!(
+            metadata
+                .iter()
+                .any(|file| file.relative_path == "vendor/dep.rs")
         );
     }
 }


### PR DESCRIPTION
## Summary

- load root-level `p4ignore.ini` rules alongside Git ignore rules
- normalize Windows path separators and preserve negated re-inclusions
- prune ignored subtrees during indexing, file counting, and metadata scans
- apply the same rules to watcher event filtering
- propagate `--no-ignore` consistently through search, counting, indexing, serving, reloads, and stale scans
- include global Git ignore rules in watcher matching with local rules taking precedence
- rebuild ignore matchers and reconcile indexed paths when `.gitignore` or `p4ignore.ini` changes while serving
- document Perforce ignore behavior and `--no-ignore` semantics

## Validation

- `cargo test --workspace --quiet`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --quiet -- -D warnings`