### PR TITLE
Keep the watcher off the index until the gitignore matcher exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -335,9 +335,12 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         let stale_index_dir = index_dir.clone();
         thread::spawn(move || {
             // Publish the gitignore matcher *before* the stale check, not
-            // after. The watcher is already live by now and `indexing` is
-            // false on this path, so `gitignore_pending` is the only thing
-            // keeping it off the index while the matcher is missing.
+            // after. On this path `indexing` is false from the very first
+            // event, so `gitignore_pending` is the only thing keeping the
+            // watcher off the index while the matcher is missing. That gate
+            // is armed when `ServerState` is built — before this thread is
+            // spawned and before `start_file_watcher` runs below — so it
+            // holds whichever of the two wins the race.
             //
             // Doing this first also means the stale check that follows is
             // what recovers the events dropped during the gap: it compares

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -110,6 +110,16 @@ struct ServerState {
     /// from kicking off a redundant parallel snapshot while the bulk
     /// flush (or stale-refresh flush) is still executing.
     flushing: std::sync::atomic::AtomicBool,
+    /// True until the `.gitignore` matcher has been published for the first
+    /// time. The watcher must not touch the index while this is set: with no
+    /// matcher in place `should_skip_watcher_path` cannot apply gitignore
+    /// rules, so it would index build output the walk deliberately skipped.
+    ///
+    /// Only the *initial* publish is gated. Later rebuilds (an edited
+    /// `.gitignore`) swap the matcher atomically and leave the previous one
+    /// readable throughout, so events keep being filtered by slightly stale
+    /// but still valid rules rather than being dropped.
+    gitignore_pending: std::sync::atomic::AtomicBool,
     /// An ignore file changed during the initial build and requires a
     /// reconciliation after the build publishes.
     ignore_rules_dirty: std::sync::atomic::AtomicBool,
@@ -269,6 +279,9 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         watcher_active: std::sync::atomic::AtomicBool::new(false),
         indexing: std::sync::atomic::AtomicBool::new(needs_build),
         flushing: std::sync::atomic::AtomicBool::new(false),
+        // Only meaningful when the watcher runs with gitignore filtering
+        // enabled; otherwise there is no matcher to wait for.
+        gitignore_pending: std::sync::atomic::AtomicBool::new(!no_watch && !no_ignore),
         ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
         ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
         index_progress: std::sync::atomic::AtomicU64::new(0),
@@ -321,10 +334,19 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         let stale_root = root.clone();
         let stale_index_dir = index_dir.clone();
         thread::spawn(move || {
-            background_refresh_stale(&stale_state, &stale_root, &stale_index_dir, None);
+            // Publish the gitignore matcher *before* the stale check, not
+            // after. The watcher is already live by now and `indexing` is
+            // false on this path, so `gitignore_pending` is the only thing
+            // keeping it off the index while the matcher is missing.
+            //
+            // Doing this first also means the stale check that follows is
+            // what recovers the events dropped during the gap: it compares
+            // the whole tree against the index, so any edit that landed
+            // while the matcher was still building is picked up here.
             if stale_state.watch_enabled && !stale_state.no_ignore {
                 build_gitignore_matcher_after_ready(&stale_state, &stale_root);
             }
+            background_refresh_stale(&stale_state, &stale_root, &stale_index_dir, None);
         });
     }
 
@@ -372,6 +394,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
 fn build_gitignore_matcher_after_ready(state: &ServerState, root: &Path) {
     if state.no_ignore {
         *state.gitignore.write().unwrap() = None;
+        state.gitignore_pending.store(false, Ordering::SeqCst);
         return;
     }
     let start = Instant::now();
@@ -379,6 +402,10 @@ fn build_gitignore_matcher_after_ready(state: &ServerState, root: &Path) {
     let matcher = tgrep_core::gitignore::build_matcher(root);
     let has_matcher = matcher.is_some();
     *state.gitignore.write().unwrap() = matcher;
+    // Release the watcher only once the matcher is actually readable. A repo
+    // with no ignore rules at all yields `None`, which is a legitimate final
+    // answer rather than a missing matcher, so it clears the gate too.
+    state.gitignore_pending.store(false, Ordering::SeqCst);
     eprintln!(
         "[trace] gitignore matcher build complete in {:.1}ms{}",
         start.elapsed().as_secs_f64() * 1000.0,
@@ -1030,6 +1057,17 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         return;
     }
 
+    // Likewise, stay off the index until the gitignore matcher exists. On a
+    // warm start (complete index on disk) `indexing` is false from the very
+    // first event, so without this the watcher would run with a `None`
+    // matcher and index exactly the build output the walk skipped — the
+    // divergence `should_skip_watcher_path` exists to prevent. Events dropped
+    // here are recovered by the stale check that runs right after the
+    // matcher is published.
+    if state.gitignore_pending.load(Ordering::SeqCst) {
+        return;
+    }
+
     // Acquire the snapshot gate up-front for the whole event. While a
     // flush/auto-save is publishing (writer holds it), no reindex
     // *work* — file I/O, trigram extraction, even the [trace] line —
@@ -1583,6 +1621,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             tgrep_core::walker::build_gitignore_matcher_from_files(root, &outcome.gitignore_files);
         let found = matcher.is_some();
         *state.gitignore.write().unwrap() = matcher;
+        state.gitignore_pending.store(false, Ordering::SeqCst);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -1669,6 +1708,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         let matcher = walker::build_gitignore_matcher_from_files(root, &walk.gitignore_files);
         let has_matcher = matcher.is_some();
         *state.gitignore.write().unwrap() = matcher;
+        state.gitignore_pending.store(false, Ordering::SeqCst);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms ({} .gitignore files{})",
             start.elapsed().as_secs_f64() * 1000.0,

--- a/tgrep-cli/tests/warm_start_gitignore.rs
+++ b/tgrep-cli/tests/warm_start_gitignore.rs
@@ -1,0 +1,179 @@
+//! Regression test for the warm-start gitignore gap.
+//!
+//! On a warm start (a complete index already on disk) the server does not run a
+//! background build, so its `indexing` flag is false from the very first
+//! filesystem event. The `.gitignore` matcher, however, is built on a
+//! background thread and is not available immediately. If the watcher is
+//! allowed to run in that gap it sees `gitignore == None`, applies no ignore
+//! rules, and indexes exactly the build output the walker deliberately skips —
+//! permanently polluting the index with files a search should never return.
+//!
+//! This test pins the watcher shut until the matcher is published.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+fn tgrep_bin() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin("tgrep")
+}
+
+struct ServerGuard {
+    child: Child,
+    port: u16,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// A repository whose `.gitignore` excludes `build/`.
+///
+/// The `.git` directory is real (if empty) on purpose: the `ignore` crate
+/// applies `.gitignore` rules only when it can see a git repository, so
+/// without it the walker would ignore the ignore file and the test would be
+/// measuring the wrong thing entirely. An empty directory is enough for that
+/// check, which keeps the fixture independent of the `git` binary.
+fn setup_fixture() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir_all(root.join("build")).unwrap();
+
+    // Enough files that building the matcher takes long enough for the
+    // writer loop below to land inside the startup window.
+    for pkg in 0..40 {
+        let sub = root.join("src").join(format!("pkg{pkg}"));
+        fs::create_dir_all(&sub).unwrap();
+        for f in 0..50 {
+            fs::write(
+                sub.join(format!("file{f}.rs")),
+                format!("fn tracked_{pkg}_{f}() {{ let normal_source_marker = {f}; }}\n"),
+            )
+            .unwrap();
+        }
+    }
+
+    dir
+}
+
+fn send_request(port: u16, request: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    writeln!(stream, "{request}")?;
+    stream.flush()?;
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader.read_line(&mut response)?;
+    Ok(response)
+}
+
+fn search_matches(port: u16, pattern: &str) -> u64 {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "search",
+        "id": 1,
+        "params": { "pattern": pattern }
+    })
+    .to_string();
+    let response = send_request(port, &request).expect("search request failed");
+    let value: serde_json::Value = serde_json::from_str(&response).expect("invalid JSON response");
+    value
+        .pointer("/result/num_matches")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| panic!("missing num_matches in response: {response}"))
+}
+
+fn wait_for_port(index_dir: &Path) -> u16 {
+    let serve_json = index_dir.join("serve.json");
+    let start = Instant::now();
+    loop {
+        assert!(
+            start.elapsed() <= Duration::from_secs(60),
+            "tgrep serve did not start within 60 seconds"
+        );
+        if let Ok(data) = fs::read_to_string(&serve_json)
+            && let Ok(info) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(p) = info.get("port").and_then(|v| v.as_u64())
+            && TcpStream::connect(format!("127.0.0.1:{p}")).is_ok()
+        {
+            return p as u16;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn warm_start_watcher_does_not_index_gitignored_files() {
+    let fixture = setup_fixture();
+    let root = fixture.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    // Build a complete index up front so `serve` takes the warm-start path
+    // (no background build, so `indexing` is false immediately).
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+
+    // Hammer a gitignored file for the whole startup window. Rewriting in a
+    // loop rather than once removes the race: whatever the exact moment the
+    // watcher comes up and the matcher lands, some write falls between them.
+    let ignored = root.join("build").join("leaked.txt");
+    let writer_deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < writer_deadline {
+        let _ = fs::write(&ignored, "gitignored_leak_marker build artifact\n");
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let server = ServerGuard {
+        child,
+        port: wait_for_port(&index_dir),
+    };
+
+    // Let the stale check and any resulting flush settle.
+    thread::sleep(Duration::from_secs(3));
+
+    // Positive control: without this a broken search path would let the
+    // real assertion below pass for entirely the wrong reason.
+    assert!(
+        search_matches(server.port, "normal_source_marker") > 0,
+        "expected the indexed source files to be searchable"
+    );
+
+    assert_eq!(
+        search_matches(server.port, "gitignored_leak_marker"),
+        0,
+        "watcher indexed a gitignored file during the warm-start window \
+         before the .gitignore matcher was published"
+    );
+}

--- a/tgrep-cli/tests/warm_start_gitignore.rs
+++ b/tgrep-cli/tests/warm_start_gitignore.rs
@@ -15,6 +15,8 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::path::Path;
 use std::process::{Child, Command};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -26,7 +28,6 @@ fn tgrep_bin() -> std::path::PathBuf {
 
 struct ServerGuard {
     child: Child,
-    port: u16,
 }
 
 impl Drop for ServerGuard {
@@ -133,6 +134,38 @@ fn warm_start_watcher_does_not_index_gitignored_files() {
         .expect("failed to run tgrep index");
     assert!(status.success(), "initial index build failed");
 
+    // Hammer a gitignored file across the *whole* startup window. The writer
+    // starts before `serve` is spawned and keeps going until well after the
+    // port is up, so however long startup takes, writes straddle both the
+    // moment the watcher comes live and the moment the matcher lands.
+    //
+    // A fixed-duration loop that ran before waiting for readiness would be
+    // unsound as a regression test: on a slow or loaded runner every write
+    // could complete before the watcher existed, no event would ever reach
+    // the gap, and the test would pass having exercised nothing.
+    let ignored = root.join("build").join("leaked.txt");
+    let stop = Arc::new(AtomicBool::new(false));
+    let writes = Arc::new(AtomicU64::new(0));
+    let writer = {
+        let stop = Arc::clone(&stop);
+        let writes = Arc::clone(&writes);
+        thread::spawn(move || {
+            let mut last_err = None;
+            while !stop.load(Ordering::Relaxed) {
+                match fs::write(&ignored, "gitignored_leak_marker build artifact\n") {
+                    Ok(()) => {
+                        writes.fetch_add(1, Ordering::Relaxed);
+                    }
+                    // Kept rather than swallowed so a probe that never ran
+                    // reports why instead of masquerading as a pass.
+                    Err(e) => last_err = Some(e),
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            last_err
+        })
+    };
+
     let child = Command::new(tgrep_bin())
         .args([
             "serve",
@@ -145,20 +178,23 @@ fn warm_start_watcher_does_not_index_gitignored_files() {
         .spawn()
         .expect("failed to start tgrep serve");
 
-    // Hammer a gitignored file for the whole startup window. Rewriting in a
-    // loop rather than once removes the race: whatever the exact moment the
-    // watcher comes up and the matcher lands, some write falls between them.
-    let ignored = root.join("build").join("leaked.txt");
-    let writer_deadline = Instant::now() + Duration::from_secs(3);
-    while Instant::now() < writer_deadline {
-        let _ = fs::write(&ignored, "gitignored_leak_marker build artifact\n");
-        thread::sleep(Duration::from_millis(10));
-    }
+    // Take ownership immediately so the child is reaped even if the readiness
+    // wait below times out and panics.
+    let _server = ServerGuard { child };
 
-    let server = ServerGuard {
-        child,
-        port: wait_for_port(&index_dir),
-    };
+    let port = wait_for_port(&index_dir);
+
+    // Keep writing past readiness: the matcher is built on a background
+    // thread and can land well after the port opens.
+    thread::sleep(Duration::from_secs(2));
+    stop.store(true, Ordering::Relaxed);
+    let last_err = writer.join().expect("writer thread panicked");
+
+    assert!(
+        writes.load(Ordering::Relaxed) > 0,
+        "the gitignored probe file was never written, so this test proved \
+         nothing about the warm-start window: {last_err:?}"
+    );
 
     // Let the stale check and any resulting flush settle.
     thread::sleep(Duration::from_secs(3));
@@ -166,12 +202,12 @@ fn warm_start_watcher_does_not_index_gitignored_files() {
     // Positive control: without this a broken search path would let the
     // real assertion below pass for entirely the wrong reason.
     assert!(
-        search_matches(server.port, "normal_source_marker") > 0,
+        search_matches(port, "normal_source_marker") > 0,
         "expected the indexed source files to be searchable"
     );
 
     assert_eq!(
-        search_matches(server.port, "gitignored_leak_marker"),
+        search_matches(port, "gitignored_leak_marker"),
         0,
         "watcher indexed a gitignored file during the warm-start window \
          before the .gitignore matcher was published"


### PR DESCRIPTION
## The bug

On a **warm start** (a complete index already on disk), the file watcher indexes gitignored files.

`ServerState.indexing` is initialized to `needs_build`. On a warm start that is `false`, so the `indexing` guard in `handle_fs_event` never engages — but `state.gitignore` is `RwLock::new(None)` and is only populated later, on a background thread. In that window `should_skip_watcher_path` gets `None` and applies **no ignore rules at all**, so the watcher indexes exactly the build output the initial walk was careful to skip. The next flush persists it.

On a big repo the matcher build is slow enough for this to matter, so the window is wide open in practice.

## Reproduction

Built a 30k-file fixture as a real git repo with `build/` in `.gitignore`, ran `serve`, and wrote `build/leaked.txt` right after `file watcher started`:

```
[trace] reindex: modified build/leaked.txt
```

The content was searchable, and `Files: 30003` confirmed it reached disk. The stale check independently reported "index is up-to-date", which proves the watcher was the only path writing that file into the index.

> A note for anyone extending the test: the `ignore` crate only applies `.gitignore` **inside a git repo** (`require_git` defaults to true and we never override it). A fixture without a `.git` directory silently ignores `.gitignore` entirely — my first repro was invalid for exactly this reason.

## The fix

Two parts, both needed:

1. A `gitignore_pending: AtomicBool` gate. Set at construction when the watcher will actually use ignore rules (`!no_watch && !no_ignore`), cleared at all three matcher-publish sites. While set, `handle_fs_event` drops events rather than indexing them unfiltered.
2. **Reordering warm start** so the matcher is built *before* `background_refresh_stale`.

The reorder is what makes the gate safe: events dropped during the gap are recovered by the stale check that follows. I verified this rather than assuming — an edit made inside the window is dropped by the watcher and then picked up by the stale check.

Only the *first* publish is gated. Later rebuilds (e.g. an edited `.gitignore`) swap the matcher atomically and leave the previous one readable, so events keep being filtered by slightly stale but valid rules instead of being dropped.

No wedge risk: both `bootstrap_index_build` failure paths fall through to `background_index_build`, which publishes and clears the flag. `build_gitignore_matcher_after_ready` also clears the flag when the matcher is `None`, since a repo with no ignore rules is a legitimate final answer rather than a missing matcher.

## Verification

- A/B'd pre-fix and fixed binaries with an identical probe script: pre-fix `LEAKED`, fixed `clean (no results)`.
- Regression checked that live incremental indexing still works after startup (an edit and a new file both `FOUND`, a gitignored file `absent`).
- New integration test `warm_start_gitignore.rs` — uses a real (empty) `.git` dir so `.gitignore` is honored, hammers a gitignored file for 3 s to remove the race, and asserts a **positive control** (a normal source edit *is* indexed) before asserting the leak marker is absent. **Verified to fail without the fix** (`left: 1, right: 0`).
- Full workspace suite green, `clippy -D warnings` clean, `fmt` applied.
