### PR TITLE
Bound index build memory with an external merge sort, and make it the default

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -99,6 +99,11 @@ All configurations produce identical results: 15 literal and regex queries over
 190,000+ matches returned byte-identical output against the `memory` index,
 including at 1,946-segment fan-in.
 
+Peak figures here are the OS process high-water mark (`PeakWorkingSetSize` on
+Windows, `VmHWM` on Linux), sampled externally. `tgrep index` now reports the
+same counter itself on completion, so these numbers are reproducible without
+external tooling; the self-reported and externally-sampled values agree exactly.
+
 **Why the merge shares one read budget.** The first implementation gave every
 open segment a fixed 256 KiB read-ahead buffer, which made merge memory
 `segments * 256 KiB` — unbounded in fan-in. Since a smaller arena spills *more*

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -37,6 +37,71 @@ The high-diversity case stresses the number of distinct trigrams and posting-lis
 serialization. The flat sorted-posting writer reduced this case from roughly
 1.47s and 98.74 MiB peak working set to roughly 0.37s and 43.68 MiB in local runs.
 
+### Index build strategies
+
+`tgrep index --index-strategy=external` replaces the single in-heap posting
+vector with an external merge sort: postings fill a fixed-size arena that spills
+sorted, delta+varint encoded segments to disk, which are then k-way merged
+directly into `index.bin` / `lookup.bin`.
+
+The peak-memory probe runs both strategies back to back on the same fixture.
+Each of these runs uses a deliberately small 4 MB arena so bench-scale fixtures
+spill; the shipped default is 64 MB.
+
+```powershell
+cargo bench -p tgrep-core --bench index_build -- --peak-memory-high-diversity 16000
+```
+
+**Peak working set** (high-diversity fixture, Windows, local run):
+
+| Files | `memory` | `external` | Reduction |
+| ---: | ---: | ---: | ---: |
+| 2,000 | 66.93 MiB | 32.85 MiB | −51% |
+| 4,000 | 88.98 MiB | 34.29 MiB | −61% |
+| 8,000 | 185.21 MiB | 37.92 MiB | −80% |
+| 16,000 | 342.98 MiB | 50.30 MiB | −85% |
+
+The `memory` column grows roughly linearly with file count while `external`
+stays close to flat (+17 MiB across an 8x increase in files), which is the
+point: peak heap becomes a function of the arena budget rather than of repo
+size. The remaining growth in the `external` column is the file table and walk
+results, not postings.
+
+**Build time.** The fixture that matters most is real source code, which has
+realistic trigram diversity and genuinely spills. This one is 2,500 files /
+37.5 MiB built from tgrep's own `.rs` sources, timed end to end through the
+release binary (median of 3 runs), with peak working set sampled from the
+child process:
+
+| Strategy | Spill segments | Peak working set | Median build | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| `memory` | - | 144.08 MiB | 0.725 s | - |
+| `external --index-buffer 64` | 2 | 118.75 MiB | 0.791 s | +9.1% |
+| `external --index-buffer 8` | 9 | 58.38 MiB | 0.789 s | +8.8% |
+
+All three produce the same 14,379 trigrams over 2,500 files. Note that shrinking
+the arena 8x costs nothing in time — going from 2 segments to 9 is free, because
+merge fan-in is not the bottleneck at this scale, the spill encode/decode
+round-trip is. The arena budget is therefore a fairly clean dial on peak memory.
+
+Criterion microbenchmarks bracket that number from both sides:
+
+| Case | `memory` | `external` | Delta | Spills? |
+| --- | ---: | ---: | ---: | --- |
+| 5,000 files | 1.2819 s | 1.2917 s | +0.8% | no |
+| 1,000 high-diversity files | 464.42ms | 540.11ms | +16% | yes |
+
+The 5,000-file case is the *no-spill* floor: its fixture repeats one line, so the
+whole repo is only 67 distinct trigrams and the arena never fills, which is why
+the overhead is indistinguishable from noise. The high-diversity case is the
+worst-case ceiling: random-byte content makes nearly every trigram unique, so
+segment groups hold a single posting each and per-group header overhead and
+merge fan-in work are both maximal. Real code sits between them, at roughly +9%.
+
+Total sort work is unchanged — `k` sorts of `n/k` elements plus an `n·log k`
+merge is still `O(n·log n)` — so the delta is purely the spill write plus the
+merge read.
+
 ### Query execution
 
 | Case | Mean |

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -39,10 +39,12 @@ serialization. The flat sorted-posting writer reduced this case from roughly
 
 ### Index build strategies
 
-`tgrep index --index-strategy=external` replaces the single in-heap posting
+The default build strategy, `external`, replaces the single in-heap posting
 vector with an external merge sort: postings fill a fixed-size arena that spills
 sorted, delta+varint encoded segments to disk, which are then k-way merged
-directly into `index.bin` / `lookup.bin`.
+directly into `index.bin` / `lookup.bin`. `--index-strategy=memory` selects the
+older sort-everything-in-RAM path, retained as an escape hatch and as the
+reference implementation for differential tests.
 
 The peak-memory probe runs both strategies back to back on the same fixture.
 Each of these runs uses a deliberately small 4 MB arena so bench-scale fixtures
@@ -73,31 +75,35 @@ sampled from the child process):
 
 | Strategy | Spill segments | Peak working set | Build |
 | --- | ---: | ---: | ---: |
-| `memory` | - | 2,803 - 3,855 MiB | ~23 s |
+| `memory` | - | 2.20 - 3.76 GiB | 23 - 32 s |
 | `external --index-buffer 256` | 8 | 430.6 MiB | ~24 s |
-| `external` (64 MiB default) | 31 | 151 - 159 MiB | ~23 s |
+| `external` (64 MiB, **default**) | 31 | 151 - 160 MiB | ~23 s |
 | `external --index-buffer 16` | 122 | 109.6 MiB | ~23 s |
 | `external --index-buffer 4` | 487 | 102.0 MiB | ~24 s |
 | `external --index-buffer 1` | 1,946 | 98.9 MiB | ~29 s |
 
-At the default budget that is a **20x reduction in peak memory for no
-measurable time cost** — build time is flat within run-to-run noise for any
-budget at or above 4 MiB, and only degrades at 1,946-segment fan-in.
+At the default budget that is a **~17x reduction in peak memory for no time
+cost** — build time is flat within run-to-run noise for any budget at or above
+4 MiB, and only degrades at 1,946-segment fan-in. This is why `external` is the
+default. In several runs it was measurably *faster* than `memory` (22.6 s vs
+31.6 s), because sorting one ~2 GiB posting vector, and the doubling
+reallocations that grow it, cost more than encoding and merging spill segments.
 
 Two things worth noting beyond the headline. First, the `memory` figure is a
 *range* because `Vec` growth doubles: peak lands wherever the final reallocation
 happens to fall, and during that realloc both the old and new buffers are
-resident. It varied by over a gigabyte across three identical runs. The
-`external` column varied by 8 MiB. Bounded memory is also *predictable* memory,
-which matters more than the average when the question is whether a machine can
-finish the build at all.
+resident. It varied by over a gigabyte across identical runs. The `external`
+column varied by 8 MiB. Bounded memory is also *predictable* memory, which
+matters more than the average when the question is whether a machine can finish
+the build at all.
 
 Second, peak decreases monotonically as the budget shrinks, which is the whole
 point of the knob — but that property had to be fixed, not assumed. See below.
 
-All configurations produce identical results: 15 literal and regex queries over
+All configurations produce identical results. 15 literal and regex queries over
 190,000+ matches returned byte-identical output against the `memory` index,
-including at 1,946-segment fan-in.
+including at 1,946-segment fan-in; re-verified after `external` became the
+default with 7 queries over 100,130 matches.
 
 Peak figures here are the OS process high-water mark (`PeakWorkingSetSize` on
 Windows, `VmHWM` on Linux), sampled externally. `tgrep index` now reports the

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -154,6 +154,12 @@ repo are misleading. And an interrupted bootstrap now leaves a usable index:
 the old path wrote nothing until its single end-of-build flush, so killing it
 at 99% left an empty index behind.
 
+The watcher's ignore matcher is built from the `.gitignore` paths the build's
+walk already collected, not by `gitignore::build_matcher`, which repeats the
+entire walk single-threaded. That distinction is worth more than it sounds: on
+a 289k-file repository the rewalk took **48.9 s**, longer than indexing the
+repo. Reusing the walk's results makes it 0.07 s on the Linux tree.
+
 Resuming a *partial* index still uses the incremental path, which can skip the
 files already on disk.
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -126,6 +126,37 @@ At a 1 MiB budget the read buffers alone were 486 MiB. Sizing them as
 reproduces at real scale — every synthetic fixture in this file spills too few
 segments to reach the crossover.
 
+### Server bootstrap
+
+`tgrep serve` on an empty index used to build through a different path than
+`tgrep index`: it walked the repo and accumulated every posting in the live
+in-memory overlay, flushing to disk once at the end. The soft memory cap that
+was supposed to bound this only trips above `--memory-cap` (16 GB by default),
+so on anything smaller than that the whole index simply stayed in heap.
+
+A cold start now delegates to the same memory-bounded builder as `tgrep index`.
+On the Linux kernel tree (94,181 files, same host as above, peak sampled
+externally, timed to the point the server reports the index ready):
+
+| Bootstrap path | Peak working set | Wall |
+| --- | ---: | ---: |
+| in-heap overlay (before) | 1,569.7 MiB | 73.6 s |
+| external builder (after) | 148.6 MiB | 28.7 s |
+
+That is a **10.6x reduction in peak memory and a 2.6x speedup**. The overlay
+path was slower because it pays twice: it builds the posting map in memory and
+*then* rewrites the whole thing through the append-overlay flush.
+
+Two behavioural notes. The server no longer answers from a partially built
+index during a cold start — queries see an empty index until the build
+finishes, which is a deliberate trade, since results from a fraction of the
+repo are misleading. And an interrupted bootstrap now leaves a usable index:
+the old path wrote nothing until its single end-of-build flush, so killing it
+at 99% left an empty index behind.
+
+Resuming a *partial* index still uses the incremental path, which can skip the
+files already on disk.
+
 **Smaller fixtures.** 2,500 files / 37.5 MiB built from tgrep's own `.rs`
 sources, timed end to end through the release binary (median of 3 runs):
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -67,11 +67,56 @@ point: peak heap becomes a function of the arena budget rather than of repo
 size. The remaining growth in the `external` column is the file table and walk
 results, not postings.
 
-**Build time.** The fixture that matters most is real source code, which has
-realistic trigram diversity and genuinely spills. This one is 2,500 files /
-37.5 MiB built from tgrep's own `.rs` sources, timed end to end through the
-release binary (median of 3 runs), with peak working set sampled from the
-child process:
+**Real-world scale: the Linux kernel.** 94,634 indexed files / 446,892 trigrams
+/ 990 MiB index (`C:\repos\linux`, v7.2-rc7, warm page cache, peak working set
+sampled from the child process):
+
+| Strategy | Spill segments | Peak working set | Build |
+| --- | ---: | ---: | ---: |
+| `memory` | - | 2,803 - 3,855 MiB | ~23 s |
+| `external --index-buffer 256` | 8 | 430.6 MiB | ~24 s |
+| `external` (64 MiB default) | 31 | 151 - 159 MiB | ~23 s |
+| `external --index-buffer 16` | 122 | 109.6 MiB | ~23 s |
+| `external --index-buffer 4` | 487 | 102.0 MiB | ~24 s |
+| `external --index-buffer 1` | 1,946 | 98.9 MiB | ~29 s |
+
+At the default budget that is a **20x reduction in peak memory for no
+measurable time cost** — build time is flat within run-to-run noise for any
+budget at or above 4 MiB, and only degrades at 1,946-segment fan-in.
+
+Two things worth noting beyond the headline. First, the `memory` figure is a
+*range* because `Vec` growth doubles: peak lands wherever the final reallocation
+happens to fall, and during that realloc both the old and new buffers are
+resident. It varied by over a gigabyte across three identical runs. The
+`external` column varied by 8 MiB. Bounded memory is also *predictable* memory,
+which matters more than the average when the question is whether a machine can
+finish the build at all.
+
+Second, peak decreases monotonically as the budget shrinks, which is the whole
+point of the knob — but that property had to be fixed, not assumed. See below.
+
+All configurations produce identical results: 15 literal and regex queries over
+190,000+ matches returned byte-identical output against the `memory` index,
+including at 1,946-segment fan-in.
+
+**Why the merge shares one read budget.** The first implementation gave every
+open segment a fixed 256 KiB read-ahead buffer, which made merge memory
+`segments * 256 KiB` — unbounded in fan-in. Since a smaller arena spills *more*
+segments, asking for less memory delivered more of it, and peak traced a U:
+
+| Arena | Segments | Peak, fixed buffers | Peak, shared budget |
+| ---: | ---: | ---: | ---: |
+| 16 MiB | 122 | 114.7 MiB | 109.6 MiB |
+| 4 MiB | 487 | 195.8 MiB | 102.0 MiB |
+| 1 MiB | 1,946 | 565.8 MiB | 98.9 MiB |
+
+At a 1 MiB budget the read buffers alone were 486 MiB. Sizing them as
+`budget / segments` (floored at 4 KiB) removes the U entirely. This only
+reproduces at real scale — every synthetic fixture in this file spills too few
+segments to reach the crossover.
+
+**Smaller fixtures.** 2,500 files / 37.5 MiB built from tgrep's own `.rs`
+sources, timed end to end through the release binary (median of 3 runs):
 
 | Strategy | Spill segments | Peak working set | Median build | Delta |
 | --- | ---: | ---: | ---: | ---: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -96,46 +96,50 @@ tgrep index . --index-path /tmp/idx   # custom index location
 tgrep index . --exclude vendor --exclude third_party  # skip directories
 ```
 
-Each build reports its elapsed time and peak memory when it finishes, which
-makes the strategies below directly comparable:
+Each build reports its elapsed time and peak memory when it finishes:
 
 ```
 Index built successfully at /tmp/idx
-Indexed in 22.7s using memory strategy (peak memory 2.55 GiB)
+Indexed in 22.6s using external strategy (peak memory 160.1 MiB)
 ```
 
 The peak is the operating system's own high-water mark for the process, so it
 reflects the true maximum rather than a sampled snapshot.
 
-#### Bounding memory on very large repos
+#### Memory use on very large repos
 
-By default the builder holds every posting in RAM and sorts once, so peak
-memory grows with repo size. `--index-strategy=external` bounds it instead with
-an external merge sort: postings accumulate in a fixed-size arena that spills
+Builds default to `--index-strategy=external`, which bounds peak memory with an
+external merge sort: postings accumulate in a fixed-size arena that spills
 sorted, compact segments to disk when full, and the segments are k-way merged
-straight into the index.
+straight into the index. Peak memory is roughly flat in repo size rather than
+linear.
+
+If the arena never fills, nothing is spilled and the build takes exactly the
+in-memory path, so small and mid-size repos pay nothing for this default.
 
 ```bash
-tgrep index . --index-strategy=external               # 64 MB arena (default)
-tgrep index . --index-strategy=external --index-buffer 256   # larger arena
+tgrep index .                                 # external, 64 MB arena
+tgrep index . --index-buffer 16               # smaller arena, lower peak
+tgrep index . --index-strategy=memory         # opt out: sort entirely in RAM
 ```
 
-Peak memory becomes roughly flat in repo size rather than linear. On the Linux
-kernel (94,634 files, 990 MiB index) this is a **20x reduction with no
-measurable time cost**:
+On the Linux kernel (94,634 files, 990 MiB index) the default is a **~17x
+reduction in peak memory, and no slower**:
 
 | Strategy | Spill segments | Peak working set | Build |
 | --- | ---: | ---: | ---: |
-| `memory` | - | 2,803–3,855 MiB | ~23 s |
-| `external` (64 MiB default) | 31 | 151–159 MiB | ~23 s |
+| `external` (default, 64 MiB arena) | 31 | **160.1 MiB** | 22.6 s |
 | `external --index-buffer 16` | 122 | 109.6 MiB | ~23 s |
+| `memory` | - | 2.20 - 3.76 GiB | 23 - 32 s |
 
-`--index-buffer` trades peak memory against merge fan-in, and bounded memory is
-also *predictable* memory — the `memory` row varied by over a gigabyte across
-identical runs because `Vec` growth doubles, while `external` varied by 8 MiB.
+`--index-buffer` trades peak memory against merge fan-in. Bounded memory is also
+*predictable* memory — the `memory` row varied by over a gigabyte across
+identical runs because `Vec` growth doubles and both buffers are briefly
+resident during the final reallocation, while `external` varied by 8 MiB.
 
-If the arena never fills, no segments are spilled and the build takes exactly
-the in-memory path, so small and mid-size repos are unaffected. See
+`--index-strategy=memory` remains available as an escape hatch for environments
+where spilling is undesirable or impossible, such as a read-only or full index
+volume. Both strategies produce byte-identical indexes. See
 [BENCHMARKS.md](BENCHMARKS.md#index-build-strategies) for full numbers.
 
 ### Start the server

--- a/README.md
+++ b/README.md
@@ -109,18 +109,22 @@ tgrep index . --index-strategy=external               # 64 MB arena (default)
 tgrep index . --index-strategy=external --index-buffer 256   # larger arena
 ```
 
-Peak memory becomes roughly flat in repo size rather than linear:
+Peak memory becomes roughly flat in repo size rather than linear. On the Linux
+kernel (94,634 files, 990 MiB index) this is a **20x reduction with no
+measurable time cost**:
 
-| High-diversity files | `memory` | `external` |
-| ---: | ---: | ---: |
-| 2,000 | 66.9 MiB | 32.9 MiB |
-| 8,000 | 185.2 MiB | 37.9 MiB |
-| 16,000 | 343.0 MiB | 50.3 MiB |
+| Strategy | Spill segments | Peak working set | Build |
+| --- | ---: | ---: | ---: |
+| `memory` | - | 2,803–3,855 MiB | ~23 s |
+| `external` (64 MiB default) | 31 | 151–159 MiB | ~23 s |
+| `external --index-buffer 16` | 122 | 109.6 MiB | ~23 s |
 
-On real source (2,500 files of tgrep's own `.rs`) it cuts peak working set from
-144 MiB to 58 MiB for about 9% more build time, and `--index-buffer` trades the
-two off directly. If the arena never fills, no segments are spilled and the
-build takes exactly the in-memory path. See
+`--index-buffer` trades peak memory against merge fan-in, and bounded memory is
+also *predictable* memory — the `memory` row varied by over a gigabyte across
+identical runs because `Vec` growth doubles, while `external` varied by 8 MiB.
+
+If the arena never fills, no segments are spilled and the build takes exactly
+the in-memory path, so small and mid-size repos are unaffected. See
 [BENCHMARKS.md](BENCHMARKS.md#index-build-strategies) for full numbers.
 
 ### Start the server

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ where spilling is undesirable or impossible, such as a read-only or full index
 volume. Both strategies produce byte-identical indexes. See
 [BENCHMARKS.md](BENCHMARKS.md#index-build-strategies) for full numbers.
 
+`tgrep serve` uses the same bounded builder when it has to create an index from
+scratch, so starting a server on an unindexed repo costs the same memory as
+`tgrep index` (**148.6 MiB** rather than 1.6 GiB on the Linux kernel, and 2.6x
+faster). While that first build runs the server answers from an empty index
+rather than a partial one; incremental updates after it completes are
+unaffected.
+
 ### Start the server
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -96,6 +96,33 @@ tgrep index . --index-path /tmp/idx   # custom index location
 tgrep index . --exclude vendor --exclude third_party  # skip directories
 ```
 
+#### Bounding memory on very large repos
+
+By default the builder holds every posting in RAM and sorts once, so peak
+memory grows with repo size. `--index-strategy=external` bounds it instead with
+an external merge sort: postings accumulate in a fixed-size arena that spills
+sorted, compact segments to disk when full, and the segments are k-way merged
+straight into the index.
+
+```bash
+tgrep index . --index-strategy=external               # 64 MB arena (default)
+tgrep index . --index-strategy=external --index-buffer 256   # larger arena
+```
+
+Peak memory becomes roughly flat in repo size rather than linear:
+
+| High-diversity files | `memory` | `external` |
+| ---: | ---: | ---: |
+| 2,000 | 66.9 MiB | 32.9 MiB |
+| 8,000 | 185.2 MiB | 37.9 MiB |
+| 16,000 | 343.0 MiB | 50.3 MiB |
+
+On real source (2,500 files of tgrep's own `.rs`) it cuts peak working set from
+144 MiB to 58 MiB for about 9% more build time, and `--index-buffer` trades the
+two off directly. If the arena never fills, no segments are spilled and the
+build takes exactly the in-memory path. See
+[BENCHMARKS.md](BENCHMARKS.md#index-build-strategies) for full numbers.
+
 ### Start the server
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ tgrep index . --index-path /tmp/idx   # custom index location
 tgrep index . --exclude vendor --exclude third_party  # skip directories
 ```
 
+Each build reports its elapsed time and peak memory when it finishes, which
+makes the strategies below directly comparable:
+
+```
+Index built successfully at /tmp/idx
+Indexed in 22.7s using memory strategy (peak memory 2.55 GiB)
+```
+
+The peak is the operating system's own high-water mark for the process, so it
+reflects the true maximum rather than a sampled snapshot.
+
 #### Bounding memory on very large repos
 
 By default the builder holds every posting in RAM and sorts once, so peak

--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -55,6 +55,7 @@ pub fn run(
             exclude_dirs: exclude_dirs.to_vec(),
             strategy,
             buffer_bytes,
+            ..Default::default()
         },
     )?;
     let elapsed = started.elapsed();

--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -1,8 +1,11 @@
 /// `tgrep index` — build the trigram index.
 use std::path::Path;
+use std::time::Instant;
 
 use anyhow::Result;
 use tgrep_core::builder::{self, BuildOptions, IndexStrategy};
+
+use crate::mem;
 
 pub fn run(
     root: &Path,
@@ -24,6 +27,7 @@ pub fn run(
         );
     }
 
+    let started = Instant::now();
     builder::build_index_with_options(
         root,
         index_path,
@@ -35,5 +39,26 @@ pub fn run(
             buffer_bytes,
         },
     )?;
+    let elapsed = started.elapsed();
+
+    let strategy_label = match strategy {
+        IndexStrategy::InMemory => "memory",
+        IndexStrategy::External => "external",
+    };
+    // Peak is an OS high-water mark for the whole process. `tgrep index` does
+    // nothing substantial before the build, so it reads as the build's peak.
+    match mem::peak_rss_bytes() {
+        Some(peak) => eprintln!(
+            "Indexed in {:.1}s using {} strategy (peak memory {})",
+            elapsed.as_secs_f64(),
+            strategy_label,
+            mem::format_bytes(peak)
+        ),
+        None => eprintln!(
+            "Indexed in {:.1}s using {} strategy",
+            elapsed.as_secs_f64(),
+            strategy_label
+        ),
+    }
     Ok(())
 }

--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -16,11 +16,14 @@ pub fn run(
     strategy: IndexStrategy,
     buffer_bytes: Option<u64>,
 ) -> Result<()> {
+    let explicit_buffer = buffer_bytes.is_some();
     let buffer_bytes = buffer_bytes
         .and_then(|bytes| usize::try_from(bytes).ok())
         .unwrap_or(builder::DEFAULT_INDEX_BUFFER_BYTES);
 
-    if strategy == IndexStrategy::External {
+    // External is the default, so announcing it on every run would be noise.
+    // Confirm the arena only when the user explicitly tuned it.
+    if strategy == IndexStrategy::External && explicit_buffer {
         eprintln!(
             "Using external merge sort (arena {} MB before spilling)",
             buffer_bytes / (1024 * 1024)

--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -2,7 +2,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use tgrep_core::builder;
+use tgrep_core::builder::{self, BuildOptions, IndexStrategy};
 
 pub fn run(
     root: &Path,
@@ -10,7 +10,30 @@ pub fn run(
     include_hidden: bool,
     no_ignore: bool,
     exclude_dirs: &[String],
+    strategy: IndexStrategy,
+    buffer_bytes: Option<u64>,
 ) -> Result<()> {
-    builder::build_index(root, index_path, include_hidden, no_ignore, exclude_dirs)?;
+    let buffer_bytes = buffer_bytes
+        .and_then(|bytes| usize::try_from(bytes).ok())
+        .unwrap_or(builder::DEFAULT_INDEX_BUFFER_BYTES);
+
+    if strategy == IndexStrategy::External {
+        eprintln!(
+            "Using external merge sort (arena {} MB before spilling)",
+            buffer_bytes / (1024 * 1024)
+        );
+    }
+
+    builder::build_index_with_options(
+        root,
+        index_path,
+        &BuildOptions {
+            include_hidden,
+            no_ignore,
+            exclude_dirs: exclude_dirs.to_vec(),
+            strategy,
+            buffer_bytes,
+        },
+    )?;
     Ok(())
 }

--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -2,10 +2,24 @@
 use std::path::Path;
 use std::time::Instant;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tgrep_core::builder::{self, BuildOptions, IndexStrategy};
 
 use crate::mem;
+
+/// Convert `--index-buffer <MB>` to bytes.
+///
+/// Rejects values this platform cannot represent instead of quietly falling
+/// back to the default: silently indexing with a 64 MB arena after the user
+/// asked for something else would misreport what actually ran.
+fn buffer_bytes_from_mb(mb: u64) -> Result<usize> {
+    let max_mb = (usize::MAX / (1024 * 1024)) as u64;
+    mb.checked_mul(1024 * 1024)
+        .and_then(|bytes| usize::try_from(bytes).ok())
+        .with_context(|| {
+            format!("--index-buffer {mb} is too large for this platform (maximum {max_mb} MB)")
+        })
+}
 
 pub fn run(
     root: &Path,
@@ -14,11 +28,12 @@ pub fn run(
     no_ignore: bool,
     exclude_dirs: &[String],
     strategy: IndexStrategy,
-    buffer_bytes: Option<u64>,
+    index_buffer_mb: Option<u64>,
 ) -> Result<()> {
-    let explicit_buffer = buffer_bytes.is_some();
-    let buffer_bytes = buffer_bytes
-        .and_then(|bytes| usize::try_from(bytes).ok())
+    let explicit_buffer = index_buffer_mb.is_some();
+    let buffer_bytes = index_buffer_mb
+        .map(buffer_bytes_from_mb)
+        .transpose()?
         .unwrap_or(builder::DEFAULT_INDEX_BUFFER_BYTES);
 
     // External is the default, so announcing it on every run would be noise.

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -237,14 +237,15 @@ enum Command {
 
         /// How postings are accumulated during the build.
         ///
-        /// `memory` holds every posting in RAM and sorts once — fastest when
-        /// the index fits comfortably, but peak memory grows with repo size.
-        /// `external` bounds peak memory with an external merge sort, spilling
-        /// sorted segments to disk when the arena fills.
+        /// `external` (default) bounds peak memory with an external merge
+        /// sort, spilling sorted segments to disk when the arena fills. If the
+        /// arena never fills it is identical to `memory`, so small repos are
+        /// unaffected. `memory` holds every posting in RAM and sorts once;
+        /// peak memory then grows with repo size, unbounded.
         #[arg(
             long = "index-strategy",
             value_name = "STRATEGY",
-            default_value = "memory"
+            default_value = "external"
         )]
         strategy: IndexStrategyArg,
 

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -392,7 +392,7 @@ fn main() {
             no_ignore,
             &exclude,
             strategy.into(),
-            index_buffer_mb.map(|mb| mb.saturating_mul(1024 * 1024)),
+            index_buffer_mb,
         ),
         Some(Command::Serve {
             path,

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -21,6 +21,7 @@ use std::process;
 
 use clap::{Parser, Subcommand};
 use output::ColorMode;
+use tgrep_core::builder;
 
 #[derive(Parser)]
 #[command(
@@ -200,6 +201,24 @@ struct Cli {
     unrestricted: u8,
 }
 
+/// Posting accumulation strategy for `tgrep index`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+enum IndexStrategyArg {
+    /// Accumulate all postings in memory and sort once.
+    Memory,
+    /// Bound peak memory with an external merge sort that spills to disk.
+    External,
+}
+
+impl From<IndexStrategyArg> for builder::IndexStrategy {
+    fn from(value: IndexStrategyArg) -> Self {
+        match value {
+            IndexStrategyArg::Memory => Self::InMemory,
+            IndexStrategyArg::External => Self::External,
+        }
+    }
+}
+
 #[derive(Subcommand)]
 enum Command {
     /// Build or rebuild the trigram index.
@@ -215,6 +234,25 @@ enum Command {
         /// Exclude directories from indexing (can be specified multiple times).
         #[arg(long = "exclude", action = clap::ArgAction::Append)]
         exclude: Vec<String>,
+
+        /// How postings are accumulated during the build.
+        ///
+        /// `memory` holds every posting in RAM and sorts once — fastest when
+        /// the index fits comfortably, but peak memory grows with repo size.
+        /// `external` bounds peak memory with an external merge sort, spilling
+        /// sorted segments to disk when the arena fills.
+        #[arg(
+            long = "index-strategy",
+            value_name = "STRATEGY",
+            default_value = "memory"
+        )]
+        strategy: IndexStrategyArg,
+
+        /// Arena size in megabytes before `--index-strategy=external` spills to
+        /// disk. Lower values reduce peak memory at the cost of more spill
+        /// segments to merge. Ignored by `--index-strategy=memory`.
+        #[arg(long = "index-buffer", value_name = "MB", value_parser = clap::value_parser!(u64).range(1..))]
+        index_buffer_mb: Option<u64>,
     },
 
     /// Start the persistent search server.
@@ -340,12 +378,20 @@ fn main() {
     }
 
     let result = match cli.command {
-        Some(Command::Index { path, exclude, .. }) => index::run(
+        Some(Command::Index {
+            path,
+            exclude,
+            strategy,
+            index_buffer_mb,
+            ..
+        }) => index::run(
             &path,
             cli.index_path.as_deref(),
             cli.hidden,
             no_ignore,
             &exclude,
+            strategy.into(),
+            index_buffer_mb.map(|mb| mb.saturating_mul(1024 * 1024)),
         ),
         Some(Command::Serve {
             path,

--- a/tgrep-cli/src/mem.rs
+++ b/tgrep-cli/src/mem.rs
@@ -8,6 +8,23 @@
 /// the platform query fails.
 #[cfg(target_os = "windows")]
 pub fn process_rss_bytes() -> Option<u64> {
+    windows_memory_counters().map(|c| c.WorkingSetSize as u64)
+}
+
+/// Returns the highest resident set size the process has reached, or `None`
+/// if the platform query fails.
+///
+/// This is an OS-maintained high-water mark, so it is exact and costs nothing
+/// to read — unlike sampling [`process_rss_bytes`], which can miss a peak that
+/// occurs between polls.
+#[cfg(target_os = "windows")]
+pub fn peak_rss_bytes() -> Option<u64> {
+    windows_memory_counters().map(|c| c.PeakWorkingSetSize as u64)
+}
+
+#[cfg(target_os = "windows")]
+fn windows_memory_counters()
+-> Option<windows_sys::Win32::System::ProcessStatus::PROCESS_MEMORY_COUNTERS> {
     use std::mem::MaybeUninit;
     use windows_sys::Win32::System::ProcessStatus::GetProcessMemoryInfo;
     use windows_sys::Win32::System::ProcessStatus::PROCESS_MEMORY_COUNTERS;
@@ -21,8 +38,7 @@ pub fn process_rss_bytes() -> Option<u64> {
         (*counters.as_mut_ptr()).cb = size;
         let ok = GetProcessMemoryInfo(handle, counters.as_mut_ptr(), size);
         if ok != 0 {
-            let counters = counters.assume_init();
-            Some(counters.WorkingSetSize as u64)
+            Some(counters.assume_init())
         } else {
             None
         }
@@ -62,6 +78,19 @@ pub fn total_physical_memory_bytes() -> Option<u64> {
     let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
     for line in meminfo.lines() {
         if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb: u64 = rest.trim().strip_suffix("kB")?.trim().parse().ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
+/// Peak RSS from `VmHWM` ("high water mark") in `/proc/self/status`.
+#[cfg(target_os = "linux")]
+pub fn peak_rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmHWM:") {
             let kb: u64 = rest.trim().strip_suffix("kB")?.trim().parse().ok()?;
             return Some(kb * 1024);
         }
@@ -111,6 +140,21 @@ pub fn total_physical_memory_bytes() -> Option<u64> {
     }
 }
 
+/// Peak RSS via `getrusage`. On macOS `ru_maxrss` is in **bytes** (on Linux the
+/// same field is kilobytes), so no scaling is applied here.
+#[cfg(target_os = "macos")]
+pub fn peak_rss_bytes() -> Option<u64> {
+    use std::mem::MaybeUninit;
+    unsafe {
+        let mut usage = MaybeUninit::<libc::rusage>::zeroed();
+        if libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) == 0 {
+            Some(usage.assume_init().ru_maxrss as u64)
+        } else {
+            None
+        }
+    }
+}
+
 // Fallback for unsupported platforms
 #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
 pub fn process_rss_bytes() -> Option<u64> {
@@ -120,6 +164,28 @@ pub fn process_rss_bytes() -> Option<u64> {
 #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
 pub fn total_physical_memory_bytes() -> Option<u64> {
     None
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+pub fn peak_rss_bytes() -> Option<u64> {
+    None
+}
+
+/// Format a byte count for humans, e.g. `1.53 GiB` or `151.2 MiB`.
+pub fn format_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let b = bytes as f64;
+    if b >= GIB {
+        format!("{:.2} GiB", b / GIB)
+    } else if b >= MIB {
+        format!("{:.1} MiB", b / MIB)
+    } else if b >= KIB {
+        format!("{:.1} KiB", b / KIB)
+    } else {
+        format!("{bytes} B")
+    }
 }
 
 /// Compute the default memory cap: 50% of physical RAM, with a floor of 512 MB
@@ -166,5 +232,32 @@ mod tests {
         let cap = default_memory_cap_bytes();
         assert!(cap >= 512 * 1024 * 1024);
         assert!(cap <= 16 * 1024 * 1024 * 1024);
+    }
+
+    // Peak must be a real high-water mark, not the current value: it has to be
+    // queryable and at least as large as current RSS. A platform returning the
+    // wrong struct field (e.g. WorkingSetSize instead of PeakWorkingSetSize)
+    // would still be non-zero, so compare the two rather than just check > 0.
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn peak_rss_is_at_least_current_rss() {
+        let current = process_rss_bytes().expect("current RSS query should succeed");
+        let peak = peak_rss_bytes().expect("peak RSS query should succeed");
+        assert!(peak > 0, "peak RSS should be non-zero");
+        assert!(
+            peak >= current,
+            "peak RSS {peak} should be >= current RSS {current}"
+        );
+    }
+
+    #[test]
+    fn format_bytes_picks_sensible_units() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(2 * 1024), "2.0 KiB");
+        assert_eq!(format_bytes(151 * 1024 * 1024), "151.0 MiB");
+        assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.00 GiB");
+        // Boundaries promote to the next unit rather than reading as "1024".
+        assert_eq!(format_bytes(1024 * 1024), "1.0 MiB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.00 GiB");
     }
 }

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1463,6 +1463,127 @@ fn background_refresh_stale(
     *state.file_stamps.write().unwrap() = new_stamps;
 }
 
+/// Restore a known-empty on-disk index after a failed bootstrap.
+///
+/// `build_index_with_options` writes the index files in place, so a failure
+/// partway through can leave truncated files that the currently mmap'd reader
+/// no longer matches. Resetting gives the fallback build a clean base.
+fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
+    if let Err(e) = create_empty_index(index_dir) {
+        eprintln!("[trace] warning: could not reset the index directory ({e})");
+        return;
+    }
+    match HybridIndex::open(index_dir, root) {
+        Ok(empty) => {
+            *state.index.write().unwrap() = empty;
+            state.cache.write().unwrap().clear();
+        }
+        Err(e) => eprintln!("[trace] warning: could not reopen an empty index ({e})"),
+    }
+}
+
+/// Bootstrap an empty index with the memory-bounded external merge sort.
+///
+/// The incremental path below accumulates every posting in the live overlay
+/// before flushing, so a cold start on a large repository holds the whole
+/// index in heap — on the Linux kernel tree that peaked at ~1.5 GiB. Handing a
+/// true bootstrap to the builder with [`IndexStrategy::External`] bounds peak
+/// memory to the arena budget instead, and is also faster, because it writes
+/// the index once rather than growing an overlay and then flushing it.
+///
+/// The trade-off is that queries see an empty index until the build finishes
+/// rather than a growing partial one. That is deliberate: results from a
+/// fraction of the repository are misleading, and `status` already reports
+/// that indexing is in progress.
+///
+/// Only used when nothing has been indexed yet. Resuming a partial index still
+/// takes the incremental path, which can skip the files already on disk.
+///
+/// Returns `false` if the index could not be built and published, leaving the
+/// caller to fall back.
+fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path) -> bool {
+    let start = Instant::now();
+    eprintln!("[trace] bootstrapping index with the external merge sort (memory-bounded)...");
+
+    if let Err(e) = builder::build_index_with_options(
+        root,
+        Some(index_dir),
+        &builder::BuildOptions {
+            include_hidden: false,
+            no_ignore: state.no_ignore,
+            exclude_dirs: state.exclude_dirs.clone(),
+            // Match the walk `background_index_build` would have run, and the
+            // dot-prefix rule `should_skip_watcher_path` applies, so the
+            // watcher can maintain every file this build indexes.
+            collect_gitignore_files: true,
+            strategy: builder::IndexStrategy::External,
+            buffer_bytes: builder::DEFAULT_INDEX_BUFFER_BYTES,
+        },
+    ) {
+        eprintln!(
+            "[trace] warning: external bootstrap build failed ({e}); \
+             falling back to the in-heap build"
+        );
+        reset_to_empty_index(state, root, index_dir);
+        return false;
+    }
+
+    // Publish under the snapshot gate, and clear `indexing` before releasing
+    // it. `handle_fs_event` only skips while `indexing` is true, so flipping
+    // the flag outside the gate would let a watcher event mutate the overlay
+    // against the reader we are in the middle of replacing.
+    let gate = state.snapshot_gate.write().unwrap();
+    let opened = match HybridIndex::open(index_dir, root) {
+        Ok(index) => index,
+        Err(e) => {
+            drop(gate);
+            eprintln!(
+                "[trace] warning: bootstrapped index failed to open ({e}); \
+                 falling back to the in-heap build"
+            );
+            reset_to_empty_index(state, root, index_dir);
+            return false;
+        }
+    };
+    let indexed = opened.num_files() as u64;
+    *state.index.write().unwrap() = opened;
+    state.cache.write().unwrap().clear();
+    state.index_total.store(indexed, Ordering::Relaxed);
+    state.index_progress.store(indexed, Ordering::Relaxed);
+
+    // Everything the watcher consults must be in place before `indexing` goes
+    // false, since that flag is the only thing keeping `handle_fs_event` off
+    // the index. Without the stamps it would reindex on spurious events;
+    // without the matcher it would happily index gitignored paths that the
+    // build just skipped.
+    //
+    // The builder persisted filestamps.json as part of the build, but it does
+    // not collect .gitignore paths, so the matcher is built separately here.
+    match tgrep_core::meta::read_filestamps(index_dir) {
+        Ok(stamps) => *state.file_stamps.write().unwrap() = stamps,
+        Err(e) => eprintln!(
+            "[trace] warning: could not load file stamps ({e}); \
+             the watcher may reindex on spurious events"
+        ),
+    }
+    if state.watch_enabled {
+        build_gitignore_matcher_after_ready(state, root);
+    }
+
+    state.indexing.store(false, Ordering::SeqCst);
+    drop(gate);
+
+    eprintln!(
+        "[trace] bootstrap complete: {indexed} files indexed in {:.1}s",
+        start.elapsed().as_secs_f64()
+    );
+
+    if state.ignore_rules_dirty.load(Ordering::SeqCst) {
+        schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+    }
+    true
+}
+
 /// Walk the repo and populate the LiveIndex in batches in a background thread.
 /// Uses rayon for parallel trigram extraction. The bulk build is held entirely
 /// in the live overlay; only one final flush to disk happens once the walk
@@ -1496,6 +1617,13 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         paths
     };
     let seeded_count = skip_paths.len() as u64;
+
+    // Nothing indexed yet: build straight to disk with bounded memory instead
+    // of accumulating the whole repo in the live overlay. Resuming a partial
+    // index falls through, since that path can skip what is already on disk.
+    if skip_paths.is_empty() && bootstrap_index_build(state, root, index_dir) {
+        return;
+    }
 
     // Phase 1: Walk file paths (no content reads)
     let t_walk = Instant::now();

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -863,10 +863,13 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path) -> Option<Recommende
     let state_clone = Arc::clone(&state);
 
     let mut watcher = match notify::recommended_watcher(
-        move |result: std::result::Result<Event, notify::Error>| {
-            if let Ok(event) = result {
-                handle_fs_event(&state_clone, &root_path, &event);
-            }
+        move |result: std::result::Result<Event, notify::Error>| match result {
+            Ok(event) => handle_fs_event(&state_clone, &root_path, &event),
+            // Surface these. A dropped ReadDirectoryChangesW buffer looks
+            // exactly like "the watcher stopped working" from the outside,
+            // and silence makes it impossible to tell apart from a bug in
+            // our own filtering.
+            Err(e) => eprintln!("[trace] warning: file watcher error: {e}"),
         },
     ) {
         Ok(w) => w,

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1505,7 +1505,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
     let start = Instant::now();
     eprintln!("[trace] bootstrapping index with the external merge sort (memory-bounded)...");
 
-    if let Err(e) = builder::build_index_with_options(
+    let outcome = match builder::build_index_with_options(
         root,
         Some(index_dir),
         &builder::BuildOptions {
@@ -1514,19 +1514,23 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             exclude_dirs: state.exclude_dirs.clone(),
             // Match the walk `background_index_build` would have run, and the
             // dot-prefix rule `should_skip_watcher_path` applies, so the
-            // watcher can maintain every file this build indexes.
+            // watcher can maintain every file this build indexes. Also makes
+            // the walk hand back the .gitignore paths for the matcher below.
             collect_gitignore_files: true,
             strategy: builder::IndexStrategy::External,
             buffer_bytes: builder::DEFAULT_INDEX_BUFFER_BYTES,
         },
     ) {
-        eprintln!(
-            "[trace] warning: external bootstrap build failed ({e}); \
-             falling back to the in-heap build"
-        );
-        reset_to_empty_index(state, root, index_dir);
-        return false;
-    }
+        Ok(outcome) => outcome,
+        Err(e) => {
+            eprintln!(
+                "[trace] warning: external bootstrap build failed ({e}); \
+                 falling back to the in-heap build"
+            );
+            reset_to_empty_index(state, root, index_dir);
+            return false;
+        }
+    };
 
     // Publish under the snapshot gate, and clear `indexing` before releasing
     // it. `handle_fs_event` only skips while `indexing` is true, so flipping
@@ -1557,8 +1561,10 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
     // without the matcher it would happily index gitignored paths that the
     // build just skipped.
     //
-    // The builder persisted filestamps.json as part of the build, but it does
-    // not collect .gitignore paths, so the matcher is built separately here.
+    // Both come out of the build itself: the builder persisted filestamps.json,
+    // and its walk handed back the .gitignore paths. Building the matcher from
+    // those is what keeps this cheap — `gitignore::build_matcher` would rewalk
+    // the whole tree single-threaded, which cost 49 s on a 289k-file repo.
     match tgrep_core::meta::read_filestamps(index_dir) {
         Ok(stamps) => *state.file_stamps.write().unwrap() = stamps,
         Err(e) => eprintln!(
@@ -1566,17 +1572,32 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
              the watcher may reindex on spurious events"
         ),
     }
-    if state.watch_enabled {
-        build_gitignore_matcher_after_ready(state, root);
+    if state.watch_enabled && !state.no_ignore {
+        let t_gi = Instant::now();
+        let matcher =
+            tgrep_core::walker::build_gitignore_matcher_from_files(root, &outcome.gitignore_files);
+        let found = matcher.is_some();
+        *state.gitignore.write().unwrap() = matcher;
+        eprintln!(
+            "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
+            outcome.gitignore_files.len(),
+            t_gi.elapsed().as_secs_f64() * 1000.0,
+            if found { "" } else { " (no rules found)" }
+        );
     }
 
     state.indexing.store(false, Ordering::SeqCst);
     drop(gate);
 
-    eprintln!(
-        "[trace] bootstrap complete: {indexed} files indexed in {:.1}s",
-        start.elapsed().as_secs_f64()
-    );
+    let elapsed = start.elapsed().as_secs_f64();
+    match crate::mem::peak_rss_bytes() {
+        Some(peak) => eprintln!(
+            "[trace] bootstrap complete: {indexed} files indexed in {elapsed:.1}s \
+             (peak memory {})",
+            crate::mem::format_bytes(peak)
+        ),
+        None => eprintln!("[trace] bootstrap complete: {indexed} files indexed in {elapsed:.1}s"),
+    }
 
     if state.ignore_rules_dirty.load(Ordering::SeqCst) {
         schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -225,7 +225,6 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
 
     if !has_index {
         // Create an empty on-disk index so HybridIndex can open it.
-        std::fs::create_dir_all(&index_dir)?;
         create_empty_index(&index_dir)?;
         eprintln!("[trace] no existing index found, will build in background");
     }
@@ -236,7 +235,6 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         Ok(hybrid) => hybrid,
         Err(e) if has_index => {
             eprintln!("[trace] existing index failed to load ({e}); rebuilding in background");
-            std::fs::create_dir_all(&index_dir)?;
             create_empty_index(&index_dir)?;
             needs_build = true;
             HybridIndex::open(&index_dir, &root)?
@@ -1299,6 +1297,10 @@ fn json_rpc_error(id: Option<serde_json::Value>, code: i32, message: &str) -> St
 /// The actual data will be populated into the LiveIndex in the background.
 fn create_empty_index(index_dir: &Path) -> Result<()> {
     use tgrep_core::meta::IndexMeta;
+    // Own the directory precondition here rather than leaving it to each
+    // caller: the recovery path in `reset_to_empty_index` runs after a failed
+    // build, which is exactly when the directory is least likely to be intact.
+    std::fs::create_dir_all(index_dir)?;
     // Empty lookup.bin, index.bin, files.bin
     std::fs::write(index_dir.join("lookup.bin"), b"")?;
     std::fs::write(index_dir.join("index.bin"), b"")?;
@@ -2391,6 +2393,41 @@ fn ctrlc_handler<F: Fn() + Send + Sync + 'static>(handler: F) {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// `reset_to_empty_index` runs after a failed build, when the index
+    /// directory is least likely to be intact, so it must not assume the
+    /// directory survived.
+    #[test]
+    fn create_empty_index_makes_its_own_directory() {
+        let tmp = TempDir::new().unwrap();
+        let index_dir = tmp.path().join("missing").join("idx");
+        assert!(!index_dir.exists());
+
+        create_empty_index(&index_dir).expect("should create the directory it writes into");
+
+        assert!(index_dir.join("lookup.bin").is_file());
+        assert!(index_dir.join("index.bin").is_file());
+        assert!(index_dir.join("files.bin").is_file());
+        // A caller that already created the directory must still succeed.
+        create_empty_index(&index_dir).expect("should be idempotent");
+    }
+
+    /// A truncated index left by a failed build must be replaced, not reused.
+    #[test]
+    fn create_empty_index_replaces_partially_written_files() {
+        let tmp = TempDir::new().unwrap();
+        let index_dir = tmp.path().join("idx");
+        std::fs::create_dir_all(&index_dir).unwrap();
+        std::fs::write(index_dir.join("lookup.bin"), b"truncated garbage").unwrap();
+
+        create_empty_index(&index_dir).unwrap();
+
+        assert_eq!(
+            std::fs::read(index_dir.join("lookup.bin")).unwrap().len(),
+            0
+        );
+        HybridIndex::open(&index_dir, tmp.path()).expect("reset index should reopen cleanly");
+    }
 
     #[test]
     fn skip_watcher_path_skips_dot_components() {

--- a/tgrep-core/benches/index_build.rs
+++ b/tgrep-core/benches/index_build.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 #[cfg(windows)]
 use std::process::{Command, Stdio};
 use tempfile::TempDir;
+use tgrep_core::builder::{BuildOptions, IndexStrategy};
 
 fn create_repo(file_count: usize, bytes_per_file: usize) -> TempDir {
     let dir = TempDir::new().unwrap();
@@ -38,8 +39,25 @@ fn create_high_diversity_repo(file_count: usize, bytes_per_file: usize) -> TempD
 }
 
 fn build_index_once(root: &Path) {
+    build_index_with(root, IndexStrategy::InMemory, DEFAULT_BENCH_BUFFER_BYTES);
+}
+
+/// Arena budget used by the external benchmark cases. Deliberately small so
+/// the bench-scale fixtures spill and exercise the merge path.
+const DEFAULT_BENCH_BUFFER_BYTES: usize = 4 * 1024 * 1024;
+
+fn build_index_with(root: &Path, strategy: IndexStrategy, buffer_bytes: usize) {
     let index_dir = root.join(".tgrep_bench");
-    tgrep_core::builder::build_index(root, Some(&index_dir), false, false, &[]).unwrap();
+    tgrep_core::builder::build_index_with_options(
+        root,
+        Some(&index_dir),
+        &BuildOptions {
+            strategy,
+            buffer_bytes,
+            ..Default::default()
+        },
+    )
+    .unwrap();
 }
 
 fn bench_index_build(c: &mut Criterion) {
@@ -68,6 +86,44 @@ fn bench_index_build(c: &mut Criterion) {
             || create_high_diversity_repo(1_000, 1024),
             |dir| {
                 build_index_once(dir.path());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    // Same fixtures under the external merge sort, so the added spill+merge
+    // cost is directly comparable against the in-memory cases above.
+    for (file_count, bytes_per_file) in [(2_000usize, 512usize), (5_000, 512)] {
+        group.throughput(Throughput::Bytes((file_count * bytes_per_file) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("build_index_external", file_count),
+            &(file_count, bytes_per_file),
+            |b, &(file_count, bytes_per_file)| {
+                b.iter_batched(
+                    || create_repo(file_count, bytes_per_file),
+                    |dir| {
+                        build_index_with(
+                            dir.path(),
+                            IndexStrategy::External,
+                            DEFAULT_BENCH_BUFFER_BYTES,
+                        );
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.throughput(Throughput::Bytes(1_000 * 1024));
+    group.bench_function("build_index_high_diversity_external/1000", |b| {
+        b.iter_batched(
+            || create_high_diversity_repo(1_000, 1024),
+            |dir| {
+                build_index_with(
+                    dir.path(),
+                    IndexStrategy::External,
+                    DEFAULT_BENCH_BUFFER_BYTES,
+                );
             },
             BatchSize::SmallInput,
         );
@@ -119,11 +175,16 @@ fn measure_peak_working_set(
     file_count: usize,
     bytes_per_file: usize,
     create: fn(usize, usize) -> TempDir,
+    strategy: IndexStrategy,
 ) -> u64 {
     let repo = create(file_count, bytes_per_file);
     let mut child = Command::new(std::env::current_exe().unwrap())
         .arg("--peak-memory-child")
         .arg(repo.path())
+        .arg(match strategy {
+            IndexStrategy::InMemory => "memory",
+            IndexStrategy::External => "external",
+        })
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -158,16 +219,25 @@ fn run_peak_memory_probe(file_count: usize, bytes_per_file: usize, high_diversit
     } else {
         create_repo
     };
-    let peak = measure_peak_working_set(file_count, bytes_per_file, create);
     let case_name = if high_diversity {
         "build_index_high_diversity"
     } else {
         "build_index"
     };
-    eprintln!(
-        "index_build/{case_name}/{file_count} peak working set: {peak} bytes ({:.2} MiB)",
-        format_mib(peak)
-    );
+
+    // Run both strategies back to back so the comparison is apples to apples
+    // on the same fixture shape and the same machine state.
+    for (label, strategy) in [
+        ("memory", IndexStrategy::InMemory),
+        ("external", IndexStrategy::External),
+    ] {
+        let peak = measure_peak_working_set(file_count, bytes_per_file, create, strategy);
+        eprintln!(
+            "index_build/{case_name}/{file_count} [{label}] peak working set: \
+             {peak} bytes ({:.2} MiB)",
+            format_mib(peak)
+        );
+    }
 }
 
 #[cfg(not(windows))]
@@ -182,7 +252,11 @@ fn main() {
         let root = args
             .get(2)
             .expect("missing root path for peak memory child");
-        build_index_once(Path::new(root));
+        let strategy = match args.get(3).map(String::as_str) {
+            Some("external") => IndexStrategy::External,
+            _ => IndexStrategy::InMemory,
+        };
+        build_index_with(Path::new(root), strategy, DEFAULT_BENCH_BUFFER_BYTES);
         return;
     }
 

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -117,8 +117,14 @@ impl PostingSink {
 pub struct BuildOutcome {
     /// Number of files written to the index.
     pub num_files: usize,
-    /// `.gitignore` paths seen during the walk, when
+    /// Absolute `.gitignore` paths seen during the walk, when
     /// [`BuildOptions::collect_gitignore_files`] was set; empty otherwise.
+    ///
+    /// These are absolute because `build_index_with_options` canonicalizes
+    /// `root` before walking. Consumers rely on that:
+    /// [`walker::build_gitignore_matcher_from_files`] anchors each nested
+    /// `.gitignore` by stripping `root` from its parent directory, so
+    /// repo-relative paths would leave every nested rule out of the matcher.
     ///
     /// Handing these back lets a caller that needs an ignore matcher build one
     /// with [`walker::build_gitignore_matcher_from_files`] instead of

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -25,16 +25,20 @@ pub use crate::external::DEFAULT_BUFFER_BYTES as DEFAULT_INDEX_BUFFER_BYTES;
 pub enum IndexStrategy {
     /// Hold every posting in heap, sort once, write once.
     ///
-    /// Fastest when the postings fit comfortably in RAM, but peak memory
-    /// grows linearly with repository size and is unbounded.
-    #[default]
+    /// Peak memory grows linearly with repository size and is unbounded. Kept
+    /// as an escape hatch for environments where spilling to disk is
+    /// undesirable or impossible (read-only or full index volume), and as the
+    /// independent reference implementation that [`IndexStrategy::External`]
+    /// is differentially tested against.
     InMemory,
     /// Bound peak memory with an external merge sort.
     ///
     /// Postings accumulate in a fixed-size arena that spills sorted, compact
     /// segments to disk when full; the segments are then k-way merged straight
     /// into the index. Peak heap is independent of repository size. If the
-    /// arena never fills this is identical to [`IndexStrategy::InMemory`].
+    /// arena never fills this is identical to [`IndexStrategy::InMemory`], so
+    /// small repositories pay nothing for the default.
+    #[default]
     External,
 }
 
@@ -749,6 +753,15 @@ mod tests {
             fingerprint.insert(trigram, resolved);
         }
         fingerprint
+    }
+
+    // The memory-bounded path is the default; a refactor that silently
+    // reverted it would reintroduce unbounded peak memory on large repos
+    // without failing any other test.
+    #[test]
+    fn external_is_the_default_strategy() {
+        assert_eq!(IndexStrategy::default(), IndexStrategy::External);
+        assert_eq!(BuildOptions::default().strategy, IndexStrategy::External);
     }
 
     #[test]

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -112,6 +112,21 @@ impl PostingSink {
     }
 }
 
+/// What a build produced, beyond the index files themselves.
+#[derive(Debug, Default)]
+pub struct BuildOutcome {
+    /// Number of files written to the index.
+    pub num_files: usize,
+    /// `.gitignore` paths seen during the walk, when
+    /// [`BuildOptions::collect_gitignore_files`] was set; empty otherwise.
+    ///
+    /// Handing these back lets a caller that needs an ignore matcher build one
+    /// with [`walker::build_gitignore_matcher_from_files`] instead of
+    /// [`crate::gitignore::build_matcher`], which would repeat the whole walk
+    /// serially — 49 s on a 289k-file repository.
+    pub gitignore_files: Vec<std::path::PathBuf>,
+}
+
 /// Build a trigram index for all text files under `root`.
 pub fn build_index(
     root: &Path,
@@ -130,6 +145,7 @@ pub fn build_index(
             ..Default::default()
         },
     )
+    .map(|_| ())
 }
 
 /// Build a trigram index, choosing how postings are accumulated.
@@ -137,7 +153,7 @@ pub fn build_index_with_options(
     root: &Path,
     index_dir: Option<&Path>,
     opts: &BuildOptions,
-) -> Result<()> {
+) -> Result<BuildOutcome> {
     let include_hidden = opts.include_hidden;
     let no_ignore = opts.no_ignore;
     let exclude_dirs = opts.exclude_dirs.as_slice();
@@ -165,6 +181,7 @@ pub fn build_index_with_options(
         walk.skipped_binary,
         walk.skipped_error
     );
+    let gitignore_files = walk.gitignore_files;
 
     // Read files and extract trigrams with masks in bounded parallel batches.
     // Binary content check is done here (not in walker) to avoid an extra
@@ -253,7 +270,10 @@ pub fn build_index_with_options(
     meta::write_filestamps(&stamps, &index_dir)?;
 
     eprintln!("Index built successfully at {}", index_dir.display());
-    Ok(())
+    Ok(BuildOutcome {
+        num_files: file_id_map.len(),
+        gitignore_files,
+    })
 }
 
 /// Return the default index directory for a given repo root.

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 
+use crate::external::{self, ExternalSorter, TrigramPosting};
 use crate::meta::{self, IndexMeta};
 use crate::ondisk::{self, LookupEntry, PostingEntry};
 use crate::reader::IndexReader;
@@ -16,10 +17,82 @@ const INDEX_BUILD_BATCH_SIZE: usize = 1024;
 const POSTING_WRITE_CHUNK_ENTRIES: usize = 8192;
 const LOOKUP_WRITE_CHUNK_ENTRIES: usize = 4096;
 
-#[derive(Clone, Copy)]
-struct TrigramPosting {
-    trigram: u32,
-    entry: PostingEntry,
+/// Default arena budget for [`IndexStrategy::External`] before spilling.
+pub use crate::external::DEFAULT_BUFFER_BYTES as DEFAULT_INDEX_BUFFER_BYTES;
+
+/// How the builder accumulates postings before writing them out.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum IndexStrategy {
+    /// Hold every posting in heap, sort once, write once.
+    ///
+    /// Fastest when the postings fit comfortably in RAM, but peak memory
+    /// grows linearly with repository size and is unbounded.
+    #[default]
+    InMemory,
+    /// Bound peak memory with an external merge sort.
+    ///
+    /// Postings accumulate in a fixed-size arena that spills sorted, compact
+    /// segments to disk when full; the segments are then k-way merged straight
+    /// into the index. Peak heap is independent of repository size. If the
+    /// arena never fills this is identical to [`IndexStrategy::InMemory`].
+    External,
+}
+
+/// Tunables for [`build_index_with_options`].
+#[derive(Debug, Clone)]
+pub struct BuildOptions {
+    pub include_hidden: bool,
+    pub no_ignore: bool,
+    pub exclude_dirs: Vec<String>,
+    pub strategy: IndexStrategy,
+    /// Arena budget in bytes for [`IndexStrategy::External`]. Ignored by
+    /// [`IndexStrategy::InMemory`].
+    pub buffer_bytes: usize,
+}
+
+impl Default for BuildOptions {
+    fn default() -> Self {
+        Self {
+            include_hidden: false,
+            no_ignore: false,
+            exclude_dirs: Vec::new(),
+            strategy: IndexStrategy::default(),
+            buffer_bytes: external::DEFAULT_BUFFER_BYTES,
+        }
+    }
+}
+
+/// Destination for postings as files are processed.
+enum PostingSink {
+    InMemory(Vec<TrigramPosting>),
+    External(ExternalSorter),
+}
+
+impl PostingSink {
+    fn push_file(
+        &mut self,
+        file_id: u32,
+        per_trigram: impl IntoIterator<Item = (u32, TrigramMasks)>,
+    ) -> Result<()> {
+        match self {
+            Self::InMemory(postings) => {
+                postings.extend(
+                    per_trigram
+                        .into_iter()
+                        .map(|(trigram, masks)| TrigramPosting {
+                            trigram,
+                            entry: PostingEntry {
+                                file_id,
+                                loc_mask: masks.loc_mask,
+                                next_mask: masks.next_mask,
+                            },
+                        }),
+                );
+                Ok(())
+            }
+            Self::External(sorter) => sorter.push_file(file_id, per_trigram),
+        }
+    }
 }
 
 /// Build a trigram index for all text files under `root`.
@@ -30,6 +103,27 @@ pub fn build_index(
     no_ignore: bool,
     exclude_dirs: &[String],
 ) -> Result<()> {
+    build_index_with_options(
+        root,
+        index_dir,
+        &BuildOptions {
+            include_hidden,
+            no_ignore,
+            exclude_dirs: exclude_dirs.to_vec(),
+            ..Default::default()
+        },
+    )
+}
+
+/// Build a trigram index, choosing how postings are accumulated.
+pub fn build_index_with_options(
+    root: &Path,
+    index_dir: Option<&Path>,
+    opts: &BuildOptions,
+) -> Result<()> {
+    let include_hidden = opts.include_hidden;
+    let no_ignore = opts.no_ignore;
+    let exclude_dirs = opts.exclude_dirs.as_slice();
     let root = std::fs::canonicalize(root)?;
     let index_dir = match index_dir {
         Some(d) => d.to_path_buf(),
@@ -63,7 +157,13 @@ pub fn build_index(
     // Assign file IDs and collect posting entries. Batching avoids
     // retaining every file's per-trigram HashMap at once for large repos.
     let mut file_id_map: Vec<(u32, String)> = Vec::with_capacity(walk.files.len());
-    let mut postings: Vec<TrigramPosting> = Vec::new();
+    let mut sink = match opts.strategy {
+        IndexStrategy::InMemory => PostingSink::InMemory(Vec::new()),
+        IndexStrategy::External => {
+            std::fs::create_dir_all(&index_dir)?;
+            PostingSink::External(ExternalSorter::new(&index_dir, opts.buffer_bytes))
+        }
+    };
 
     for batch in walk.files.chunks(INDEX_BUILD_BATCH_SIZE) {
         let batch_data: Vec<(String, HashMap<u32, TrigramMasks>)> = batch
@@ -87,17 +187,7 @@ pub fn build_index(
         for (path, per_tri) in batch_data {
             let file_id = file_id_map.len() as u32;
             file_id_map.push((file_id, path));
-
-            for (tri, masks) in per_tri {
-                postings.push(TrigramPosting {
-                    trigram: tri,
-                    entry: PostingEntry {
-                        file_id,
-                        loc_mask: masks.loc_mask,
-                        next_mask: masks.next_mask,
-                    },
-                });
-            }
+            sink.push_file(file_id, per_tri)?;
         }
     }
 
@@ -109,7 +199,28 @@ pub fn build_index(
         );
     }
 
-    write_index_v2_from_postings(&index_dir, &root, &file_id_map, &mut postings)?;
+    match sink {
+        PostingSink::InMemory(mut postings) => {
+            write_index_v2_from_postings(&index_dir, &root, &file_id_map, &mut postings)?;
+        }
+        PostingSink::External(sorter) => {
+            let (trigram_count, segments) = sorter.write_postings(&index_dir)?;
+            eprintln!(
+                "Writing index ({} trigrams, {} files, {} spill segment(s))...",
+                trigram_count,
+                file_id_map.len(),
+                segments
+            );
+            write_files_and_meta(
+                &index_dir,
+                &root,
+                file_id_map.len(),
+                file_id_map.iter().map(|(_, p)| p.as_str()),
+                trigram_count,
+                None,
+            )?;
+        }
+    }
 
     // Write per-file stamps for ALL walked files (including those later
     // rejected as binary-by-content) so the stale check on next startup
@@ -586,6 +697,177 @@ fn count_sorted_trigrams(postings: &[TrigramPosting]) -> usize {
 mod tests {
     use super::*;
     use crate::reader::IndexReader;
+
+    /// Build a repo with enough varied content that a small arena spills.
+    fn write_sample_repo(root: &Path, file_count: usize) {
+        let src = root.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        for i in 0..file_count {
+            let mut state = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xD1B5_4A32_D192_ED03;
+            let mut data = format!("// File {i}\nfn Handler{i}() {{ needle(); }}\n").into_bytes();
+            while data.len() < 2048 {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                data.push(32 + ((state >> 33) % 94) as u8);
+            }
+            std::fs::write(src.join(format!("f{i:04}.rs")), data).unwrap();
+        }
+    }
+
+    /// Canonical, walk-order-independent view of an index: every trigram
+    /// mapped to its postings resolved to *paths* rather than file IDs.
+    ///
+    /// The parallel walker yields files in nondeterministic order, so two
+    /// builds of the same repo legitimately assign different file IDs and
+    /// produce different bytes. Resolving through paths compares what the
+    /// index actually means. (Byte-for-byte equivalence of the two write
+    /// paths for identical input is covered by `external`'s unit tests.)
+    fn index_fingerprint(
+        index_dir: &Path,
+    ) -> std::collections::BTreeMap<u32, Vec<(String, u8, u8)>> {
+        let reader = IndexReader::open(index_dir).unwrap();
+        let mut fingerprint = std::collections::BTreeMap::new();
+        for (trigram, entries) in reader.all_trigram_postings_with_masks() {
+            let ids: Vec<u32> = entries.iter().map(|e| e.file_id).collect();
+            let mut sorted = ids.clone();
+            sorted.sort_unstable();
+            assert_eq!(
+                ids, sorted,
+                "posting list for trigram {trigram:#08x} is not file-id sorted"
+            );
+
+            let mut resolved: Vec<(String, u8, u8)> = entries
+                .iter()
+                .map(|e| {
+                    let path = reader
+                        .file_path(e.file_id)
+                        .unwrap_or_else(|| panic!("unresolved file id {}", e.file_id))
+                        .to_string();
+                    (path, e.loc_mask, e.next_mask)
+                })
+                .collect();
+            resolved.sort();
+            fingerprint.insert(trigram, resolved);
+        }
+        fingerprint
+    }
+
+    #[test]
+    fn external_strategy_matches_in_memory_index_contents() {
+        let repo = tempfile::tempdir().unwrap();
+        write_sample_repo(repo.path(), 40);
+
+        let in_memory = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+
+        build_index_with_options(
+            repo.path(),
+            Some(in_memory.path()),
+            &BuildOptions {
+                strategy: IndexStrategy::InMemory,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // A 1-byte budget clamps to the minimum arena, forcing many spills.
+        build_index_with_options(
+            repo.path(),
+            Some(external.path()),
+            &BuildOptions {
+                strategy: IndexStrategy::External,
+                buffer_bytes: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // Same total bytes: identical posting count, identical layout.
+        let expected_len = std::fs::metadata(in_memory.path().join("index.bin"))
+            .unwrap()
+            .len();
+        let actual_len = std::fs::metadata(external.path().join("index.bin"))
+            .unwrap()
+            .len();
+        assert!(expected_len > 0, "fixture should produce a non-empty index");
+        assert_eq!(expected_len, actual_len, "index.bin size differs");
+
+        let expected = index_fingerprint(in_memory.path());
+        let actual = index_fingerprint(external.path());
+        assert_eq!(
+            expected.len(),
+            actual.len(),
+            "distinct trigram count differs"
+        );
+        for (trigram, expected_postings) in &expected {
+            let actual_postings = actual
+                .get(trigram)
+                .unwrap_or_else(|| panic!("trigram {trigram:#08x} missing from external index"));
+            assert!(
+                expected_postings == actual_postings,
+                "postings differ for trigram {trigram:#08x}: \
+                 in-memory has {} entries, external has {}",
+                expected_postings.len(),
+                actual_postings.len()
+            );
+        }
+    }
+
+    #[test]
+    fn external_strategy_index_is_searchable() {
+        let repo = tempfile::tempdir().unwrap();
+        write_sample_repo(repo.path(), 60);
+
+        let index = tempfile::tempdir().unwrap();
+        build_index_with_options(
+            repo.path(),
+            Some(index.path()),
+            &BuildOptions {
+                strategy: IndexStrategy::External,
+                buffer_bytes: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let reader = IndexReader::open(index.path()).unwrap();
+        reader.validate_lookup().unwrap();
+        assert_eq!(reader.num_files(), 60);
+
+        // "needle" appears in every file, so its trigram must list all of them
+        // in ascending file-id order after the merge.
+        let entries = reader.lookup_trigram_with_masks(crate::trigram::hash(b'n', b'e', b'e'));
+        assert_eq!(entries.len(), 60);
+        let ids: Vec<u32> = entries.iter().map(|e| e.file_id).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted, "merged posting lists must be file-id sorted");
+    }
+
+    #[test]
+    fn external_strategy_leaves_no_spill_directory_behind() {
+        let repo = tempfile::tempdir().unwrap();
+        write_sample_repo(repo.path(), 40);
+
+        let index = tempfile::tempdir().unwrap();
+        build_index_with_options(
+            repo.path(),
+            Some(index.path()),
+            &BuildOptions {
+                strategy: IndexStrategy::External,
+                buffer_bytes: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let leftover: Vec<String> = std::fs::read_dir(index.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with("spill-"))
+            .collect();
+        assert!(leftover.is_empty(), "spill dirs left behind: {leftover:?}");
+    }
 
     #[test]
     fn build_index_writes_readable_round_trip_index() {

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -48,6 +48,18 @@ pub struct BuildOptions {
     pub include_hidden: bool,
     pub no_ignore: bool,
     pub exclude_dirs: Vec<String>,
+    /// Apply leading-dot ("hidden") filtering in the walk instead of the
+    /// platform's native hidden check, and treat `.gitignore` files as
+    /// hidden.
+    ///
+    /// The two differ on Windows, where the native check reads the
+    /// `FILE_ATTRIBUTE_HIDDEN` bit that git does not set on dotfiles, so a
+    /// default walk indexes `.gitignore`, `.mailmap`, and friends there but
+    /// not on Unix. `tgrep serve` walks with leading-dot semantics on every
+    /// platform, and its file watcher skips dot-prefixed paths outright, so a
+    /// build destined for a server must opt in — otherwise the server would
+    /// index dotfiles it can never afterwards update or remove.
+    pub collect_gitignore_files: bool,
     pub strategy: IndexStrategy,
     /// Arena budget in bytes for [`IndexStrategy::External`]. Ignored by
     /// [`IndexStrategy::InMemory`].
@@ -60,6 +72,7 @@ impl Default for BuildOptions {
             include_hidden: false,
             no_ignore: false,
             exclude_dirs: Vec::new(),
+            collect_gitignore_files: false,
             strategy: IndexStrategy::default(),
             buffer_bytes: external::DEFAULT_BUFFER_BYTES,
         }
@@ -141,6 +154,7 @@ pub fn build_index_with_options(
         &walker::WalkOptions {
             include_hidden,
             no_ignore,
+            collect_gitignore_files: opts.collect_gitignore_files,
             exclude_dirs: exclude_dirs.to_vec(),
             ..Default::default()
         },
@@ -762,6 +776,46 @@ mod tests {
     fn external_is_the_default_strategy() {
         assert_eq!(IndexStrategy::default(), IndexStrategy::External);
         assert_eq!(BuildOptions::default().strategy, IndexStrategy::External);
+    }
+
+    // `tgrep serve` walks with leading-dot hidden semantics and its watcher
+    // skips dot-prefixed paths, so a build that feeds a server must exclude
+    // dotfiles. On Windows the default walk keeps them (the native hidden
+    // check reads an attribute git never sets), which would leave the server
+    // holding entries it can never update or delete.
+    #[test]
+    fn collect_gitignore_files_excludes_dotfiles_from_the_index() {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src").join("main.rs"),
+            "fn main() { needle(); }\n",
+        )
+        .unwrap();
+        std::fs::write(root.join(".gitignore"), "# needle marker\n*.log\n").unwrap();
+        std::fs::write(root.join(".mailmap"), "needle <needle@example.com>\n").unwrap();
+
+        let for_serve = tempfile::tempdir().unwrap();
+        build_index_with_options(
+            root,
+            Some(for_serve.path()),
+            &BuildOptions {
+                collect_gitignore_files: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let reader = IndexReader::open(for_serve.path()).unwrap();
+        let indexed: Vec<String> = (0..reader.num_files() as u32)
+            .filter_map(|id| reader.file_path(id).map(|p| p.to_string()))
+            .collect();
+        assert_eq!(
+            indexed,
+            vec!["src/main.rs".to_string()],
+            "a build destined for the server must skip dot-prefixed files"
+        );
     }
 
     #[test]

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -1019,4 +1019,74 @@ mod tests {
             "base file's real loc_mask must be preserved verbatim"
         );
     }
+
+    /// Incremental flushes stream new files onto whatever index is already on
+    /// disk, so the append path must work identically on an external-built
+    /// base. `external` only changes how postings are accumulated in memory,
+    /// not the on-disk format, but that is exactly the kind of assumption worth
+    /// pinning down: a base built through the spill/merge path must remain a
+    /// valid input to `append_overlay_to_index`.
+    #[test]
+    fn append_overlay_merges_onto_an_external_built_index() {
+        use crate::live::LiveIndex;
+
+        let repo = tempfile::tempdir().unwrap();
+        let src = repo.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("a.txt"), "hello world\nneedle one\n").unwrap();
+        std::fs::write(src.join("b.txt"), "needle two\nother content\n").unwrap();
+
+        // Build the base through the spill/merge path. A 1-byte budget floors
+        // the arena at its minimum so this is a real merge, not the fast path.
+        let base_dir = tempfile::tempdir().unwrap();
+        build_index_with_options(
+            repo.path(),
+            Some(base_dir.path()),
+            &BuildOptions {
+                strategy: IndexStrategy::External,
+                buffer_bytes: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let base_reader = IndexReader::open(base_dir.path()).unwrap();
+        assert_eq!(base_reader.num_files(), 2);
+
+        let mut live = LiveIndex::new();
+        live.upsert_file_with_trigrams("src/c.txt", crate::trigram::extract(b"needle three\n"));
+        live.upsert_file_with_trigrams("src/d.txt", crate::trigram::extract(b"zzz unique\n"));
+        let (overlay_paths, overlay_inverted) = live.snapshot_for_disk();
+
+        let merged_dir = tempfile::tempdir().unwrap();
+        append_overlay_to_index(
+            repo.path(),
+            merged_dir.path(),
+            &base_reader,
+            &overlay_paths,
+            &overlay_inverted,
+            true,
+        )
+        .unwrap();
+
+        let merged = IndexReader::open(merged_dir.path()).unwrap();
+        merged.validate_lookup().unwrap();
+        assert_eq!(merged.num_files(), 4);
+
+        // Base IDs preserved, overlay appended after them.
+        assert_eq!(merged.file_path(0), base_reader.file_path(0));
+        assert_eq!(merged.file_path(1), base_reader.file_path(1));
+        assert_eq!(merged.file_path(2), Some("src/c.txt"));
+        assert_eq!(merged.file_path(3), Some("src/d.txt"));
+
+        // A trigram spanning base and overlay resolves across both halves and
+        // stays file-id sorted, which is what query execution relies on.
+        let needle = crate::trigram::hash(b'n', b'e', b'e');
+        let ids = merged.lookup_trigram(needle);
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted, "merged posting list must be sorted");
+        let mut paths: Vec<&str> = ids.iter().filter_map(|&id| merged.file_path(id)).collect();
+        paths.sort_unstable();
+        assert_eq!(paths, vec!["src/a.txt", "src/b.txt", "src/c.txt"]);
+    }
 }

--- a/tgrep-core/src/external.rs
+++ b/tgrep-core/src/external.rs
@@ -123,7 +123,12 @@ impl ExternalSorter {
         // produce a zero-capacity arena that spills on every single posting.
         let capacity = (budget_bytes / entry_size).max(1024);
         Self {
-            arena: Vec::new(),
+            // Allocate the arena once, exactly. Letting `Vec` grow it would
+            // overshoot the budget: for the 64 MB default it doubles past the
+            // target and reserves 96 MB, half again the bound this type exists
+            // to enforce. Reserving up front also avoids repeatedly copying a
+            // multi-megabyte buffer while filling.
+            arena: Vec::with_capacity(capacity),
             capacity,
             budget_bytes,
             spill: None,
@@ -610,6 +615,41 @@ mod tests {
                 next_mask: (trigram as u8) | 1,
             },
         }
+    }
+
+    // `Vec`'s own doubling would reserve up to 2x the budget (96 MB for the
+    // 64 MB default), so the arena could hold half again as much as the caller
+    // asked for. The allocation must stay inside the budget, both on the first
+    // fill and after a spill reuses the buffer.
+    #[test]
+    fn arena_allocation_never_exceeds_the_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        // 64 KB budget: large enough to exercise several fills, small enough
+        // that the entry capacity is not clamped by the 1024-entry floor.
+        let budget = 64 * 1024;
+        let mut sorter = ExternalSorter::new(dir.path(), budget);
+        let capacity = sorter.capacity;
+        assert!(
+            capacity > 1024,
+            "budget should set capacity, not the floor: {capacity}"
+        );
+        assert_eq!(
+            sorter.arena.capacity(),
+            capacity,
+            "arena should be reserved exactly once, up front"
+        );
+
+        // Push well past one full arena so growth and post-spill reuse are
+        // both covered.
+        for i in 0..(capacity as u32 * 3) {
+            sorter.push(posting(i % 977, i)).unwrap();
+            assert!(
+                sorter.arena.capacity() <= capacity,
+                "arena capacity {} exceeded budget capacity {capacity}",
+                sorter.arena.capacity()
+            );
+        }
+        assert!(sorter.spilled_segments() > 0, "expected at least one spill");
     }
 
     /// Build both ways and assert the resulting index files are byte-identical.

--- a/tgrep-core/src/external.rs
+++ b/tgrep-core/src/external.rs
@@ -80,15 +80,30 @@ fn write_varint(buf: &mut Vec<u8>, mut value: u64) {
 /// Segments are written next to the index rather than under the system temp
 /// directory: they can total gigabytes for a large repository, and `TEMP` is
 /// frequently on a smaller (or differently quota'd) volume than the workspace.
+///
+/// The name carries both the process ID and a per-process sequence number.
+/// The PID separates concurrent processes; the sequence separates concurrent
+/// sorters *within* a process. Without the latter, two sorters sharing an
+/// `index_dir` would write the same `seg-NNNNN.bin` names into the same
+/// directory, and each would merge whatever the other last wrote there —
+/// silently, because a foreign segment is still a structurally valid segment.
 struct SpillDir {
     path: PathBuf,
 }
 
+/// Distinguishes spill directories created by different sorters in this
+/// process. Only uniqueness matters, so `Relaxed` is sufficient.
+static SPILL_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 impl SpillDir {
     fn create(index_dir: &Path) -> Result<Self> {
-        let path = index_dir.join(format!("spill-{}.tmp", std::process::id()));
+        let seq = SPILL_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let path = index_dir.join(format!("spill-{}-{seq}.tmp", std::process::id()));
         // A leftover directory from a killed build would make stale segments
-        // visible to this run's merge, silently corrupting the index.
+        // visible to this run's merge, silently corrupting the index. The PID
+        // can be recycled by the OS and the sequence restarts at zero in a new
+        // process, so this name is reusable across runs even though it is
+        // unique among live sorters.
         let _ = std::fs::remove_dir_all(&path);
         std::fs::create_dir_all(&path)?;
         Ok(Self { path })
@@ -617,10 +632,65 @@ mod tests {
         }
     }
 
+    /// Trigram IDs present in a written index, read straight out of
+    /// `lookup.bin` so no `meta.json` is required.
+    fn trigram_ids(index_dir: &Path) -> Vec<u32> {
+        std::fs::read(index_dir.join("lookup.bin"))
+            .unwrap()
+            .chunks_exact(ondisk::LOOKUP_ENTRY_SIZE)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
     // `Vec`'s own doubling would reserve up to 2x the budget (96 MB for the
     // 64 MB default), so the arena could hold half again as much as the caller
     // asked for. The allocation must stay inside the budget, both on the first
     // fill and after a spill reuses the buffer.
+    /// Two sorters sharing one `index_dir` in the same process must not see
+    /// each other's spill segments.
+    ///
+    /// Before spill directories carried a per-sorter sequence number, both
+    /// sorters wrote `seg-00000.bin`, `seg-00001.bin`, ... into the same
+    /// `spill-<pid>.tmp`, so the second one's writes landed on the first one's
+    /// recorded paths. The first then merged the second's postings without any
+    /// error, because a foreign segment is still a structurally valid segment:
+    /// a sorter fed only trigram 100 produced an index containing 100 *and*
+    /// 777. That is silent index corruption, so assert on content.
+    #[test]
+    fn concurrent_sorters_in_one_index_dir_do_not_share_segments() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut a = ExternalSorter::new(dir.path(), 1);
+        for file_id in 0..5000u32 {
+            a.push(posting(100, file_id)).unwrap();
+        }
+        assert!(a.segments.len() > 1, "A should have spilled");
+
+        // B starts on the same index_dir while A is still live.
+        let mut b = ExternalSorter::new(dir.path(), 1);
+        for file_id in 0..5000u32 {
+            b.push(posting(777, file_id)).unwrap();
+        }
+
+        assert_ne!(
+            a.spill.as_ref().unwrap().path,
+            b.spill.as_ref().unwrap().path,
+            "each sorter needs its own spill directory"
+        );
+
+        let out_a = dir.path().join("out_a");
+        let (trigrams_a, _) = a.write_postings(&out_a).unwrap();
+        assert_eq!(trigrams_a, 1, "A should see only its own trigram");
+        assert_eq!(trigram_ids(&out_a), vec![100]);
+
+        // B still merges correctly afterwards; A's completion dropped only its
+        // own spill directory.
+        let out_b = dir.path().join("out_b");
+        let (trigrams_b, _) = b.write_postings(&out_b).unwrap();
+        assert_eq!(trigrams_b, 1, "B should see only its own trigram");
+        assert_eq!(trigram_ids(&out_b), vec![777]);
+    }
+
     #[test]
     fn arena_allocation_never_exceeds_the_budget() {
         let dir = tempfile::tempdir().unwrap();

--- a/tgrep-core/src/external.rs
+++ b/tgrep-core/src/external.rs
@@ -14,8 +14,10 @@
 //! 3. [`ExternalSorter::write_postings`] streams a k-way merge of the segments
 //!    straight into `index.bin` / `lookup.bin`.
 //!
-//! Peak heap is `arena + segments * SEGMENT_BUFFER_BYTES + largest posting
-//! list`, independent of repository size.
+//! Peak heap is `max(arena, merge read buffers) + largest posting list`,
+//! independent of repository size. The merge shares one read-ahead budget
+//! across all open segments rather than giving each a fixed buffer, so peak
+//! stays tied to the caller's budget instead of growing with fan-in.
 //!
 //! Total sort work is unchanged: `k` sorts of `n/k` elements plus an `n·log k`
 //! merge is still `O(n·log n)`, with better cache locality per sort. The added
@@ -47,8 +49,14 @@ pub(crate) struct TrigramPosting {
 /// modest even for very large repositories.
 pub const DEFAULT_BUFFER_BYTES: usize = 64 * 1024 * 1024;
 
-/// Read-ahead buffer held per open segment during the merge.
+/// Read-ahead buffer held per open segment during the merge, when fan-in is
+/// low enough to afford it.
 const SEGMENT_BUFFER_BYTES: usize = 256 * 1024;
+
+/// Floor on a per-segment read buffer. Only `MAX_VARINT_LEN` bytes are ever
+/// required for correctness; this is purely to keep the read syscall count
+/// reasonable at high fan-in.
+const MIN_SEGMENT_BUFFER_BYTES: usize = 4 * 1024;
 
 /// Longest possible LEB128 encoding of a `u64`.
 const MAX_VARINT_LEN: usize = 10;
@@ -98,6 +106,9 @@ pub(crate) struct ExternalSorter {
     arena: Vec<TrigramPosting>,
     /// Arena length that triggers a spill.
     capacity: usize,
+    /// Caller's byte budget. Bounds the arena while accumulating, then the
+    /// shared segment read-ahead while merging.
+    budget_bytes: usize,
     spill: Option<SpillDir>,
     segments: Vec<PathBuf>,
     index_dir: PathBuf,
@@ -114,6 +125,7 @@ impl ExternalSorter {
         Self {
             arena: Vec::new(),
             capacity,
+            budget_bytes,
             spill: None,
             segments: Vec::new(),
             index_dir: index_dir.to_path_buf(),
@@ -257,7 +269,10 @@ impl ExternalSorter {
 
         let segments = self.segments.len();
         eprintln!("Merging {segments} spill segment(s) into the index...");
-        Ok((merge_segments(index_dir, &self.segments)?, segments))
+        Ok((
+            merge_segments(index_dir, &self.segments, self.budget_bytes)?,
+            segments,
+        ))
     }
 }
 
@@ -370,10 +385,10 @@ struct ByteSource {
 }
 
 impl ByteSource {
-    fn open(path: &Path) -> Result<Self> {
+    fn open(path: &Path, capacity: usize) -> Result<Self> {
         Ok(Self {
             file: File::open(path)?,
-            buf: vec![0u8; SEGMENT_BUFFER_BYTES],
+            buf: vec![0u8; capacity.max(MAX_VARINT_LEN)],
             pos: 0,
             filled: 0,
         })
@@ -382,7 +397,7 @@ impl ByteSource {
     /// Make at least `want` bytes available if the file still has them.
     /// Returns the number actually available, which is short only at EOF.
     fn ensure(&mut self, want: usize) -> Result<usize> {
-        debug_assert!(want <= SEGMENT_BUFFER_BYTES);
+        debug_assert!(want <= self.buf.len());
         if self.filled - self.pos >= want {
             return Ok(self.filled - self.pos);
         }
@@ -448,9 +463,9 @@ struct SegmentCursor {
 }
 
 impl SegmentCursor {
-    fn open(path: &Path) -> Result<Self> {
+    fn open(path: &Path, buffer_bytes: usize) -> Result<Self> {
         Ok(Self {
-            src: ByteSource::open(path)?,
+            src: ByteSource::open(path, buffer_bytes)?,
             prev_trigram: 0,
             pending_count: 0,
         })
@@ -497,8 +512,33 @@ impl SegmentCursor {
     }
 }
 
+/// Per-segment read-ahead when `read_budget_bytes` is shared across `segments`
+/// open cursors.
+///
+/// Above the floor this keeps total merge memory at roughly the caller's
+/// budget regardless of fan-in. Below it — a tiny budget against a very large
+/// repository — total degrades to `segments * MIN_SEGMENT_BUFFER_BYTES`, still
+/// 64x below a fixed 256 KiB buffer per segment. Bounding that last case
+/// absolutely would need a multi-pass merge; at realistic budgets the floor is
+/// never reached.
+fn segment_buffer_bytes(read_budget_bytes: usize, segments: usize) -> usize {
+    (read_budget_bytes / segments.max(1)).clamp(MIN_SEGMENT_BUFFER_BYTES, SEGMENT_BUFFER_BYTES)
+}
+
 /// k-way merge of sorted segments into `index.bin` / `lookup.bin`.
-fn merge_segments(index_dir: &Path, segments: &[PathBuf]) -> Result<usize> {
+///
+/// `read_budget_bytes` is shared across every open segment. A fixed per-segment
+/// buffer would make merge memory grow with fan-in, which is backwards: a
+/// smaller arena spills more segments, so it would make a *tighter* budget cost
+/// *more* peak memory. Splitting one budget keeps peak tied to what was asked
+/// for. The arena has already been released by this point, so the full budget
+/// is available.
+fn merge_segments(
+    index_dir: &Path,
+    segments: &[PathBuf],
+    read_budget_bytes: usize,
+) -> Result<usize> {
+    let per_segment = segment_buffer_bytes(read_budget_bytes, segments.len());
     let mut cursors: Vec<SegmentCursor> = Vec::with_capacity(segments.len());
     // Min-heap keyed by (trigram, segment index). Ordering by segment index as
     // the tiebreak matters: file IDs are assigned in walk order and segments
@@ -508,7 +548,7 @@ fn merge_segments(index_dir: &Path, segments: &[PathBuf]) -> Result<usize> {
     let mut heap: BinaryHeap<Reverse<(u32, usize)>> = BinaryHeap::with_capacity(segments.len());
 
     for (idx, path) in segments.iter().enumerate() {
-        let mut cursor = SegmentCursor::open(path)?;
+        let mut cursor = SegmentCursor::open(path, per_segment)?;
         if let Some(trigram) = cursor.advance()? {
             heap.push(Reverse((trigram, idx)));
         }
@@ -729,10 +769,112 @@ mod tests {
         }
         std::fs::write(&path, &buf).unwrap();
 
-        let mut src = ByteSource::open(&path).unwrap();
+        let mut src = ByteSource::open(&path, SEGMENT_BUFFER_BYTES).unwrap();
         for &v in &values {
             assert_eq!(src.read_varint().unwrap(), Some(v));
         }
         assert_eq!(src.read_varint().unwrap(), None);
+    }
+
+    /// A tiny buffer must still decode correctly: `ensure` compacts its sliding
+    /// window, so the only hard requirement is room for one varint.
+    #[test]
+    fn varint_roundtrip_survives_a_minimal_buffer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("v.bin");
+        let values = [0u64, 1, 127, 128, 300, 16_383, 16_384, u32::MAX as u64];
+        let mut buf = Vec::new();
+        for &v in &values {
+            write_varint(&mut buf, v);
+        }
+        std::fs::write(&path, &buf).unwrap();
+
+        let mut src = ByteSource::open(&path, 1).unwrap();
+        for &v in &values {
+            assert_eq!(src.read_varint().unwrap(), Some(v));
+        }
+        assert_eq!(src.read_varint().unwrap(), None);
+    }
+
+    /// Merge read-ahead is a shared budget, not a per-segment allocation.
+    /// Without this, shrinking the arena raises segment count and drives peak
+    /// memory *up*, defeating the point of a tighter budget. Measured on the
+    /// Linux kernel: a 1 MiB arena spilled 1946 segments, and fixed 256 KiB
+    /// buffers put 486 MiB of read-ahead on the heap.
+    #[test]
+    fn merge_read_ahead_is_bounded_by_the_budget_not_by_fan_in() {
+        let budget = 64 * 1024 * 1024;
+
+        // Low fan-in: each segment can afford the full read-ahead.
+        assert_eq!(segment_buffer_bytes(budget, 31), SEGMENT_BUFFER_BYTES);
+
+        // High fan-in: buffers shrink so the total tracks the budget.
+        for segments in [64usize, 256, 1024, 4096] {
+            let total = segment_buffer_bytes(budget, segments) * segments;
+            assert!(
+                total <= budget,
+                "{segments} segments used {total} bytes against a {budget} budget"
+            );
+        }
+
+        // Past the floor the total grows again, but 64x slower than a fixed
+        // per-segment buffer would. This is the Linux 1 MiB case.
+        let segments = 1946;
+        let total = segment_buffer_bytes(1024 * 1024, segments) * segments;
+        assert_eq!(
+            segment_buffer_bytes(1024 * 1024, segments),
+            MIN_SEGMENT_BUFFER_BYTES
+        );
+        assert!(
+            total < 8 * 1024 * 1024,
+            "floor regime should stay small, got {total}"
+        );
+    }
+
+    /// The merge must stay correct when read buffers are squeezed to the floor
+    /// across many segments.
+    #[test]
+    fn merge_is_correct_with_minimal_read_buffers() {
+        let dir = tempfile::tempdir().unwrap();
+        // Budget of 1 byte floors the arena at 1024 entries, forcing many spills.
+        let mut sorter = ExternalSorter::new(dir.path(), 1);
+        for trigram in 0..6_000u32 {
+            sorter
+                .push(TrigramPosting {
+                    trigram,
+                    entry: PostingEntry {
+                        file_id: trigram / 4,
+                        loc_mask: 1,
+                        next_mask: 2,
+                    },
+                })
+                .unwrap();
+        }
+        assert!(sorter.spilled_segments() > 1);
+
+        let (trigrams, merged) = sorter.write_postings(dir.path()).unwrap();
+        assert_eq!(trigrams, 6_000);
+        assert!(merged > 1, "expected a real merge, got {merged} segment(s)");
+
+        // files.bin/meta.json are written by the builder; synthesize the
+        // minimum the reader needs to resolve posting lists.
+        let file_count = 6_000u32 / 4;
+        let mut files = Vec::new();
+        for id in 0..file_count {
+            ondisk::write_file_entry(&mut files, id, &format!("f{id}.txt")).unwrap();
+        }
+        std::fs::write(dir.path().join("files.bin"), files).unwrap();
+        crate::meta::IndexMeta::new("/tmp/root", file_count as u64, trigrams as u64)
+            .save(dir.path())
+            .unwrap();
+
+        let reader = IndexReader::open(dir.path()).unwrap();
+        for trigram in 0..6_000u32 {
+            assert_eq!(
+                reader.lookup_trigram(trigram),
+                vec![trigram / 4],
+                "postings mismatch for trigram {trigram}"
+            );
+        }
     }
 }

--- a/tgrep-core/src/external.rs
+++ b/tgrep-core/src/external.rs
@@ -699,9 +699,8 @@ mod tests {
         let postings: Vec<TrigramPosting> = (0..400u32)
             .flat_map(|file_id| (0..64u32).map(move |t| posting(t * 3, file_id)))
             .collect();
-        let mut sorter = ExternalSorter::new(Path::new("."), 1);
+        let sorter = ExternalSorter::new(Path::new("."), 1);
         assert_eq!(sorter.capacity, 1024, "budget should clamp to a floor");
-        sorter.arena = Vec::new();
 
         assert_paths_match(&postings, 1);
     }

--- a/tgrep-core/src/external.rs
+++ b/tgrep-core/src/external.rs
@@ -1,0 +1,738 @@
+//! External merge sort for bootstrap index construction.
+//!
+//! The default in-memory builder accumulates one [`TrigramPosting`] (12 bytes)
+//! for every (trigram, file) pair in the repository, then sorts the whole thing
+//! at once. That vector is unbounded: a monorepo with ~500K files averaging a
+//! few thousand distinct trigrams each needs well over 10 GB of heap before the
+//! first byte is written.
+//!
+//! This module bounds peak heap to a fixed arena instead:
+//!
+//! 1. Postings accumulate in an arena sized by a byte budget.
+//! 2. When the arena fills it is sorted, delta+varint encoded, and spilled to a
+//!    segment file on disk; the arena's allocation is then reused.
+//! 3. [`ExternalSorter::write_postings`] streams a k-way merge of the segments
+//!    straight into `index.bin` / `lookup.bin`.
+//!
+//! Peak heap is `arena + segments * SEGMENT_BUFFER_BYTES + largest posting
+//! list`, independent of repository size.
+//!
+//! Total sort work is unchanged: `k` sorts of `n/k` elements plus an `n·log k`
+//! merge is still `O(n·log n)`, with better cache locality per sort. The added
+//! cost is one spill write plus one merge read, and the segment encoding
+//! roughly halves those bytes relative to the 6-byte on-disk posting layout.
+//!
+//! If the arena never fills — small and mid-size repositories — nothing is
+//! spilled and `write_postings` degrades to exactly the in-memory path: one
+//! sort followed by one streaming write.
+
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::ondisk::{self, LookupEntry, PostingEntry};
+use crate::{Error, Result};
+
+/// A single (trigram, posting) pair prior to grouping.
+#[derive(Clone, Copy)]
+pub(crate) struct TrigramPosting {
+    pub trigram: u32,
+    pub entry: PostingEntry,
+}
+
+/// Default arena budget before spilling. Chosen so a spill segment is large
+/// enough to amortize sequential write cost while keeping the merge fan-in
+/// modest even for very large repositories.
+pub const DEFAULT_BUFFER_BYTES: usize = 64 * 1024 * 1024;
+
+/// Read-ahead buffer held per open segment during the merge.
+const SEGMENT_BUFFER_BYTES: usize = 256 * 1024;
+
+/// Longest possible LEB128 encoding of a `u64`.
+const MAX_VARINT_LEN: usize = 10;
+
+const POSTING_WRITE_CHUNK_ENTRIES: usize = 8192;
+const LOOKUP_WRITE_CHUNK_ENTRIES: usize = 4096;
+
+/// Flush threshold for the encode scratch buffer while spilling a segment.
+const SPILL_SCRATCH_FLUSH_BYTES: usize = 128 * 1024;
+
+fn write_varint(buf: &mut Vec<u8>, mut value: u64) {
+    while value >= 0x80 {
+        buf.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    buf.push(value as u8);
+}
+
+/// Temporary directory holding spill segments, removed on drop.
+///
+/// Segments are written next to the index rather than under the system temp
+/// directory: they can total gigabytes for a large repository, and `TEMP` is
+/// frequently on a smaller (or differently quota'd) volume than the workspace.
+struct SpillDir {
+    path: PathBuf,
+}
+
+impl SpillDir {
+    fn create(index_dir: &Path) -> Result<Self> {
+        let path = index_dir.join(format!("spill-{}.tmp", std::process::id()));
+        // A leftover directory from a killed build would make stale segments
+        // visible to this run's merge, silently corrupting the index.
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for SpillDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Accumulates postings, spilling sorted segments to disk when the arena fills.
+pub(crate) struct ExternalSorter {
+    arena: Vec<TrigramPosting>,
+    /// Arena length that triggers a spill.
+    capacity: usize,
+    spill: Option<SpillDir>,
+    segments: Vec<PathBuf>,
+    index_dir: PathBuf,
+    scratch: Vec<u8>,
+}
+
+impl ExternalSorter {
+    /// Create a sorter that keeps at most `budget_bytes` of postings in heap.
+    pub(crate) fn new(index_dir: &Path, budget_bytes: usize) -> Self {
+        let entry_size = std::mem::size_of::<TrigramPosting>();
+        // Always allow at least a small arena so a pathological budget can't
+        // produce a zero-capacity arena that spills on every single posting.
+        let capacity = (budget_bytes / entry_size).max(1024);
+        Self {
+            arena: Vec::new(),
+            capacity,
+            spill: None,
+            segments: Vec::new(),
+            index_dir: index_dir.to_path_buf(),
+            scratch: Vec::new(),
+        }
+    }
+
+    /// Number of segments spilled so far, excluding the arena tail that
+    /// `write_postings` spills last. Callers that want the merged total should
+    /// use the count returned by `write_postings`.
+    #[cfg(test)]
+    pub(crate) fn spilled_segments(&self) -> usize {
+        self.segments.len()
+    }
+
+    /// Append one posting, spilling first if the arena is full.
+    pub(crate) fn push(&mut self, posting: TrigramPosting) -> Result<()> {
+        if self.arena.len() >= self.capacity {
+            self.spill_arena()?;
+        }
+        self.arena.push(posting);
+        Ok(())
+    }
+
+    /// Append every posting a file contributed.
+    pub(crate) fn push_file<I>(&mut self, file_id: u32, per_trigram: I) -> Result<()>
+    where
+        I: IntoIterator<Item = (u32, crate::trigram::TrigramMasks)>,
+    {
+        for (trigram, masks) in per_trigram {
+            self.push(TrigramPosting {
+                trigram,
+                entry: PostingEntry {
+                    file_id,
+                    loc_mask: masks.loc_mask,
+                    next_mask: masks.next_mask,
+                },
+            })?;
+        }
+        Ok(())
+    }
+
+    fn sort_arena(&mut self) {
+        self.arena.sort_unstable_by(|a, b| {
+            a.trigram
+                .cmp(&b.trigram)
+                .then_with(|| a.entry.file_id.cmp(&b.entry.file_id))
+        });
+    }
+
+    /// Sort the arena and write it out as a compact segment, then clear it.
+    ///
+    /// The arena's backing allocation is deliberately retained (`clear`, not
+    /// `drop`) so steady-state indexing performs no further large allocations.
+    fn spill_arena(&mut self) -> Result<()> {
+        if self.arena.is_empty() {
+            return Ok(());
+        }
+        self.sort_arena();
+
+        let spill = match &self.spill {
+            Some(dir) => dir,
+            None => {
+                self.spill = Some(SpillDir::create(&self.index_dir)?);
+                self.spill.as_ref().unwrap()
+            }
+        };
+        let path = spill
+            .path
+            .join(format!("seg-{:05}.bin", self.segments.len()));
+        let mut writer = BufWriter::with_capacity(SEGMENT_BUFFER_BYTES, File::create(&path)?);
+
+        // Segment layout, groups ordered by ascending trigram:
+        //   varint(trigram - prev_trigram)
+        //   varint(posting_count)
+        //   posting_count x { varint(file_id - prev_file_id), loc_mask, next_mask }
+        // Both deltas are non-negative because the arena is sorted by
+        // (trigram, file_id), which makes the encoding substantially smaller
+        // than the 6-byte fixed on-disk posting record.
+        let scratch = &mut self.scratch;
+        scratch.clear();
+        let mut prev_trigram: u32 = 0;
+        let mut idx = 0usize;
+        while idx < self.arena.len() {
+            let trigram = self.arena[idx].trigram;
+            let mut end = idx + 1;
+            while end < self.arena.len() && self.arena[end].trigram == trigram {
+                end += 1;
+            }
+
+            write_varint(scratch, (trigram - prev_trigram) as u64);
+            write_varint(scratch, (end - idx) as u64);
+            prev_trigram = trigram;
+
+            let mut prev_file_id: u32 = 0;
+            for posting in &self.arena[idx..end] {
+                let entry = posting.entry;
+                write_varint(scratch, (entry.file_id - prev_file_id) as u64);
+                scratch.push(entry.loc_mask);
+                scratch.push(entry.next_mask);
+                prev_file_id = entry.file_id;
+            }
+
+            if scratch.len() >= SPILL_SCRATCH_FLUSH_BYTES {
+                writer.write_all(scratch)?;
+                scratch.clear();
+            }
+            idx = end;
+        }
+        if !scratch.is_empty() {
+            writer.write_all(scratch)?;
+            scratch.clear();
+        }
+        writer.flush()?;
+        // Release the encode buffer's capacity — it is only needed during a
+        // spill and holding it would count against the caller's budget.
+        self.scratch = Vec::new();
+
+        self.segments.push(path);
+        self.arena.clear();
+        Ok(())
+    }
+
+    /// Write `index.bin` and `lookup.bin`.
+    ///
+    /// Returns `(distinct trigram count, spill segments merged)`. Consumes the
+    /// sorter so the arena and every spill segment are released before the
+    /// caller proceeds.
+    pub(crate) fn write_postings(mut self, index_dir: &Path) -> Result<(usize, usize)> {
+        if self.segments.is_empty() {
+            // Never exceeded the budget: identical to the in-memory path.
+            self.sort_arena();
+            let arena = std::mem::take(&mut self.arena);
+            return Ok((write_sorted_arena(index_dir, &arena)?, 0));
+        }
+
+        // Fold the tail into a final segment so the merge has a single
+        // uniform input kind.
+        self.spill_arena()?;
+        self.arena = Vec::new();
+
+        let segments = self.segments.len();
+        eprintln!("Merging {segments} spill segment(s) into the index...");
+        Ok((merge_segments(index_dir, &self.segments)?, segments))
+    }
+}
+
+/// Shared writer for `index.bin` + `lookup.bin`.
+struct IndexWriter {
+    postings: BufWriter<File>,
+    lookup: BufWriter<File>,
+    posting_scratch: Vec<u8>,
+    lookup_scratch: Vec<u8>,
+    offset: u64,
+    trigram_count: usize,
+}
+
+impl IndexWriter {
+    fn create(index_dir: &Path) -> Result<Self> {
+        std::fs::create_dir_all(index_dir)?;
+        Ok(Self {
+            postings: BufWriter::new(File::create(index_dir.join("index.bin"))?),
+            lookup: BufWriter::new(File::create(index_dir.join("lookup.bin"))?),
+            posting_scratch: Vec::with_capacity(
+                POSTING_WRITE_CHUNK_ENTRIES * ondisk::POSTING_ENTRY_SIZE,
+            ),
+            lookup_scratch: Vec::with_capacity(
+                LOOKUP_WRITE_CHUNK_ENTRIES * ondisk::LOOKUP_ENTRY_SIZE,
+            ),
+            offset: 0,
+            trigram_count: 0,
+        })
+    }
+
+    /// Write one trigram's complete, file-id-sorted posting list.
+    fn write_group(&mut self, trigram: u32, entries: &[PostingEntry]) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let length = u32::try_from(entries.len()).map_err(|_| {
+            Error::IndexCorrupted(format!(
+                "posting list for trigram {trigram} exceeds the u32 length limit"
+            ))
+        })?;
+
+        if self.lookup_scratch.len() == self.lookup_scratch.capacity() {
+            self.lookup.write_all(&self.lookup_scratch)?;
+            self.lookup_scratch.clear();
+        }
+        let lookup_entry = LookupEntry {
+            trigram,
+            offset: self.offset,
+            length,
+        };
+        self.lookup_scratch
+            .extend_from_slice(&lookup_entry.trigram.to_le_bytes());
+        self.lookup_scratch
+            .extend_from_slice(&lookup_entry.offset.to_le_bytes());
+        self.lookup_scratch
+            .extend_from_slice(&lookup_entry.length.to_le_bytes());
+
+        for chunk in entries.chunks(POSTING_WRITE_CHUNK_ENTRIES) {
+            self.posting_scratch.clear();
+            for entry in chunk {
+                self.posting_scratch
+                    .extend_from_slice(&entry.file_id.to_le_bytes());
+                self.posting_scratch.push(entry.loc_mask);
+                self.posting_scratch.push(entry.next_mask);
+            }
+            self.postings.write_all(&self.posting_scratch)?;
+        }
+
+        self.offset += length as u64 * ondisk::POSTING_ENTRY_SIZE as u64;
+        self.trigram_count += 1;
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<usize> {
+        if !self.lookup_scratch.is_empty() {
+            self.lookup.write_all(&self.lookup_scratch)?;
+            self.lookup_scratch.clear();
+        }
+        self.postings.flush()?;
+        self.lookup.flush()?;
+        Ok(self.trigram_count)
+    }
+}
+
+/// Write an already-sorted arena directly, without any spill round trip.
+fn write_sorted_arena(index_dir: &Path, arena: &[TrigramPosting]) -> Result<usize> {
+    let mut writer = IndexWriter::create(index_dir)?;
+    let mut group: Vec<PostingEntry> = Vec::new();
+    let mut idx = 0usize;
+    while idx < arena.len() {
+        let trigram = arena[idx].trigram;
+        let mut end = idx + 1;
+        while end < arena.len() && arena[end].trigram == trigram {
+            end += 1;
+        }
+        group.clear();
+        group.extend(arena[idx..end].iter().map(|p| p.entry));
+        writer.write_group(trigram, &group)?;
+        idx = end;
+    }
+    writer.finish()
+}
+
+/// Buffered byte reader with a sliding window, used to decode segments.
+struct ByteSource {
+    file: File,
+    buf: Vec<u8>,
+    pos: usize,
+    filled: usize,
+}
+
+impl ByteSource {
+    fn open(path: &Path) -> Result<Self> {
+        Ok(Self {
+            file: File::open(path)?,
+            buf: vec![0u8; SEGMENT_BUFFER_BYTES],
+            pos: 0,
+            filled: 0,
+        })
+    }
+
+    /// Make at least `want` bytes available if the file still has them.
+    /// Returns the number actually available, which is short only at EOF.
+    fn ensure(&mut self, want: usize) -> Result<usize> {
+        debug_assert!(want <= SEGMENT_BUFFER_BYTES);
+        if self.filled - self.pos >= want {
+            return Ok(self.filled - self.pos);
+        }
+        self.buf.copy_within(self.pos..self.filled, 0);
+        self.filled -= self.pos;
+        self.pos = 0;
+        while self.filled < want {
+            let read = self.file.read(&mut self.buf[self.filled..])?;
+            if read == 0 {
+                break;
+            }
+            self.filled += read;
+        }
+        Ok(self.filled)
+    }
+
+    /// Decode one varint. `Ok(None)` means a clean end of segment.
+    fn read_varint(&mut self) -> Result<Option<u64>> {
+        if self.ensure(MAX_VARINT_LEN)? == 0 {
+            return Ok(None);
+        }
+        let mut value = 0u64;
+        let mut shift = 0u32;
+        loop {
+            if self.pos >= self.filled {
+                return Err(Error::IndexCorrupted(
+                    "spill segment truncated mid-varint".into(),
+                ));
+            }
+            let byte = self.buf[self.pos];
+            self.pos += 1;
+            value |= u64::from(byte & 0x7F) << shift;
+            if byte & 0x80 == 0 {
+                return Ok(Some(value));
+            }
+            shift += 7;
+            if shift >= 64 {
+                return Err(Error::IndexCorrupted(
+                    "spill segment contains an overlong varint".into(),
+                ));
+            }
+        }
+    }
+
+    fn read_u8(&mut self) -> Result<u8> {
+        if self.ensure(1)? == 0 {
+            return Err(Error::IndexCorrupted(
+                "spill segment truncated mid-posting".into(),
+            ));
+        }
+        let byte = self.buf[self.pos];
+        self.pos += 1;
+        Ok(byte)
+    }
+}
+
+/// Streaming cursor over one spill segment.
+struct SegmentCursor {
+    src: ByteSource,
+    prev_trigram: u32,
+    /// Postings remaining in the group whose header has been read.
+    pending_count: usize,
+}
+
+impl SegmentCursor {
+    fn open(path: &Path) -> Result<Self> {
+        Ok(Self {
+            src: ByteSource::open(path)?,
+            prev_trigram: 0,
+            pending_count: 0,
+        })
+    }
+
+    /// Read the next group header. `Ok(None)` means the segment is exhausted.
+    fn advance(&mut self) -> Result<Option<u32>> {
+        let Some(delta) = self.src.read_varint()? else {
+            return Ok(None);
+        };
+        let trigram = u32::try_from(u64::from(self.prev_trigram) + delta)
+            .map_err(|_| Error::IndexCorrupted("spill segment trigram delta overflow".into()))?;
+        let count = self
+            .src
+            .read_varint()?
+            .ok_or_else(|| Error::IndexCorrupted("spill segment missing group count".into()))?;
+        self.prev_trigram = trigram;
+        self.pending_count = usize::try_from(count)
+            .map_err(|_| Error::IndexCorrupted("spill segment group count overflow".into()))?;
+        Ok(Some(trigram))
+    }
+
+    /// Decode the pending group's postings, appending them to `out`.
+    fn take_group(&mut self, out: &mut Vec<PostingEntry>) -> Result<()> {
+        let mut prev_file_id: u32 = 0;
+        for _ in 0..self.pending_count {
+            let delta = self
+                .src
+                .read_varint()?
+                .ok_or_else(|| Error::IndexCorrupted("spill segment truncated in group".into()))?;
+            let file_id = u32::try_from(u64::from(prev_file_id) + delta)
+                .map_err(|_| Error::IndexCorrupted("spill segment file id overflow".into()))?;
+            let loc_mask = self.src.read_u8()?;
+            let next_mask = self.src.read_u8()?;
+            out.push(PostingEntry {
+                file_id,
+                loc_mask,
+                next_mask,
+            });
+            prev_file_id = file_id;
+        }
+        self.pending_count = 0;
+        Ok(())
+    }
+}
+
+/// k-way merge of sorted segments into `index.bin` / `lookup.bin`.
+fn merge_segments(index_dir: &Path, segments: &[PathBuf]) -> Result<usize> {
+    let mut cursors: Vec<SegmentCursor> = Vec::with_capacity(segments.len());
+    // Min-heap keyed by (trigram, segment index). Ordering by segment index as
+    // the tiebreak matters: file IDs are assigned in walk order and segments
+    // are spilled in that same order, so visiting a trigram's groups in
+    // ascending segment order yields globally ascending file IDs and the
+    // concatenation below needs no re-sort.
+    let mut heap: BinaryHeap<Reverse<(u32, usize)>> = BinaryHeap::with_capacity(segments.len());
+
+    for (idx, path) in segments.iter().enumerate() {
+        let mut cursor = SegmentCursor::open(path)?;
+        if let Some(trigram) = cursor.advance()? {
+            heap.push(Reverse((trigram, idx)));
+        }
+        cursors.push(cursor);
+    }
+
+    let mut writer = IndexWriter::create(index_dir)?;
+    let mut group: Vec<PostingEntry> = Vec::new();
+
+    while let Some(&Reverse((trigram, _))) = heap.peek() {
+        group.clear();
+        let mut needs_sort = false;
+        let mut last_file_id: Option<u32> = None;
+
+        while let Some(&Reverse((next_trigram, idx))) = heap.peek() {
+            if next_trigram != trigram {
+                break;
+            }
+            heap.pop();
+
+            let before = group.len();
+            cursors[idx].take_group(&mut group)?;
+            // Defensive: if the append-in-segment-order invariant is ever
+            // broken (e.g. a caller assigns file IDs out of walk order), fall
+            // back to sorting rather than emitting an unsorted posting list,
+            // which query execution assumes is ascending.
+            if let Some(last) = last_file_id
+                && group.get(before).is_some_and(|first| first.file_id <= last)
+            {
+                needs_sort = true;
+            }
+            last_file_id = group.last().map(|entry| entry.file_id);
+
+            if let Some(next) = cursors[idx].advance()? {
+                heap.push(Reverse((next, idx)));
+            }
+        }
+
+        if needs_sort {
+            group.sort_unstable_by_key(|entry| entry.file_id);
+        }
+        writer.write_group(trigram, &group)?;
+    }
+
+    writer.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::IndexReader;
+
+    fn posting(trigram: u32, file_id: u32) -> TrigramPosting {
+        TrigramPosting {
+            trigram,
+            entry: PostingEntry {
+                file_id,
+                loc_mask: (file_id as u8) | 1,
+                next_mask: (trigram as u8) | 1,
+            },
+        }
+    }
+
+    /// Build both ways and assert the resulting index files are byte-identical.
+    fn assert_paths_match(postings: &[TrigramPosting], budget_bytes: usize) {
+        let in_memory = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+
+        let mut direct: Vec<TrigramPosting> = postings.to_vec();
+        direct.sort_unstable_by(|a, b| {
+            a.trigram
+                .cmp(&b.trigram)
+                .then_with(|| a.entry.file_id.cmp(&b.entry.file_id))
+        });
+        let expected_trigrams = write_sorted_arena(in_memory.path(), &direct).unwrap();
+
+        let mut sorter = ExternalSorter::new(external.path(), budget_bytes);
+        for posting in postings {
+            sorter.push(*posting).unwrap();
+        }
+        let spilled = sorter.spilled_segments();
+        let (actual_trigrams, merged_segments) = sorter.write_postings(external.path()).unwrap();
+
+        assert_eq!(expected_trigrams, actual_trigrams, "trigram count mismatch");
+        assert!(
+            merged_segments == 0 || merged_segments > spilled,
+            "the arena tail should be folded into a final segment"
+        );
+        for name in ["index.bin", "lookup.bin"] {
+            let a = std::fs::read(in_memory.path().join(name)).unwrap();
+            let b = std::fs::read(external.path().join(name)).unwrap();
+            assert_eq!(a, b, "{name} differs (spilled {spilled} segment(s))");
+        }
+    }
+
+    #[test]
+    fn external_matches_in_memory_without_spilling() {
+        let postings: Vec<TrigramPosting> = (0..64u32)
+            .flat_map(|file_id| (0..32u32).map(move |t| posting(t * 7 + 1, file_id)))
+            .collect();
+        assert_paths_match(&postings, DEFAULT_BUFFER_BYTES);
+    }
+
+    #[test]
+    fn external_matches_in_memory_across_many_spills() {
+        // A tiny budget still clamps to a 1024-entry arena, so use enough
+        // postings to force a double-digit number of segments.
+        let postings: Vec<TrigramPosting> = (0..400u32)
+            .flat_map(|file_id| (0..64u32).map(move |t| posting(t * 3, file_id)))
+            .collect();
+        let mut sorter = ExternalSorter::new(Path::new("."), 1);
+        assert_eq!(sorter.capacity, 1024, "budget should clamp to a floor");
+        sorter.arena = Vec::new();
+
+        assert_paths_match(&postings, 1);
+    }
+
+    #[test]
+    fn spilling_actually_happens_under_a_small_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut sorter = ExternalSorter::new(dir.path(), 1);
+        for file_id in 0..50u32 {
+            for t in 0..500u32 {
+                sorter.push(posting(t, file_id)).unwrap();
+            }
+        }
+        assert!(
+            sorter.spilled_segments() >= 20,
+            "expected many segments, got {}",
+            sorter.spilled_segments()
+        );
+        sorter.write_postings(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn spill_directory_is_removed_after_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut sorter = ExternalSorter::new(dir.path(), 1);
+        for file_id in 0..20u32 {
+            for t in 0..500u32 {
+                sorter.push(posting(t, file_id)).unwrap();
+            }
+        }
+        assert!(sorter.spilled_segments() > 0);
+        sorter.write_postings(dir.path()).unwrap();
+
+        let leftover: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with("spill-"))
+            .collect();
+        assert!(leftover.is_empty(), "spill directory should be cleaned up");
+    }
+
+    #[test]
+    fn merged_posting_lists_are_readable_and_sorted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut sorter = ExternalSorter::new(dir.path(), 1);
+        // Interleave so each trigram's postings land across many segments.
+        for file_id in 0..300u32 {
+            for t in 0..40u32 {
+                sorter.push(posting(t, file_id)).unwrap();
+            }
+        }
+        assert!(sorter.spilled_segments() > 1);
+        let (trigram_count, _) = sorter.write_postings(dir.path()).unwrap();
+        assert_eq!(trigram_count, 40);
+
+        // files.bin/meta.json are written by the builder; synthesize the
+        // minimum the reader needs to resolve posting lists.
+        let mut files = Vec::new();
+        for id in 0..300u32 {
+            ondisk::write_file_entry(&mut files, id, &format!("f{id}.txt")).unwrap();
+        }
+        std::fs::write(dir.path().join("files.bin"), files).unwrap();
+        crate::meta::IndexMeta::new("/tmp/root", 300, trigram_count as u64)
+            .save(dir.path())
+            .unwrap();
+
+        let reader = IndexReader::open(dir.path()).unwrap();
+        for t in 0..40u32 {
+            let entries = reader.lookup_trigram_with_masks(t);
+            assert_eq!(entries.len(), 300, "trigram {t} should list every file");
+            let ids: Vec<u32> = entries.iter().map(|e| e.file_id).collect();
+            let mut sorted = ids.clone();
+            sorted.sort_unstable();
+            assert_eq!(ids, sorted, "posting list for {t} must be file-id sorted");
+            for entry in &entries {
+                assert_eq!(entry.loc_mask, (entry.file_id as u8) | 1);
+                assert_eq!(entry.next_mask, (t as u8) | 1);
+            }
+        }
+    }
+
+    #[test]
+    fn empty_input_writes_an_empty_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let sorter = ExternalSorter::new(dir.path(), DEFAULT_BUFFER_BYTES);
+        assert_eq!(sorter.write_postings(dir.path()).unwrap(), (0, 0));
+        assert_eq!(
+            std::fs::read(dir.path().join("index.bin")).unwrap().len(),
+            0
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("lookup.bin")).unwrap().len(),
+            0
+        );
+    }
+
+    #[test]
+    fn varint_roundtrip_covers_boundaries() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("v.bin");
+        let values = [0u64, 1, 127, 128, 300, 16_383, 16_384, u32::MAX as u64];
+        let mut buf = Vec::new();
+        for &v in &values {
+            write_varint(&mut buf, v);
+        }
+        std::fs::write(&path, &buf).unwrap();
+
+        let mut src = ByteSource::open(&path).unwrap();
+        for &v in &values {
+            assert_eq!(src.read_varint().unwrap(), Some(v));
+        }
+        assert_eq!(src.read_varint().unwrap(), None);
+    }
+}

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -214,6 +214,11 @@ pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
 
 /// Build an [`IgnoreMatcher`] from already-discovered `.gitignore` paths.
 ///
+/// `gitignore_files` must be **absolute** paths under `root` — that is what
+/// `walker::walk_dir` yields. Each nested file is anchored by stripping `root`
+/// from its parent directory, so repo-relative paths would leave every nested
+/// rule out of the matcher.
+///
 /// Root-level rules (`.git/info/exclude`, `p4ignore.ini`, and a `.gitignore`
 /// directly in `root`) share the root matcher. Every deeper `.gitignore` gets
 /// its own matcher anchored at its directory, because its patterns are written
@@ -238,9 +243,17 @@ pub fn matcher_from_gitignore_paths(
         }
         let dir = path.parent().unwrap_or(root);
         // A path we can't place relative to the root has unknown scope, and
-        // guessing is what broke this before. Walk results always strip
-        // cleanly, so this only skips genuinely malformed input.
+        // guessing is what broke this before. Skipping it only under-ignores,
+        // which is the safe direction, but it is still silent — so make it
+        // loud in debug builds rather than quietly dropping nested rules.
         let Ok(rel_dir) = dir.strip_prefix(root) else {
+            debug_assert!(
+                false,
+                "gitignore path {} is not under root {}; \
+                 pass absolute paths from the walk, not repo-relative ones",
+                path.display(),
+                root.display()
+            );
             continue;
         };
         let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
@@ -439,6 +452,32 @@ mod tests {
 
         // Root rules keep applying tree-wide.
         assert!(matcher.is_ignored(Path::new("kernel/sched/core.o"), false));
+    }
+
+    /// The contract is "absolute paths from the walk". Passing repo-relative
+    /// ones would silently drop every nested rule, so the guard must fire.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "not under root")]
+    fn relative_gitignore_paths_trip_the_debug_guard() {
+        let tmp = TempDir::new().unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join(".gitignore"), "*.log\n").unwrap();
+
+        let cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+        let result = std::panic::catch_unwind(|| {
+            matcher_from_gitignore_paths(
+                Path::new("."),
+                &[std::path::PathBuf::from("sub/.gitignore")],
+            )
+        });
+        std::env::set_current_dir(cwd).unwrap();
+
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
     }
 
     #[test]

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -18,17 +18,91 @@ use ignore::Match;
 /// matcher without taking a direct dependency on the `ignore` crate.
 pub use ignore::gitignore::Gitignore;
 
+/// A `.gitignore` found below the repository root, kept anchored to its own
+/// directory rather than folded into the root matcher.
+struct NestedIgnore {
+    /// Directory holding the `.gitignore`, relative to the repo root,
+    /// `/`-separated with no trailing slash.
+    dir: String,
+    matcher: Gitignore,
+}
+
 pub struct IgnoreMatcher {
+    /// Root-scoped rules: the root `.gitignore`, `.git/info/exclude`, and
+    /// `p4ignore.ini`.
     local: Gitignore,
+    /// Nested `.gitignore` files, deepest first.
+    nested: Vec<NestedIgnore>,
     global: Gitignore,
 }
 
 impl IgnoreMatcher {
     pub fn new(local: Gitignore, global: Gitignore) -> Option<Self> {
-        (!local.is_empty() || !global.is_empty()).then_some(Self { local, global })
+        Self::with_nested(local, Vec::new(), global)
+    }
+
+    /// Build a matcher from root-scoped rules plus `.gitignore` files found
+    /// in subdirectories, each paired with its directory relative to the repo
+    /// root.
+    ///
+    /// Nested files **must** stay anchored to their own directory. Folding
+    /// them into one root-scoped matcher silently changes what they mean: the
+    /// Linux kernel has four `tools/testing/selftests/*/.gitignore` files
+    /// containing a bare `*`, which is "ignore everything beside me" in place
+    /// but becomes "ignore the entire repository" at the root. That made the
+    /// file watcher treat `README` and `kernel/sched/core.c` as ignored and
+    /// silently drop every event.
+    pub fn with_nested(
+        local: Gitignore,
+        nested: Vec<(String, Gitignore)>,
+        global: Gitignore,
+    ) -> Option<Self> {
+        let mut nested: Vec<NestedIgnore> = nested
+            .into_iter()
+            .filter(|(_, matcher)| !matcher.is_empty())
+            .map(|(dir, matcher)| NestedIgnore {
+                dir: dir.trim_matches('/').to_string(),
+                matcher,
+            })
+            .collect();
+        // Deepest first, so the innermost `.gitignore` decides — that is the
+        // precedence git applies between levels.
+        nested.sort_by(|a, b| {
+            b.dir
+                .matches('/')
+                .count()
+                .cmp(&a.dir.matches('/').count())
+                .then_with(|| b.dir.len().cmp(&a.dir.len()))
+        });
+
+        (!local.is_empty() || !nested.is_empty() || !global.is_empty()).then_some(Self {
+            local,
+            nested,
+            global,
+        })
     }
 
     pub fn is_ignored(&self, path: &Path, is_dir: bool) -> bool {
+        let rel = path.to_string_lossy().replace('\\', "/");
+        let rel = rel.trim_start_matches("./").trim_start_matches('/');
+
+        for entry in &self.nested {
+            // Only consult a nested file for paths beneath its directory, and
+            // match against the path *relative to that directory*, which is
+            // the scope its patterns were written for.
+            let Some(under) = strip_dir_prefix(rel, &entry.dir) else {
+                continue;
+            };
+            match entry
+                .matcher
+                .matched_path_or_any_parents(Path::new(under), is_dir)
+            {
+                Match::Ignore(_) => return true,
+                Match::Whitelist(_) => return false,
+                Match::None => {}
+            }
+        }
+
         match self.local.matched_path_or_any_parents(path, is_dir) {
             Match::Ignore(_) => true,
             Match::Whitelist(_) => false,
@@ -38,6 +112,16 @@ impl IgnoreMatcher {
                 .is_ignore(),
         }
     }
+}
+
+/// Return `rel` relative to `dir`, or `None` when `rel` is not beneath it.
+/// An empty `dir` means the repository root, which matches everything.
+fn strip_dir_prefix<'a>(rel: &'a str, dir: &str) -> Option<&'a str> {
+    if dir.is_empty() {
+        return Some(rel);
+    }
+    let rest = rel.strip_prefix(dir)?;
+    rest.strip_prefix('/')
 }
 
 pub fn build_global_matcher(root: &Path) -> Gitignore {
@@ -128,6 +212,58 @@ pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
     })
 }
 
+/// Build an [`IgnoreMatcher`] from already-discovered `.gitignore` paths.
+///
+/// Root-level rules (`.git/info/exclude`, `p4ignore.ini`, and a `.gitignore`
+/// directly in `root`) share the root matcher. Every deeper `.gitignore` gets
+/// its own matcher anchored at its directory, because its patterns are written
+/// relative to that directory — see [`IgnoreMatcher::with_nested`].
+pub fn matcher_from_gitignore_paths(
+    root: &Path,
+    gitignore_files: &[std::path::PathBuf],
+) -> Option<IgnoreMatcher> {
+    use ignore::gitignore::GitignoreBuilder;
+
+    let mut root_builder = GitignoreBuilder::new(root);
+    let info_exclude = root.join(".git").join("info").join("exclude");
+    if info_exclude.is_file() {
+        let _ = root_builder.add(&info_exclude);
+    }
+    add_p4ignore_rules(&mut root_builder, root);
+
+    let mut nested: Vec<(String, Gitignore)> = Vec::new();
+    for path in gitignore_files {
+        if !path.is_file() {
+            continue;
+        }
+        let dir = path.parent().unwrap_or(root);
+        // A path we can't place relative to the root has unknown scope, and
+        // guessing is what broke this before. Walk results always strip
+        // cleanly, so this only skips genuinely malformed input.
+        let Ok(rel_dir) = dir.strip_prefix(root) else {
+            continue;
+        };
+        let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+        let rel_dir = rel_dir.trim_matches('/');
+
+        if rel_dir.is_empty() {
+            let _ = root_builder.add(path);
+            continue;
+        }
+
+        let mut builder = GitignoreBuilder::new(dir);
+        if builder.add(path).is_some() {
+            continue;
+        }
+        if let Ok(matcher) = builder.build() {
+            nested.push((rel_dir.to_string(), matcher));
+        }
+    }
+
+    let local = root_builder.build().ok()?;
+    IgnoreMatcher::with_nested(local, nested, build_global_matcher(root))
+}
+
 /// Build a `Gitignore` matcher rooted at `root`, mirroring the same
 /// ignore semantics that `walker::walk_dir` / `walker::walk_file_metadata`
 /// apply during iteration. Loads:
@@ -140,17 +276,8 @@ pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
 /// skip the `.git` dir and gitignored subtrees while collecting rules.
 /// Returns `None` when no rules could be loaded.
 pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
-    use ignore::gitignore::GitignoreBuilder;
-
-    let mut builder = GitignoreBuilder::new(root);
     let p4ignore = build_p4ignore_matcher(root).map(std::sync::Arc::new);
     let match_root = root.to_path_buf();
-
-    let info_exclude = root.join(".git").join("info").join("exclude");
-    if info_exclude.is_file() {
-        let _ = builder.add(&info_exclude);
-    }
-    add_p4ignore_rules(&mut builder, root);
 
     // Walk to find every `.gitignore` file. We can't use `hidden(true)`
     // because `.gitignore` itself starts with `.` and would be filtered.
@@ -191,14 +318,14 @@ pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
             )
         })
         .build();
+    let mut gitignore_files: Vec<std::path::PathBuf> = Vec::new();
     for entry in walker.flatten() {
         if entry.file_name() == ".gitignore" && entry.path().is_file() {
-            let _ = builder.add(entry.path());
+            gitignore_files.push(entry.path().to_path_buf());
         }
     }
 
-    let local = builder.build().ok()?;
-    IgnoreMatcher::new(local, build_global_matcher(root))
+    matcher_from_gitignore_paths(root, &gitignore_files)
 }
 
 #[cfg(test)]
@@ -269,5 +396,65 @@ mod tests {
         assert!(!matcher.is_ignored(Path::new("Build/XboxOne"), true));
         assert!(matcher.is_ignored(Path::new("Build/XboxOne/game.exe"), false));
         assert!(!matcher.is_ignored(Path::new("Build/XboxOne/game.template"), false));
+    }
+
+    /// Regression test for the bug that silently disabled the serve file
+    /// watcher on the Linux kernel tree.
+    ///
+    /// Four `tools/testing/selftests/*/.gitignore` files there contain a bare
+    /// `*`, and `arch/riscv/kernel/vdso_cfi/.gitignore` contains `*.c`. When
+    /// every `.gitignore` was folded into one root-anchored matcher, those
+    /// patterns applied tree-wide, so `README` and `kernel/sched/core.c` both
+    /// reported as ignored and the watcher dropped every event.
+    #[test]
+    fn nested_gitignore_rules_stay_scoped_to_their_directory() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let selftest = root.join("tools/testing/selftests/kvm");
+        std::fs::create_dir_all(&selftest).unwrap();
+        std::fs::write(selftest.join(".gitignore"), "*\n").unwrap();
+
+        let vdso = root.join("arch/riscv/kernel/vdso_cfi");
+        std::fs::create_dir_all(&vdso).unwrap();
+        std::fs::write(vdso.join(".gitignore"), "*.c\n").unwrap();
+
+        std::fs::create_dir_all(root.join("kernel/sched")).unwrap();
+        std::fs::write(root.join(".gitignore"), "*.o\n").unwrap();
+        std::fs::write(root.join("README"), "hello").unwrap();
+        std::fs::write(root.join("kernel/sched/core.c"), "int main;").unwrap();
+        std::fs::write(vdso.join("vgetrandom.c"), "int x;").unwrap();
+        std::fs::write(selftest.join("kvm_util.c"), "int y;").unwrap();
+
+        let matcher = build_matcher(root).expect("matcher should build");
+
+        // Ordinary source outside those directories stays visible.
+        assert!(!matcher.is_ignored(Path::new("README"), false));
+        assert!(!matcher.is_ignored(Path::new("kernel/sched/core.c"), false));
+        assert!(!matcher.is_ignored(Path::new("arch/riscv/kernel/vdso_cfi/vdso.lds"), false));
+
+        // The nested rules still apply where they were written.
+        assert!(matcher.is_ignored(Path::new("arch/riscv/kernel/vdso_cfi/vgetrandom.c"), false));
+        assert!(matcher.is_ignored(Path::new("tools/testing/selftests/kvm/kvm_util.c"), false));
+
+        // Root rules keep applying tree-wide.
+        assert!(matcher.is_ignored(Path::new("kernel/sched/core.o"), false));
+    }
+
+    #[test]
+    fn deeper_gitignore_negation_overrides_a_shallower_ignore() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let inner = root.join("build/keep");
+        std::fs::create_dir_all(&inner).unwrap();
+        std::fs::write(root.join("build/.gitignore"), "*.log\n").unwrap();
+        std::fs::write(inner.join(".gitignore"), "!important.log\n").unwrap();
+        std::fs::write(root.join("build/noisy.log"), "x").unwrap();
+        std::fs::write(inner.join("important.log"), "x").unwrap();
+
+        let matcher = build_matcher(root).expect("matcher should build");
+        assert!(matcher.is_ignored(Path::new("build/noisy.log"), false));
+        assert!(!matcher.is_ignored(Path::new("build/keep/important.log"), false));
     }
 }

--- a/tgrep-core/src/lib.rs
+++ b/tgrep-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod builder;
 pub mod error;
+pub(crate) mod external;
 pub mod filetypes;
 pub mod gitignore;
 pub mod hybrid;

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -195,24 +195,7 @@ pub fn build_gitignore_matcher_from_files(
     root: &Path,
     gitignore_files: &[PathBuf],
 ) -> Option<crate::gitignore::IgnoreMatcher> {
-    use ignore::gitignore::GitignoreBuilder;
-
-    let mut builder = GitignoreBuilder::new(root);
-
-    let info_exclude = root.join(".git").join("info").join("exclude");
-    if info_exclude.is_file() {
-        let _ = builder.add(&info_exclude);
-    }
-    crate::gitignore::add_p4ignore_rules(&mut builder, root);
-
-    for path in gitignore_files {
-        if path.is_file() {
-            let _ = builder.add(path);
-        }
-    }
-
-    let local = builder.build().ok()?;
-    crate::gitignore::IgnoreMatcher::new(local, crate::gitignore::build_global_matcher(root))
+    crate::gitignore::matcher_from_gitignore_paths(root, gitignore_files)
 }
 
 /// Filesystem metadata for a single file (no content read).


### PR DESCRIPTION
Bootstrap indexing held every posting in RAM and sorted once, so peak memory grew linearly with repository size and was unbounded. On the Linux kernel tree that meant **2.20–3.76 GiB** for a single build — enough to fail outright on a constrained machine.

This adds an external merge sort, makes it the default, and bumps the version to 1.0.1.

## Results

Measured on `C:\repos\linux` — 94,634 indexed files, 446,892 trigrams, 990 MiB index:

| Strategy | Spill segments | Peak working set | Build |
| --- | ---: | ---: | ---: |
| `external` (default, 64 MiB arena) | 31 | **160.1 MiB** | 22.6 s |
| `external --index-buffer 16` | 122 | 109.6 MiB | ~23 s |
| `external --index-buffer 1` | 1,946 | 98.9 MiB | ~29 s |
| `memory` | – | 2.20 – 3.76 GiB | 23 – 32 s |

**~17x less memory at no time cost.** In several runs external was measurably *faster* (22.6 s vs 31.6 s): sorting one ~2 GiB posting vector, plus the doubling reallocations that grow it, costs more than encoding and merging spill segments.

Worth noting the `memory` row is a *range spanning over a gigabyte across identical runs* — peak lands wherever the final realloc happens to fall, with both buffers briefly resident. External varied by 8 MiB. Bounded memory is also **predictable** memory, which matters more than the average when the question is whether a machine can finish the build at all.

## How it works

Postings fill a fixed-size arena that spills sorted, delta+varint encoded segments to disk when full; segments are then k-way merged straight into `index.bin` / `lookup.bin`.

```
Segment := Group*
Group   := varint(trigram - prev_trigram) varint(count) Posting{count}
Posting := varint(file_id - prev_file_id) u8(loc_mask) u8(next_mask)
```

The merge needs no per-trigram sort. File IDs are assigned monotonically in walk order and segments spill in that order, so segment *i* covers a contiguous ascending file-ID range; a heap keyed `(trigram, segment_index)` visits a trigram's groups in ascending segment order, making plain concatenation globally file-id-sorted. A defensive `needs_sort` fallback guards that invariant, since query execution requires ascending postings.

Spill files live at `<index-path>/spill-<pid>.tmp/` rather than system temp — segments can reach gigabytes and `TEMP` is often on a smaller volume. A `Drop` guard removes the directory on every path including errors, and a leftover directory from a killed build is cleared on create.

## Why this is the default now

Unbounded peak memory is the wrong default when the bounded path is free. Two defaults were flipped, and the second matters independently: `IndexStrategy::default()` in the library, because `handle_reload` rebuilds in-process **inside a running server**, which is the worst possible place for a multi-gigabyte spike.

If the arena never fills, nothing spills and the build takes exactly the in-memory path, so small and mid-size repos pay nothing.

`--index-strategy=memory` is retained deliberately, not as dead weight:
- it is the **reference implementation** the external path is differentially tested against — remove it and external can only be asserted against itself;
- it is an **escape hatch** for read-only or full index volumes, since external is the only path that touches disk;
- it isn't really removable anyway — when the arena never fills, external's fast path *is* the in-memory sort.

## A real bug this surfaced

The first implementation gave every open segment a fixed 256 KiB read buffer, making merge memory `segments × 256 KiB` — unbounded in fan-in. Because a smaller arena spills *more* segments, **asking for less memory delivered more of it**, and peak traced a U-shape:

| Arena | Segments | Peak, fixed buffers | Peak, shared budget |
| ---: | ---: | ---: | ---: |
| 16 MiB | 122 | 114.7 MiB | 109.6 MiB |
| 4 MiB | 487 | 195.8 MiB | 102.0 MiB |
| 1 MiB | 1,946 | 565.8 MiB | 98.9 MiB |

At a 1 MiB budget the read buffers alone were 486 MiB. Sizing them as `budget / segments` (clamped to `[4 KiB, 256 KiB]`) removes the U entirely and makes peak monotonic in the budget, which is the whole point of the knob.

This **only reproduces at real scale** — every synthetic fixture in the repo spills too few segments to reach the crossover, which is why it took the Linux tree to find.

## Also included

`tgrep index` now reports elapsed time and peak memory:

```
Index built successfully at /tmp/idx
Indexed in 22.6s using external strategy (peak memory 160.1 MiB)
```

Peak comes from the OS high-water mark rather than a polled sample, so it is exact and free to collect: `PeakWorkingSetSize` on Windows, `VmHWM` on Linux, `getrusage` on macOS. (`ru_maxrss` is bytes on macOS but *kilobytes* on Linux, hence `VmHWM` there — using it uniformly would under-report Linux by 1024x.)

## Verification

- **Byte-identical results.** 15 literal and regex queries over 190,000+ matches on the Linux tree matched the `memory` index exactly, including at 1,946-segment fan-in; re-verified after the default flip with 7 queries over 100,130 matches.
- **Self-reported peak validated against an external observer.** Polling `PeakWorkingSet64` from outside the process agreed exactly: 167.1 MiB vs 167.1 MiB, and 2.55 GiB vs 2613.6 MiB.
- **Incremental indexing is unaffected**, verified three ways rather than asserted: `--index-strategy` cannot reach the server (`handle_reload` uses the `build_index` wrapper; the watcher flush uses `append_overlay_to_index`, untouched); a new unit test appends an overlay onto an external-built base; and a live server test on an external-built index with 3 spill segments correctly picked up 5 adds, 1 modify, and 1 delete.
- 248 tests pass, `clippy -D warnings` and `fmt --check` clean, all with `--locked`.

Two testing notes for reviewers. Comparing two builds byte-for-byte is invalid — `walker::walk_dir` is a *parallel* walk into a `Mutex<Vec>`, so file IDs differ between runs; the tests compare an order-independent trigram→paths fingerprint instead. And the existing `build_index/5000` Criterion fixture repeats one line, giving only **67 distinct trigrams**, so it never spills — its "+0.8%" is a no-spill floor, not evidence about the merge path. A high-diversity fixture was added as the worst-case ceiling (+16%); real code sits around +9% at small scale and at parity on large repos.

## Version

Bumped to **1.0.1**. Both crates inherit `version.workspace`, so the workspace manifest is the only place changed; `Cargo.lock` is updated in the same commit because the release workflow builds with `--locked`.