### PR TITLE
Honor .ignore files, process watcher events off-thread, and parallelize the matcher walk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.2"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.2"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.2"
+version = "1.0.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -291,6 +291,14 @@ enum Command {
         /// process is killed. Defaults to 5000.
         #[arg(long = "auto-save-mutations", value_name = "N", value_parser = clap::value_parser!(u32).range(1..))]
         auto_save_mutations: Option<u32>,
+
+        /// Maximum number of filesystem events buffered between the OS
+        /// watcher and the indexing worker. Raise it if bulk changes (branch
+        /// switches, builds) log watcher queue overflows; each overflow costs
+        /// a full stale check instead of incremental updates. Defaults to
+        /// 16384.
+        #[arg(long = "watcher-queue-cap", value_name = "N", value_parser = clap::value_parser!(u64).range(1..))]
+        watcher_queue_cap: Option<u64>,
     },
 
     /// Search for a pattern.
@@ -401,6 +409,7 @@ fn main() {
             max_cpu_percent,
             exclude,
             auto_save_mutations,
+            watcher_queue_cap,
         }) => {
             let memory_cap = max_memory_mb
                 .map(|mb| mb.saturating_mul(1024 * 1024))
@@ -416,6 +425,7 @@ fn main() {
                     index_threads,
                     no_ignore,
                     auto_save_mutations,
+                    watcher_queue_cap: watcher_queue_cap.map(|n| n as usize),
                 },
             )
         }

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -297,7 +297,17 @@ enum Command {
         /// switches, builds) log watcher queue overflows; each overflow costs
         /// a full stale check instead of incremental updates. Defaults to
         /// 16384.
-        #[arg(long = "watcher-queue-cap", value_name = "N", value_parser = clap::value_parser!(u64).range(1..))]
+        // Bounded by `usize::MAX` so the value always survives the conversion
+        // at the call site. Without it, a value above `usize::MAX` would
+        // truncate on a 32-bit target — and truncating to 0 turns the
+        // watcher's `sync_channel` into a rendezvous channel, where every
+        // `try_send` fails and no event is ever delivered. Plain `//` so the
+        // rationale stays out of `--help`.
+        #[arg(
+            long = "watcher-queue-cap",
+            value_name = "N",
+            value_parser = clap::value_parser!(u64).range(1..=usize::MAX as u64)
+        )]
         watcher_queue_cap: Option<u64>,
     },
 
@@ -425,7 +435,11 @@ fn main() {
                     index_threads,
                     no_ignore,
                     auto_save_mutations,
-                    watcher_queue_cap: watcher_queue_cap.map(|n| n as usize),
+                    // Clap's range bound guarantees this fits; saturating keeps
+                    // the conversion total, and errs toward a large cap rather
+                    // than a zero-length (rendezvous) queue.
+                    watcher_queue_cap: watcher_queue_cap
+                        .map(|n| usize::try_from(n).unwrap_or(usize::MAX)),
                 },
             )
         }

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -234,11 +234,55 @@ pub fn run(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) -> Resu
     }
 
     // No server — use on-disk index directly (or brute force)
-    if opts.no_index || !index_dir.join("lookup.bin").exists() {
+    if opts.no_index {
+        return brute_force_search(&root, opts, ci);
+    }
+    if !index_dir.join("lookup.bin").exists() {
+        warn_missing_index(&index_dir, index_path.is_some(), opts.quiet);
         return brute_force_search(&root, opts, ci);
     }
 
     search_local_index(&root, &index_dir, opts, ci)
+}
+
+/// Render a path the way the user typed it.
+///
+/// `std::fs::canonicalize` returns Windows extended-length paths (`\\?\C:\...`,
+/// or `\\?\UNC\server\share` for network paths). That prefix is an internal
+/// Win32 detail and only confuses people when it shows up in a diagnostic.
+fn display_path(p: &Path) -> String {
+    let s = p.display().to_string();
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = s.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else {
+        s
+    }
+}
+
+/// Warn when a search silently degrades to scanning every file.
+///
+/// This is the difference between a sub-second query and a multi-minute one on
+/// a large tree, so it must never be silent. The most common cause is starting
+/// `serve` with `--index-path` but omitting it on the search: the flag is
+/// global, meaning it is accepted on every subcommand, not remembered between
+/// invocations. The client then looks for `serve.json` in the default location,
+/// finds nothing, and falls through to here without ever contacting the server.
+fn warn_missing_index(index_dir: &Path, explicit_path: bool, quiet: bool) {
+    if quiet {
+        return;
+    }
+    let dir = display_path(index_dir);
+    eprintln!("warning: no index at {dir} - scanning every file (slow on large trees)");
+    if explicit_path {
+        eprintln!("note: build one with `tgrep index --index-path {dir}`");
+    } else {
+        eprintln!(
+            "note: if a server is running with `--index-path <dir>`, pass the same \
+             --index-path here; otherwise build an index with `tgrep index`"
+        );
+    }
 }
 
 fn search_via_server(info: &ServerInfo, opts: &SearchOptions, ci: bool) -> Result<bool> {
@@ -782,5 +826,36 @@ fn plan_summary(plan: &QueryPlan) -> String {
             format!("OR({})", subs.join(", "))
         }
         QueryPlan::MatchAll => "MatchAll (full scan)".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_path_strips_extended_length_prefix() {
+        assert_eq!(
+            display_path(Path::new(r"\\?\C:\src\repo\.tgrep")),
+            r"C:\src\repo\.tgrep"
+        );
+    }
+
+    #[test]
+    fn display_path_restores_unc_paths() {
+        // Naively stripping `\\?\` would leave a bogus `UNC\server\...` path.
+        assert_eq!(
+            display_path(Path::new(r"\\?\UNC\server\share\idx")),
+            r"\\server\share\idx"
+        );
+    }
+
+    #[test]
+    fn display_path_leaves_ordinary_paths_alone() {
+        assert_eq!(display_path(Path::new(r"C:\src\repo")), r"C:\src\repo");
+        assert_eq!(
+            display_path(Path::new("/home/user/repo")),
+            "/home/user/repo"
+        );
     }
 }

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1531,13 +1531,25 @@ fn background_refresh_stale(
     let current_meta = &walk.files;
 
     // Load stored per-file stamps from last index write
-    let old_stamps = match meta::read_filestamps(index_dir) {
+    let mut old_stamps = match meta::read_filestamps(index_dir) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("[trace] stale check: no filestamps found ({e}), skipping");
             return;
         }
     };
+
+    // Fold in stamps the watcher recorded since the last flush. `filestamps.json`
+    // only advances when the index is written to disk, so mid-session it lags
+    // the live overlay. Comparing against the on-disk copy alone would re-index
+    // every file the watcher already handled since that write, and — worse —
+    // a file created and then deleted inside that window appears in neither the
+    // on-disk stamps nor the filesystem, so it would never be classified as
+    // deleted and would linger in the index. The in-memory stamps are the
+    // fresher record of what the index actually holds, so they win.
+    for (path, stamp) in state.file_stamps.read().unwrap().iter() {
+        old_stamps.insert(path.clone(), stamp.clone());
+    }
     if old_stamps.is_empty() && indexed_paths.is_none() {
         eprintln!("[trace] stale check: no filestamps found, skipping");
         return;

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -30,6 +30,20 @@ const CACHE_CAPACITY: usize = 50_000;
 const AUTO_SAVE_MUTATIONS: u32 = 5000;
 const AUTO_SAVE_INTERVAL: Duration = Duration::from_secs(600); // 10 minutes
 
+/// Default bound on the queue between the OS notification callback and the
+/// watcher worker (override with `--watcher-queue-cap`).
+///
+/// Sized to absorb a bulk change — a branch switch or a build — without
+/// dropping events, while staying small enough that a truly runaway producer
+/// is capped rather than growing memory without limit. Each queued `Event`
+/// holds only its paths, so this is on the order of a few MB at worst.
+const WATCHER_QUEUE_CAP: usize = 16_384;
+
+/// How long the watcher worker waits for an event before looking for an
+/// overflow to repair. Doubles as the quiet period that must elapse before a
+/// reconciling stale check runs.
+const WATCHER_IDLE_POLL: Duration = Duration::from_secs(1);
+
 /// Server discovery info, written to `serve.json`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServerInfo {
@@ -208,6 +222,8 @@ pub struct ServeOptions<'a> {
     pub index_threads: usize,
     pub no_ignore: bool,
     pub auto_save_mutations: Option<u32>,
+    /// Bound on the watcher's hand-off queue. `None` uses [`WATCHER_QUEUE_CAP`].
+    pub watcher_queue_cap: Option<usize>,
 }
 
 pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) -> Result<()> {
@@ -218,8 +234,10 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         index_threads,
         no_ignore,
         auto_save_mutations,
+        watcher_queue_cap,
     } = options;
     let serve_start = Instant::now();
+    let watcher_queue_cap = watcher_queue_cap.unwrap_or(WATCHER_QUEUE_CAP);
     let auto_save_mutations = auto_save_mutations.unwrap_or(AUTO_SAVE_MUTATIONS);
     let root = std::fs::canonicalize(root)?;
     let index_dir = index_path
@@ -312,12 +330,13 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
 
     eprintln!(
         "[trace] serve ready in {:.1}ms. TCP on port {}. Cache: max {} entries. \
-         Memory cap: {} MB. Index threads: {}.",
+         Memory cap: {} MB. Index threads: {}. Watcher queue cap: {}.",
         serve_start.elapsed().as_secs_f64() * 1000.0,
         port,
         CACHE_CAPACITY,
         memory_cap_bytes / (1024 * 1024),
         index_threads,
+        watcher_queue_cap,
     );
 
     // If no pre-existing index, build into the LiveIndex in background
@@ -334,21 +353,22 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         let stale_root = root.clone();
         let stale_index_dir = index_dir.clone();
         thread::spawn(move || {
-            // Publish the gitignore matcher *before* the stale check, not
-            // after. On this path `indexing` is false from the very first
-            // event, so `gitignore_pending` is the only thing keeping the
-            // watcher off the index while the matcher is missing. That gate
-            // is armed when `ServerState` is built — before this thread is
-            // spawned and before `start_file_watcher` runs below — so it
-            // holds whichever of the two wins the race.
+            // The stale check owns publishing the gitignore matcher on this
+            // path: it walks the whole tree anyway, so it collects the ignore
+            // files as it goes rather than paying for a second traversal.
             //
-            // Doing this first also means the stale check that follows is
-            // what recovers the events dropped during the gap: it compares
-            // the whole tree against the index, so any edit that landed
-            // while the matcher was still building is picked up here.
-            if stale_state.watch_enabled && !stale_state.no_ignore {
-                build_gitignore_matcher_after_ready(&stale_state, &stale_root);
-            }
+            // On this path `indexing` is false from the very first event, so
+            // `gitignore_pending` is the only thing keeping the watcher off
+            // the index while the matcher is missing. That gate is armed when
+            // `ServerState` is built — before this thread is spawned and
+            // before `start_file_watcher` runs below — so it holds whichever
+            // of the two wins the race, and the stale check releases it
+            // before any of its early returns.
+            //
+            // The same stale check is also what recovers events dropped
+            // during the gap: it compares the whole tree against the index,
+            // so any edit that landed while the matcher was still building is
+            // picked up here.
             background_refresh_stale(&stale_state, &stale_root, &stale_index_dir, None);
         });
     }
@@ -360,7 +380,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     } else {
         let watcher_state = Arc::clone(&state);
         let watcher_root = root.clone();
-        start_file_watcher(watcher_state, &watcher_root)
+        start_file_watcher(watcher_state, &watcher_root, watcher_queue_cap)
     };
 
     // Set up graceful shutdown
@@ -394,25 +414,47 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     Ok(())
 }
 
-fn build_gitignore_matcher_after_ready(state: &ServerState, root: &Path) {
+/// Publish the watcher's ignore matcher from ignore files discovered by a walk
+/// that already happened, and release the `gitignore_pending` gate.
+///
+/// Reusing the caller's walk is the whole point: `gitignore::build_matcher`
+/// would traverse the entire tree a second time purely to find the same ignore
+/// files. On a 289k-file repo on a network drive that second walk cost 205s,
+/// against 1.6s for the stale-check walk over the same tree.
+///
+/// Every exit path clears the gate. A repo with no ignore rules at all yields
+/// `None`, which is a legitimate final answer rather than a missing matcher, so
+/// it clears the gate too — otherwise the watcher would stay muted forever.
+fn publish_watcher_matcher(
+    state: &ServerState,
+    root: &Path,
+    walk: &tgrep_core::walker::MetaWalkResult,
+) {
+    if !state.watch_enabled {
+        return;
+    }
     if state.no_ignore {
         *state.gitignore.write().unwrap() = None;
         state.gitignore_pending.store(false, Ordering::SeqCst);
         return;
     }
+
     let start = Instant::now();
-    eprintln!("[trace] gitignore matcher build started...");
-    let matcher = tgrep_core::gitignore::build_matcher(root);
+    let matcher = tgrep_core::walker::build_gitignore_matcher_from_files(
+        root,
+        &walk.gitignore_files,
+        &walk.ignore_files,
+    );
     let has_matcher = matcher.is_some();
     *state.gitignore.write().unwrap() = matcher;
-    // Release the watcher only once the matcher is actually readable. A repo
-    // with no ignore rules at all yields `None`, which is a legitimate final
-    // answer rather than a missing matcher, so it clears the gate too.
     state.gitignore_pending.store(false, Ordering::SeqCst);
     eprintln!(
-        "[trace] gitignore matcher build complete in {:.1}ms{}",
+        "[trace] gitignore matcher built from stale walk in {:.1}ms \
+         ({} .gitignore + {} .ignore files{})",
         start.elapsed().as_secs_f64() * 1000.0,
-        if has_matcher { "" } else { " (no rules found)" }
+        walk.gitignore_files.len(),
+        walk.ignore_files.len(),
+        if has_matcher { "" } else { ", no rules found" }
     );
 }
 
@@ -886,13 +928,39 @@ fn handle_reload(id: Option<serde_json::Value>, state: &ServerState) -> String {
     }
 }
 
-fn start_file_watcher(state: Arc<ServerState>, root: &Path) -> Option<RecommendedWatcher> {
-    let root_path = root.to_path_buf();
-    let state_clone = Arc::clone(&state);
+fn start_file_watcher(
+    state: Arc<ServerState>,
+    root: &Path,
+    queue_cap: usize,
+) -> Option<RecommendedWatcher> {
+    use std::sync::mpsc::{RecvTimeoutError, TrySendError};
 
+    let root_path = root.to_path_buf();
+
+    // Hand events to a worker thread instead of indexing inside the callback.
+    // The callback runs on the platform's notification thread, which on Windows
+    // owns a fixed-size `ReadDirectoryChangesW` buffer; doing file I/O and
+    // trigram extraction there stalls it, and everything arriving meanwhile is
+    // dropped by the OS with no error we can see. The queue is bounded so a
+    // burst (a branch switch, a build) can't grow it without limit.
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Event>(queue_cap);
+    let overflowed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    let callback_overflow = Arc::clone(&overflowed);
     let mut watcher = match notify::recommended_watcher(
         move |result: std::result::Result<Event, notify::Error>| match result {
-            Ok(event) => handle_fs_event(&state_clone, &root_path, &event),
+            Ok(event) => match tx.try_send(event) {
+                Ok(()) => {}
+                // Don't block the notification thread waiting for room —
+                // that's the stall this hand-off exists to avoid. Drop the
+                // event and note that we did; the worker reconciles with a
+                // stale check, which is cheaper and more reliable than
+                // trying to replay an unknown number of lost events.
+                Err(TrySendError::Full(_)) => {
+                    callback_overflow.store(true, Ordering::SeqCst);
+                }
+                Err(TrySendError::Disconnected(_)) => {}
+            },
             // Surface these. A dropped ReadDirectoryChangesW buffer looks
             // exactly like "the watcher stopped working" from the outside,
             // and silence makes it impossible to tell apart from a bug in
@@ -911,6 +979,50 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path) -> Option<Recommende
         eprintln!("[trace] warning: failed to watch directory: {e}");
         return None;
     }
+
+    let worker_state = Arc::clone(&state);
+    let worker_root = root_path;
+    let worker_index_dir = state.index_dir.clone();
+    std::thread::Builder::new()
+        .name("tgrep-watcher".into())
+        .spawn(move || {
+            loop {
+                match rx.recv_timeout(WATCHER_IDLE_POLL) {
+                    Ok(event) => handle_fs_event(&worker_state, &worker_root, &event),
+                    // A quiet interval means the burst has drained, so this is
+                    // the point to repair an overflow: reconciling earlier
+                    // would run a full stale check while events are still
+                    // queued behind it, and repeat for each one.
+                    Err(RecvTimeoutError::Timeout) => {
+                        if !overflowed.load(Ordering::SeqCst) {
+                            continue;
+                        }
+                        // An index build or a pending matcher ends with its own
+                        // stale check, which reconciles the same drift. Leave
+                        // the flag set and let that run instead of racing it.
+                        if worker_state.indexing.load(Ordering::SeqCst)
+                            || worker_state.gitignore_pending.load(Ordering::SeqCst)
+                        {
+                            continue;
+                        }
+                        overflowed.store(false, Ordering::SeqCst);
+                        eprintln!(
+                            "[trace] watcher queue overflowed (cap {queue_cap}); \
+                             reconciling with a stale check"
+                        );
+                        background_refresh_stale(
+                            &worker_state,
+                            &worker_root,
+                            &worker_index_dir,
+                            None,
+                        );
+                    }
+                    // The watcher was dropped, so the server is shutting down.
+                    Err(RecvTimeoutError::Disconnected) => break,
+                }
+            }
+        })
+        .ok()?;
 
     state
         .watcher_active
@@ -1004,7 +1116,9 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
     thread::spawn(move || {
         loop {
             if state.ignore_rules_dirty.swap(false, Ordering::SeqCst) {
-                build_gitignore_matcher_after_ready(&state, &root);
+                // The stale refresh walks the tree anyway and republishes the
+                // matcher from that walk, so the reload costs one traversal
+                // rather than a rebuild plus a re-scan.
                 let indexed_paths = {
                     let index = state.index.read().unwrap();
                     let mut paths = index.reader_paths();
@@ -1407,6 +1521,15 @@ fn background_refresh_stale(
     let start = Instant::now();
     eprintln!("[trace] stale check: comparing index against filesystem...");
 
+    // Walk first. This single traversal feeds both the stale diff and the
+    // watcher's ignore matcher, and it must run before the early returns
+    // below so the matcher is published — and `gitignore_pending` released —
+    // even when the index turns out to be up to date or has no stamps yet.
+    let walk = walker::walk_file_metadata(root, &state.exclude_dirs, state.no_ignore);
+    let walk_ms = start.elapsed().as_millis();
+    publish_watcher_matcher(state, root, &walk);
+    let current_meta = &walk.files;
+
     // Load stored per-file stamps from last index write
     let old_stamps = match meta::read_filestamps(index_dir) {
         Ok(s) => s,
@@ -1420,12 +1543,7 @@ fn background_refresh_stale(
         return;
     }
 
-    // Walk filesystem metadata (no content reads)
-    let current_meta = walker::walk_file_metadata(root, &state.exclude_dirs, state.no_ignore);
-    let walk_ms = start.elapsed().as_millis();
-
-    let (changed, added, deleted) =
-        classify_file_changes(&current_meta, &old_stamps, indexed_paths);
+    let (changed, added, deleted) = classify_file_changes(current_meta, &old_stamps, indexed_paths);
 
     let total_changes = changed.len() + added.len() + deleted.len();
     if total_changes == 0 {
@@ -1608,9 +1726,9 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
     // build just skipped.
     //
     // Both come out of the build itself: the builder persisted filestamps.json,
-    // and its walk handed back the .gitignore paths. Building the matcher from
-    // those is what keeps this cheap — `gitignore::build_matcher` would rewalk
-    // the whole tree single-threaded, which cost 49 s on a 289k-file repo.
+    // and its walk handed back the .gitignore / .ignore paths. Building the
+    // matcher from those is what keeps this cheap — `gitignore::build_matcher`
+    // would rewalk the whole tree, which cost 49 s on a 289k-file repo.
     match tgrep_core::meta::read_filestamps(index_dir) {
         Ok(stamps) => *state.file_stamps.write().unwrap() = stamps,
         Err(e) => eprintln!(
@@ -1620,8 +1738,11 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
     }
     if state.watch_enabled && !state.no_ignore {
         let t_gi = Instant::now();
-        let matcher =
-            tgrep_core::walker::build_gitignore_matcher_from_files(root, &outcome.gitignore_files);
+        let matcher = tgrep_core::walker::build_gitignore_matcher_from_files(
+            root,
+            &outcome.gitignore_files,
+            &outcome.ignore_files,
+        );
         let found = matcher.is_some();
         *state.gitignore.write().unwrap() = matcher;
         state.gitignore_pending.store(false, Ordering::SeqCst);
@@ -1708,14 +1829,20 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
 
     if state.watch_enabled && !state.no_ignore {
         let start = Instant::now();
-        let matcher = walker::build_gitignore_matcher_from_files(root, &walk.gitignore_files);
+        let matcher = walker::build_gitignore_matcher_from_files(
+            root,
+            &walk.gitignore_files,
+            &walk.ignore_files,
+        );
         let has_matcher = matcher.is_some();
         *state.gitignore.write().unwrap() = matcher;
         state.gitignore_pending.store(false, Ordering::SeqCst);
         eprintln!(
-            "[trace] gitignore matcher built from index walk in {:.1}ms ({} .gitignore files{})",
+            "[trace] gitignore matcher built from index walk in {:.1}ms \
+             ({} .gitignore + {} .ignore files{})",
             start.elapsed().as_secs_f64() * 1000.0,
             walk.gitignore_files.len(),
+            walk.ignore_files.len(),
             if has_matcher { "" } else { ", no rules found" }
         );
     }
@@ -1872,6 +1999,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     let walk_meta =
         tgrep_core::walker::walk_file_metadata(root, &state.exclude_dirs, state.no_ignore);
     let stamps: std::collections::HashMap<String, tgrep_core::meta::FileStamp> = walk_meta
+        .files
         .into_iter()
         .map(|fm| {
             (
@@ -2560,6 +2688,9 @@ mod tests {
         // Build the matcher via the public tgrep-core helper so this test
         // also exercises the shared loading logic.
         let tmp = TempDir::new().unwrap();
+        // `.gitignore` is git-gated, matching the indexing walk, so the
+        // matcher only picks it up inside a repo.
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
         let gi_path = tmp.path().join(".gitignore");
         std::fs::write(&gi_path, "*.log\ntarget/\n").unwrap();
         let gi = tgrep_core::gitignore::build_matcher(tmp.path())

--- a/tgrep-cli/tests/watcher_dot_ignore.rs
+++ b/tgrep-cli/tests/watcher_dot_ignore.rs
@@ -1,0 +1,178 @@
+//! End-to-end coverage for the live watcher's ignore handling.
+//!
+//! Two properties are checked together on purpose, because each one alone can
+//! pass for the wrong reason:
+//!
+//!  * a file created under a directory excluded by `.ignore` must never be
+//!    indexed, and
+//!  * an ordinary file created at the same moment *must* be.
+//!
+//! Without the second assertion a watcher that had simply stopped working —
+//! for example one whose events never reach the indexing worker — would
+//! satisfy the first. Without the first, the ignore rules could be ignored
+//! entirely and nothing would notice.
+//!
+//! The fixture deliberately has **no** `.git` directory. `.gitignore` rules
+//! only apply inside a repository, but `.ignore` applies everywhere, so this
+//! also pins that distinction.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+fn tgrep_bin() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin("tgrep")
+}
+
+struct ServerGuard {
+    child: Child,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn send_request(port: u16, request: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    writeln!(stream, "{request}")?;
+    stream.flush()?;
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader.read_line(&mut response)?;
+    Ok(response)
+}
+
+fn search_matches(port: u16, pattern: &str) -> u64 {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "search",
+        "id": 1,
+        "params": { "pattern": pattern }
+    })
+    .to_string();
+    let response = send_request(port, &request).expect("search request failed");
+    let value: serde_json::Value = serde_json::from_str(&response).expect("invalid JSON response");
+    value
+        .pointer("/result/num_matches")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| panic!("missing num_matches in response: {response}"))
+}
+
+fn wait_for_port(index_dir: &Path) -> u16 {
+    let serve_json = index_dir.join("serve.json");
+    let start = Instant::now();
+    loop {
+        assert!(
+            start.elapsed() <= Duration::from_secs(60),
+            "tgrep serve did not start within 60 seconds"
+        );
+        if let Ok(data) = fs::read_to_string(&serve_json)
+            && let Ok(info) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(p) = info.get("port").and_then(|v| v.as_u64())
+            && TcpStream::connect(format!("127.0.0.1:{p}")).is_ok()
+        {
+            return p as u16;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Poll until `pattern` is searchable, returning whether it ever showed up.
+fn wait_for_match(port: u16, pattern: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        if search_matches(port, pattern) > 0 {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn watcher_honors_dot_ignore_and_still_indexes_new_files() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    // No `.git` here: `.ignore` must apply on its own.
+    fs::write(root.join(".ignore"), "secret/\n").unwrap();
+    fs::create_dir_all(root.join("secret")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let port = wait_for_port(&index_dir);
+
+    // Positive control on the seeded index, and a wait for the watcher to be
+    // live: the matcher is published on a background thread, and until it is
+    // the watcher drops events rather than risk indexing ignored paths.
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source file to be searchable"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    fs::write(
+        root.join("secret").join("creds.txt"),
+        "dot_ignored_leak_marker\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src").join("added.rs"),
+        "fn added() { let watcher_added_marker = 2; }\n",
+    )
+    .unwrap();
+
+    // The ordinary file proves the watcher is actually delivering events to
+    // the indexing worker, so the ignored-file assertion below means something.
+    assert!(
+        wait_for_match(port, "watcher_added_marker", Duration::from_secs(30)),
+        "watcher never indexed a newly created ordinary file"
+    );
+
+    assert_eq!(
+        search_matches(port, "dot_ignored_leak_marker"),
+        0,
+        "watcher indexed a file under a directory excluded by .ignore"
+    );
+}

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -128,9 +128,13 @@ pub struct BuildOutcome {
     ///
     /// Handing these back lets a caller that needs an ignore matcher build one
     /// with [`walker::build_gitignore_matcher_from_files`] instead of
-    /// [`crate::gitignore::build_matcher`], which would repeat the whole walk
-    /// serially — 49 s on a 289k-file repository.
+    /// [`crate::gitignore::build_matcher`], which would repeat the whole walk —
+    /// 49 s on a 289k-file repository.
     pub gitignore_files: Vec<std::path::PathBuf>,
+    /// Absolute `.ignore` paths seen during the same walk, kept separate from
+    /// `gitignore_files` so a matcher can apply them last and give them
+    /// precedence over `.gitignore`.
+    pub ignore_files: Vec<std::path::PathBuf>,
 }
 
 /// Build a trigram index for all text files under `root`.
@@ -188,6 +192,7 @@ pub fn build_index_with_options(
         walk.skipped_error
     );
     let gitignore_files = walk.gitignore_files;
+    let ignore_files = walk.ignore_files;
 
     // Read files and extract trigrams with masks in bounded parallel batches.
     // Binary content check is done here (not in walker) to avoid an extra
@@ -279,6 +284,7 @@ pub fn build_index_with_options(
     Ok(BuildOutcome {
         num_files: file_id_map.len(),
         gitignore_files,
+        ignore_files,
     })
 }
 

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -13,6 +13,37 @@ use std::path::Path;
 
 pub const P4IGNORE_FILENAME: &str = "p4ignore.ini";
 
+/// Git's per-directory ignore file.
+pub const GITIGNORE_FILENAME: &str = ".gitignore";
+
+/// The VCS-agnostic ignore file honored by ripgrep and friends. Unlike
+/// `.gitignore` it applies with or without a git repository.
+pub const DOT_IGNORE_FILENAME: &str = ".ignore";
+
+/// Return the ignore files sitting directly inside `dir`, as
+/// `(.gitignore, .ignore)`.
+///
+/// Walks must call this on each directory they descend into rather than
+/// collecting the ignore files the walk *yields*. An ignore file matched by its
+/// own rules — the common `build/.gitignore` holding `*` — is filtered out of
+/// the walk's own output, so collecting yielded entries silently drops that
+/// rule. The indexer would still skip the subtree (the walker reads the file
+/// even though it won't emit it), but the matcher built from those paths would
+/// not know about it, and the watcher would then index a subtree the indexer
+/// deliberately excluded.
+///
+/// Probing directories is also *complete*: a `.gitignore` only matters when the
+/// walk descends into its directory, and every such directory is yielded. It
+/// avoids duplicates for the same reason — one probe per directory.
+pub fn ignore_files_in(dir: &Path) -> (Option<std::path::PathBuf>, Option<std::path::PathBuf>) {
+    let gitignore = dir.join(GITIGNORE_FILENAME);
+    let dot_ignore = dir.join(DOT_IGNORE_FILENAME);
+    (
+        gitignore.is_file().then_some(gitignore),
+        dot_ignore.is_file().then_some(dot_ignore),
+    )
+}
+
 /// Thread count for the `.gitignore` enumeration walk.
 ///
 /// Mirrors `walker::walker_thread_count`. The walk is I/O-bound rather than
@@ -27,20 +58,34 @@ use ignore::Match;
 /// matcher without taking a direct dependency on the `ignore` crate.
 pub use ignore::gitignore::Gitignore;
 
-/// A `.gitignore` found below the repository root, kept anchored to its own
+/// Relative precedence of ignore sources that live in the *same* directory.
+/// `.ignore` outranks `.gitignore`, matching the `ignore` crate's ordering in
+/// the indexing walk.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum IgnoreKind {
+    /// `.ignore` — consulted first, so it wins over a same-directory
+    /// `.gitignore`.
+    DotIgnore,
+    /// `.gitignore`.
+    GitIgnore,
+}
+
+/// An ignore file found below the repository root, kept anchored to its own
 /// directory rather than folded into the root matcher.
 struct NestedIgnore {
-    /// Directory holding the `.gitignore`, relative to the repo root,
+    /// Directory holding the ignore file, relative to the repo root,
     /// `/`-separated with no trailing slash.
     dir: String,
+    kind: IgnoreKind,
     matcher: Gitignore,
 }
 
 pub struct IgnoreMatcher {
-    /// Root-scoped rules: the root `.gitignore`, `.git/info/exclude`, and
-    /// `p4ignore.ini`.
+    /// Root-scoped rules: the root `.gitignore`, `.git/info/exclude`,
+    /// `p4ignore.ini`, and the root `.ignore` (added last so it wins).
     local: Gitignore,
-    /// Nested `.gitignore` files, deepest first.
+    /// Nested ignore files, deepest first and `.ignore` before `.gitignore`
+    /// within a directory.
     nested: Vec<NestedIgnore>,
     global: Gitignore,
 }
@@ -50,9 +95,9 @@ impl IgnoreMatcher {
         Self::with_nested(local, Vec::new(), global)
     }
 
-    /// Build a matcher from root-scoped rules plus `.gitignore` files found
-    /// in subdirectories, each paired with its directory relative to the repo
-    /// root.
+    /// Build a matcher from root-scoped rules plus ignore files found in
+    /// subdirectories, each paired with its directory relative to the repo
+    /// root and the kind of ignore file it came from.
     ///
     /// Nested files **must** stay anchored to their own directory. Folding
     /// them into one root-scoped matcher silently changes what they mean: the
@@ -63,25 +108,28 @@ impl IgnoreMatcher {
     /// silently drop every event.
     pub fn with_nested(
         local: Gitignore,
-        nested: Vec<(String, Gitignore)>,
+        nested: Vec<(String, IgnoreKind, Gitignore)>,
         global: Gitignore,
     ) -> Option<Self> {
         let mut nested: Vec<NestedIgnore> = nested
             .into_iter()
-            .filter(|(_, matcher)| !matcher.is_empty())
-            .map(|(dir, matcher)| NestedIgnore {
+            .filter(|(_, _, matcher)| !matcher.is_empty())
+            .map(|(dir, kind, matcher)| NestedIgnore {
                 dir: dir.trim_matches('/').to_string(),
+                kind,
                 matcher,
             })
             .collect();
-        // Deepest first, so the innermost `.gitignore` decides — that is the
-        // precedence git applies between levels.
+        // Deepest first, so the innermost ignore file decides — that is the
+        // precedence git applies between levels. Within one directory,
+        // `.ignore` is consulted before `.gitignore` so it wins.
         nested.sort_by(|a, b| {
             b.dir
                 .matches('/')
                 .count()
                 .cmp(&a.dir.matches('/').count())
                 .then_with(|| b.dir.len().cmp(&a.dir.len()))
+                .then_with(|| a.kind.cmp(&b.kind))
         });
 
         (!local.is_empty() || !nested.is_empty() || !global.is_empty()).then_some(Self {
@@ -223,67 +271,108 @@ pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
 
 /// Build an [`IgnoreMatcher`] from already-discovered `.gitignore` paths.
 ///
-/// `gitignore_files` must be **absolute** paths under `root` — that is what
-/// `walker::walk_dir` yields. Each nested file is anchored by stripping `root`
-/// from its parent directory, so repo-relative paths would leave every nested
-/// rule out of the matcher.
+/// `gitignore_files` / `ignore_files` must be **absolute** paths under `root` —
+/// that is what `walker::walk_dir` yields. Each nested file is anchored by
+/// stripping `root` from its parent directory, so repo-relative paths would
+/// leave every nested rule out of the matcher.
 ///
-/// Root-level rules (`.git/info/exclude`, `p4ignore.ini`, and a `.gitignore`
-/// directly in `root`) share the root matcher. Every deeper `.gitignore` gets
-/// its own matcher anchored at its directory, because its patterns are written
-/// relative to that directory — see [`IgnoreMatcher::with_nested`].
-pub fn matcher_from_gitignore_paths(
+/// Root-level rules (`.git/info/exclude`, `p4ignore.ini`, a `.gitignore`
+/// directly in `root`, and finally the root `.ignore`) share the root matcher,
+/// added in that order so the last match wins and `.ignore` outranks
+/// `.gitignore`. Every deeper ignore file gets its own matcher anchored at its
+/// directory, because its patterns are written relative to that directory —
+/// see [`IgnoreMatcher::with_nested`].
+///
+/// `.gitignore` and `.git/info/exclude` are **git-gated** to match the indexing
+/// walk (`WalkBuilder`'s `require_git` default): they apply only when `root` is
+/// inside a git repository, detected by scanning `root` and its ancestors for a
+/// `.git` entry so a subdirectory of a repo still counts. `.ignore` always
+/// applies. Without this gate the watcher would filter events using rules the
+/// indexer never applied.
+pub fn matcher_from_ignore_paths(
     root: &Path,
     gitignore_files: &[std::path::PathBuf],
+    ignore_files: &[std::path::PathBuf],
 ) -> Option<IgnoreMatcher> {
     use ignore::gitignore::GitignoreBuilder;
 
+    // `root` is inside a git repo if it or any ancestor holds a `.git` entry.
+    let in_git_repo = root.ancestors().any(|dir| dir.join(".git").exists());
+
     let mut root_builder = GitignoreBuilder::new(root);
-    let info_exclude = root.join(".git").join("info").join("exclude");
-    if info_exclude.is_file() {
-        let _ = root_builder.add(&info_exclude);
+    if in_git_repo {
+        // `.git/info/exclude` is anchored at the repo root, but this matcher is
+        // queried with paths relative to `root`. Only apply it when `root` is
+        // itself the repo root — a `.git` *directory*, not a worktree's `.git`
+        // file — so its anchoring matches.
+        if root.join(".git").is_dir() {
+            let info_exclude = root.join(".git").join("info").join("exclude");
+            if info_exclude.is_file() {
+                let _ = root_builder.add(&info_exclude);
+            }
+        }
     }
     add_p4ignore_rules(&mut root_builder, root);
 
-    let mut nested: Vec<(String, Gitignore)> = Vec::new();
-    for path in gitignore_files {
-        if !path.is_file() {
-            continue;
-        }
-        let dir = path.parent().unwrap_or(root);
-        // A path we can't place relative to the root has unknown scope, and
-        // guessing is what broke this before. Skipping it only under-ignores,
-        // which is the safe direction, but it is still silent — so make it
-        // loud in debug builds rather than quietly dropping nested rules.
-        let Ok(rel_dir) = dir.strip_prefix(root) else {
-            debug_assert!(
-                false,
-                "gitignore path {} is not under root {}; \
-                 pass absolute paths from the walk, not repo-relative ones",
-                path.display(),
-                root.display()
-            );
-            continue;
-        };
-        let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
-        let rel_dir = rel_dir.trim_matches('/');
+    let mut nested: Vec<(String, IgnoreKind, Gitignore)> = Vec::new();
 
-        if rel_dir.is_empty() {
-            let _ = root_builder.add(path);
+    // `.gitignore` first, then `.ignore`, so that within the root matcher the
+    // later-added `.ignore` patterns win.
+    let sources = [
+        (IgnoreKind::GitIgnore, gitignore_files, in_git_repo),
+        (IgnoreKind::DotIgnore, ignore_files, true),
+    ];
+    for (kind, paths, enabled) in sources {
+        if !enabled {
             continue;
         }
+        for path in paths {
+            if !path.is_file() {
+                continue;
+            }
+            let dir = path.parent().unwrap_or(root);
+            // A path we can't place relative to the root has unknown scope, and
+            // guessing is what broke this before. Skipping it only under-ignores,
+            // which is the safe direction, but it is still silent — so make it
+            // loud in debug builds rather than quietly dropping nested rules.
+            let Ok(rel_dir) = dir.strip_prefix(root) else {
+                debug_assert!(
+                    false,
+                    "ignore path {} is not under root {}; \
+                     pass absolute paths from the walk, not repo-relative ones",
+                    path.display(),
+                    root.display()
+                );
+                continue;
+            };
+            let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+            let rel_dir = rel_dir.trim_matches('/');
 
-        let mut builder = GitignoreBuilder::new(dir);
-        if builder.add(path).is_some() {
-            continue;
-        }
-        if let Ok(matcher) = builder.build() {
-            nested.push((rel_dir.to_string(), matcher));
+            if rel_dir.is_empty() {
+                let _ = root_builder.add(path);
+                continue;
+            }
+
+            let mut builder = GitignoreBuilder::new(dir);
+            if builder.add(path).is_some() {
+                continue;
+            }
+            if let Ok(matcher) = builder.build() {
+                nested.push((rel_dir.to_string(), kind, matcher));
+            }
         }
     }
 
     let local = root_builder.build().ok()?;
     IgnoreMatcher::with_nested(local, nested, build_global_matcher(root))
+}
+
+/// Convenience wrapper for callers that only have `.gitignore` paths.
+pub fn matcher_from_gitignore_paths(
+    root: &Path,
+    gitignore_files: &[std::path::PathBuf],
+) -> Option<IgnoreMatcher> {
+    matcher_from_ignore_paths(root, gitignore_files, &[])
 }
 
 /// Build a `Gitignore` matcher rooted at `root`, mirroring the same
@@ -333,7 +422,7 @@ pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
             {
                 return false;
             }
-            if entry.file_name() == ".gitignore" {
+            if entry.file_name() == ".gitignore" || entry.file_name() == ".ignore" {
                 return true;
             }
 
@@ -352,19 +441,28 @@ pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
         .build_parallel();
 
     let gitignore_files = std::sync::Mutex::new(Vec::<std::path::PathBuf>::new());
+    let ignore_files = std::sync::Mutex::new(Vec::<std::path::PathBuf>::new());
     walker.run(|| {
         let found = &gitignore_files;
+        let found_ignore = &ignore_files;
         Box::new(move |entry| {
+            // Probe directories rather than collecting yielded ignore files;
+            // see `ignore_files_in` for why the yielded set is incomplete.
             if let Ok(entry) = entry
-                && entry.file_name() == ".gitignore"
-                && entry.path().is_file()
+                && entry.file_type().is_some_and(|ft| ft.is_dir())
             {
+                let (gitignore, dot_ignore) = ignore_files_in(entry.path());
                 // Ignore poisoning: a panic in another worker must not
                 // cascade into every remaining thread.
-                found
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .push(entry.path().to_path_buf());
+                if let Some(path) = gitignore {
+                    found.lock().unwrap_or_else(|e| e.into_inner()).push(path);
+                }
+                if let Some(path) = dot_ignore {
+                    found_ignore
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push(path);
+                }
             }
             ignore::WalkState::Continue
         })
@@ -382,8 +480,10 @@ pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
         .into_inner()
         .unwrap_or_else(|e| e.into_inner());
     gitignore_files.sort();
+    let mut ignore_files = ignore_files.into_inner().unwrap_or_else(|e| e.into_inner());
+    ignore_files.sort();
 
-    matcher_from_gitignore_paths(root, &gitignore_files)
+    matcher_from_ignore_paths(root, &gitignore_files, &ignore_files)
 }
 
 #[cfg(test)]
@@ -392,14 +492,91 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    fn collects_a_gitignore_that_its_own_rules_ignore() {
+        // `build/.gitignore` holding `*` matches itself, so the walk never
+        // yields it. Missing that rule would leave the watcher indexing a
+        // subtree the indexer skips.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        let build = root.join("build");
+        std::fs::create_dir_all(&build).unwrap();
+        std::fs::write(build.join(".gitignore"), "*\n").unwrap();
+        std::fs::write(build.join("artifact.o"), "x").unwrap();
+
+        let matcher = build_matcher(root).expect("matcher should build");
+        assert!(
+            matcher.is_ignored(Path::new("build/artifact.o"), false),
+            "a self-ignoring .gitignore must still contribute its rules"
+        );
+    }
+
+    #[test]
     fn builds_matcher_from_root_gitignore() {
         let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
         std::fs::write(tmp.path().join(".gitignore"), "*.log\ntarget/\n").unwrap();
         std::fs::write(tmp.path().join(P4IGNORE_FILENAME), ".gitignore\n").unwrap();
         let gi = build_matcher(tmp.path()).expect("matcher should build");
         assert!(gi.is_ignored(Path::new("build/output.log"), false));
         assert!(gi.is_ignored(Path::new("target/release/foo"), false));
         assert!(!gi.is_ignored(Path::new("src/main.rs"), false));
+    }
+
+    #[test]
+    fn builds_matcher_from_dot_ignore_without_a_git_repo() {
+        // `.ignore` is not git-gated: it applies with no `.git` present.
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".ignore"), "*.log\ntarget/\n").unwrap();
+        let gi = build_matcher(tmp.path()).expect("matcher should build from .ignore");
+        assert!(gi.is_ignored(Path::new("build/output.log"), false));
+        assert!(gi.is_ignored(Path::new("target/release/foo"), false));
+        assert!(!gi.is_ignored(Path::new("src/main.rs"), false));
+    }
+
+    #[test]
+    fn gitignore_is_inert_without_a_git_dir() {
+        // No `.git`, so `.gitignore` contributes no rules — matching what the
+        // indexing walk does, so the watcher can't filter on rules the indexer
+        // never applied.
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".gitignore"), "*.log\ntarget/\n").unwrap();
+        assert!(build_matcher(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn root_dot_ignore_overrides_root_gitignore() {
+        // `.gitignore` excludes the tree; `.ignore` re-includes it via a
+        // negation. `.ignore` is applied last, so its rule wins.
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        std::fs::write(tmp.path().join(".gitignore"), "logs/\n").unwrap();
+        std::fs::write(tmp.path().join(".ignore"), "!logs/\n").unwrap();
+        let gi = build_matcher(tmp.path()).expect("matcher should build");
+        assert!(
+            !gi.is_ignored(Path::new("logs/today.txt"), false),
+            ".ignore negation should override the .gitignore rule"
+        );
+    }
+
+    #[test]
+    fn nested_dot_ignore_overrides_gitignore_in_the_same_directory() {
+        // Same directory, two ignore files: `.ignore` must be consulted first
+        // so its negation wins over the sibling `.gitignore`.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        let sub = root.join("pkg");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join(".gitignore"), "*.log\n").unwrap();
+        std::fs::write(sub.join(".ignore"), "!keep.log\n").unwrap();
+
+        let gi = build_matcher(root).expect("matcher should build");
+        assert!(gi.is_ignored(Path::new("pkg/noisy.log"), false));
+        assert!(
+            !gi.is_ignored(Path::new("pkg/keep.log"), false),
+            "a nested .ignore must outrank a .gitignore in the same directory"
+        );
     }
 
     #[test]
@@ -468,6 +645,8 @@ mod tests {
     fn nested_gitignore_rules_stay_scoped_to_their_directory() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
+        // `.gitignore` rules are git-gated, as in the indexing walk.
+        std::fs::create_dir(root.join(".git")).unwrap();
 
         let selftest = root.join("tools/testing/selftests/kvm");
         std::fs::create_dir_all(&selftest).unwrap();
@@ -508,6 +687,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let sub = tmp.path().join("sub");
         std::fs::create_dir_all(&sub).unwrap();
+        // Open the git gate, or the `.gitignore` path is skipped before the
+        // guard under test is ever reached.
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
         std::fs::write(sub.join(".gitignore"), "*.log\n").unwrap();
 
         let cwd = std::env::current_dir().unwrap();
@@ -532,6 +714,7 @@ mod tests {
 
         let inner = root.join("build/keep");
         std::fs::create_dir_all(&inner).unwrap();
+        std::fs::create_dir(root.join(".git")).unwrap();
         std::fs::write(root.join("build/.gitignore"), "*.log\n").unwrap();
         std::fs::write(inner.join(".gitignore"), "!important.log\n").unwrap();
         std::fs::write(root.join("build/noisy.log"), "x").unwrap();

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -8,6 +8,7 @@
 //! The canonical caller is the file watcher in `tgrep-cli`, which has to
 //! answer that per `notify` event without re-walking.
 
+use crate::walker::walker_thread_count;
 use ignore::WalkBuilder;
 use std::path::Path;
 
@@ -42,15 +43,6 @@ pub fn ignore_files_in(dir: &Path) -> (Option<std::path::PathBuf>, Option<std::p
         gitignore.is_file().then_some(gitignore),
         dot_ignore.is_file().then_some(dot_ignore),
     )
-}
-
-/// Thread count for the `.gitignore` enumeration walk.
-///
-/// Mirrors `walker::walker_thread_count`. The walk is I/O-bound rather than
-/// CPU-bound, so the cap exists to avoid thrashing network filesystems, not
-/// to match core count.
-fn matcher_walk_thread_count() -> usize {
-    std::thread::available_parallelism().map_or(4, |n| n.get().min(12))
 }
 
 use ignore::Match;
@@ -437,7 +429,7 @@ pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
                 entry.file_type().is_some_and(|kind| kind.is_dir()),
             )
         })
-        .threads(matcher_walk_thread_count())
+        .threads(walker_thread_count())
         .build_parallel();
 
     let gitignore_files = std::sync::Mutex::new(Vec::<std::path::PathBuf>::new());

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -13,6 +13,15 @@ use std::path::Path;
 
 pub const P4IGNORE_FILENAME: &str = "p4ignore.ini";
 
+/// Thread count for the `.gitignore` enumeration walk.
+///
+/// Mirrors `walker::walker_thread_count`. The walk is I/O-bound rather than
+/// CPU-bound, so the cap exists to avoid thrashing network filesystems, not
+/// to match core count.
+fn matcher_walk_thread_count() -> usize {
+    std::thread::available_parallelism().map_or(4, |n| n.get().min(12))
+}
+
 use ignore::Match;
 /// Re-export of `ignore::gitignore::Gitignore` so callers can hold a
 /// matcher without taking a direct dependency on the `ignore` crate.
@@ -288,6 +297,15 @@ pub fn matcher_from_gitignore_paths(
 /// Uses `WalkBuilder` to enumerate `.gitignore` files so we automatically
 /// skip the `.git` dir and gitignored subtrees while collecting rules.
 /// Returns `None` when no rules could be loaded.
+///
+/// The enumeration walk is *parallel*, matching `walker.rs`. It used to be
+/// single-threaded, which made this a latency trap on large or
+/// network-backed trees: the walk is almost pure I/O wait, so one thread
+/// serializes every directory read. On a 289k-file repo on a network drive
+/// it took 205 s, against 1.6 s for the parallel stale-check walk over the
+/// same tree immediately afterwards. Callers that already have the
+/// `.gitignore` paths from their own walk should still prefer
+/// `matcher_from_gitignore_paths` and skip this entirely.
 pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
     let p4ignore = build_p4ignore_matcher(root).map(std::sync::Arc::new);
     let match_root = root.to_path_buf();
@@ -330,13 +348,40 @@ pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
                 entry.file_type().is_some_and(|kind| kind.is_dir()),
             )
         })
-        .build();
-    let mut gitignore_files: Vec<std::path::PathBuf> = Vec::new();
-    for entry in walker.flatten() {
-        if entry.file_name() == ".gitignore" && entry.path().is_file() {
-            gitignore_files.push(entry.path().to_path_buf());
-        }
-    }
+        .threads(matcher_walk_thread_count())
+        .build_parallel();
+
+    let gitignore_files = std::sync::Mutex::new(Vec::<std::path::PathBuf>::new());
+    walker.run(|| {
+        let found = &gitignore_files;
+        Box::new(move |entry| {
+            if let Ok(entry) = entry
+                && entry.file_name() == ".gitignore"
+                && entry.path().is_file()
+            {
+                // Ignore poisoning: a panic in another worker must not
+                // cascade into every remaining thread.
+                found
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(entry.path().to_path_buf());
+            }
+            ignore::WalkState::Continue
+        })
+    });
+
+    // Sorting is not needed for correctness: `IgnoreMatcher::with_nested`
+    // re-sorts deepest-first, which is what actually establishes git's
+    // between-level precedence, and its remaining ties are same-depth
+    // same-length directories that anchor to disjoint subtrees and so can
+    // never both match one path. But that re-sort is *stable*, so leaving
+    // the input in parallel-completion order would let the built matcher
+    // vary run to run. Sorting here keeps builds reproducible, for a few
+    // hundred paths' worth of cost.
+    let mut gitignore_files = gitignore_files
+        .into_inner()
+        .unwrap_or_else(|e| e.into_inner());
+    gitignore_files.sort();
 
     matcher_from_gitignore_paths(root, &gitignore_files)
 }

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -341,22 +341,33 @@ impl HybridIndex {
         Vec<String>,
         std::collections::HashMap<u32, Vec<PostingEntry>>,
     ) {
+        use rayon::prelude::*;
         use std::collections::HashMap;
 
         let reader = self.reader();
 
         // Phase 1: Build merged file list (reader files not in overlay + overlay files)
         let mut paths: Vec<String> = Vec::new();
-        let mut reader_id_map: HashMap<u32, u32> = HashMap::new();
 
-        // Add reader files (skip those superseded by overlay or deleted)
-        for (old_id, path) in reader.all_paths().iter().enumerate() {
-            let old_id = old_id as u32;
+        // Add reader files (skip those superseded by overlay or deleted).
+        //
+        // The old -> new id table is a dense `Vec` rather than a `HashMap`
+        // because it is consulted once per *posting entry*, and there are
+        // hundreds of millions of those (170M for a 94k-file tree). Reader ids
+        // are exactly the contiguous range `0..num_files`, so an index into a
+        // Vec replaces a hash of a random u32 — and the lookups then run in
+        // file-id order within each posting list, which is sequential rather
+        // than scattered. `DROPPED` marks a reader file the overlay supersedes
+        // or deletes.
+        const DROPPED: u32 = u32::MAX;
+        let reader_paths = reader.all_paths();
+        let mut reader_id_map: Vec<u32> = Vec::with_capacity(reader_paths.len());
+        for path in reader_paths {
             if self.live.is_deleted(path) || self.live.has_path(path) {
-                continue; // superseded or deleted
+                reader_id_map.push(DROPPED);
+                continue;
             }
-            let new_id = paths.len() as u32;
-            reader_id_map.insert(old_id, new_id);
+            reader_id_map.push(paths.len() as u32);
             paths.push(path.clone());
         }
 
@@ -369,27 +380,30 @@ impl HybridIndex {
             paths.push(op.to_string());
         }
 
-        // Phase 2: Build merged inverted index with masks
-        let mut inverted: HashMap<u32, Vec<PostingEntry>> = HashMap::new();
-
-        // Reader trigram postings with masks (remapped, excluding superseded files)
-        for (trigram, posting) in reader.all_trigram_postings_with_masks() {
-            let remapped: Vec<PostingEntry> = posting
-                .into_iter()
-                .filter_map(|entry| {
-                    reader_id_map
-                        .get(&entry.file_id)
-                        .map(|&new_id| PostingEntry {
+        // Phase 2: Build merged inverted index with masks.
+        //
+        // Decode and remap in one parallel pass. Collecting the decoded index
+        // first and then transforming it would hold two full copies of every
+        // posting entry at once — for a 94k-file tree that is ~170M entries,
+        // and the flush is exactly when memory is most contended.
+        let mut inverted: HashMap<u32, Vec<PostingEntry>> = (0..reader.num_trigrams())
+            .into_par_iter()
+            .filter_map(|i| {
+                let (trigram, posting) = reader.trigram_posting_at(i);
+                let remapped: Vec<PostingEntry> = posting
+                    .into_iter()
+                    .filter_map(|entry| {
+                        let new_id = *reader_id_map.get(entry.file_id as usize)?;
+                        (new_id != DROPPED).then_some(PostingEntry {
                             file_id: new_id,
                             loc_mask: entry.loc_mask,
                             next_mask: entry.next_mask,
                         })
-                })
-                .collect();
-            if !remapped.is_empty() {
-                inverted.entry(trigram).or_default().extend(remapped);
-            }
-        }
+                    })
+                    .collect();
+                (!remapped.is_empty()).then_some((trigram, remapped))
+            })
+            .collect();
 
         // Overlay trigram postings with masks (remapped)
         // Trigram keys in the live inverted index never have OVERLAY_BIT set
@@ -416,10 +430,16 @@ impl HybridIndex {
             }
         }
 
-        // Sort all posting lists by file_id
-        for posting in inverted.values_mut() {
-            posting.sort_by_key(|e| e.file_id);
-        }
+        // Sort all posting lists by file_id.
+        //
+        // Only trigrams the overlay touched are actually out of order — the
+        // reader's own lists are already sorted and the remap preserves that,
+        // since new ids are assigned in ascending old-id order. Sorting the lot
+        // anyway keeps the invariant obvious and, fanned out across cores,
+        // costs little next to the merge itself.
+        inverted.par_iter_mut().for_each(|(_, posting)| {
+            posting.sort_unstable_by_key(|e| e.file_id);
+        });
 
         (paths, inverted)
     }

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -284,16 +284,29 @@ impl IndexReader {
         result
     }
 
+    /// Decode the `i`-th trigram entry (ascending trigram order) with its full
+    /// posting list, including masks.
+    ///
+    /// Paired with [`Self::num_trigrams`] this lets a caller drive the decode
+    /// itself — across threads, and fused with its own per-entry transform, so
+    /// the whole index never has to be materialised on the heap just to be
+    /// walked once. That matters: a 94k-file tree carries ~170M posting
+    /// entries, so collecting them all first costs both the allocation and a
+    /// second copy in whatever the caller builds next.
+    pub fn trigram_posting_at(&self, i: usize) -> (u32, Vec<PostingEntry>) {
+        let entry = self.read_lookup_entry(i);
+        (
+            entry.trigram,
+            self.read_posting_entries(entry.offset, entry.length),
+        )
+    }
+
     /// Iterate all trigram entries with full posting data (including masks).
     /// Returns (trigram_hash, Vec<PostingEntry>) preserving loc_mask/next_mask.
     pub fn all_trigram_postings_with_masks(&self) -> Vec<(u32, Vec<PostingEntry>)> {
-        let mut result = Vec::with_capacity(self.num_entries);
-        for i in 0..self.num_entries {
-            let entry = self.read_lookup_entry(i);
-            let postings = self.read_posting_entries(entry.offset, entry.length);
-            result.push((entry.trigram, postings));
-        }
-        result
+        (0..self.num_entries)
+            .map(|i| self.trigram_posting_at(i))
+            .collect()
     }
 
     fn binary_search(&self, trigram: u32) -> Option<usize> {

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -32,6 +32,10 @@ fn should_skip_dir(entry: &ignore::DirEntry, exclude_dirs: &[String]) -> bool {
 pub struct WalkResult {
     pub files: Vec<PathBuf>,
     pub gitignore_files: Vec<PathBuf>,
+    /// `.ignore` files encountered during the walk. Kept separate from
+    /// `gitignore_files` so a matcher can apply them last, giving them
+    /// precedence over `.gitignore` — the `ignore` crate's own ordering.
+    pub ignore_files: Vec<PathBuf>,
     pub skipped_binary: usize,
     pub skipped_error: usize,
 }
@@ -41,7 +45,8 @@ pub struct WalkOptions {
     pub include_hidden: bool,
     pub no_ignore: bool,
     pub search_binary: bool,
-    /// Collect `.gitignore` file paths encountered during the walk.
+    /// Collect `.gitignore` and `.ignore` file paths encountered during the
+    /// walk (into `WalkResult::gitignore_files` / `WalkResult::ignore_files`).
     pub collect_gitignore_files: bool,
     /// Directory names to exclude from walking (e.g., "vendor", "third_party").
     pub exclude_dirs: Vec<String>,
@@ -66,6 +71,7 @@ fn is_binary_extension(path: &Path) -> bool {
 pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
     let files = std::sync::Mutex::new(Vec::new());
     let gitignore_files = std::sync::Mutex::new(Vec::new());
+    let ignore_files = std::sync::Mutex::new(Vec::new());
     let skipped_binary = std::sync::atomic::AtomicUsize::new(0);
     let skipped_error = std::sync::atomic::AtomicUsize::new(0);
     let exclude_dirs: std::sync::Arc<Vec<String>> = std::sync::Arc::new(opts.exclude_dirs.clone());
@@ -81,10 +87,7 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
 
     let mut builder = WalkBuilder::new(&root);
     builder
-        // When collecting .gitignore paths, keep hidden entries visible to the
-        // walker and apply hidden filtering below so .gitignore files are seen
-        // while hidden directories/files still match normal index behavior.
-        .hidden(!include_hidden && !collect_gitignore_files)
+        .hidden(!include_hidden)
         .git_ignore(!opts.no_ignore)
         .git_global(!opts.no_ignore)
         .git_exclude(!opts.no_ignore)
@@ -108,9 +111,9 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
 
     walker.run(|| {
         let exclude = exclude_dirs.clone();
-        let root = root.clone();
         let files = &files;
         let gitignore_files = &gitignore_files;
+        let ignore_files = &ignore_files;
         let skipped_binary = &skipped_binary;
         let skipped_error = &skipped_error;
         Box::new(move |entry| {
@@ -123,18 +126,21 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
             };
 
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                if collect_gitignore_files
-                    && entry.path() != root
-                    && !include_hidden
-                    && entry
-                        .file_name()
-                        .to_str()
-                        .is_some_and(|name| name.starts_with('.'))
-                {
-                    return ignore::WalkState::Skip;
-                }
                 if should_skip_dir(&entry, &exclude) {
                     return ignore::WalkState::Skip;
+                }
+                // Probe each directory we descend into for its ignore files
+                // instead of collecting the ones the walk yields, which omits
+                // any ignore file matched by its own rules. See
+                // `gitignore::ignore_files_in`.
+                if collect_gitignore_files {
+                    let (gitignore, dot_ignore) = crate::gitignore::ignore_files_in(entry.path());
+                    if let Some(path) = gitignore {
+                        gitignore_files.lock().unwrap().push(path);
+                    }
+                    if let Some(path) = dot_ignore {
+                        ignore_files.lock().unwrap().push(path);
+                    }
                 }
                 return ignore::WalkState::Continue;
             }
@@ -144,23 +150,6 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
             }
 
             let path = entry.path();
-
-            if collect_gitignore_files && entry.file_name() == ".gitignore" {
-                gitignore_files.lock().unwrap().push(path.to_path_buf());
-                if !include_hidden {
-                    return ignore::WalkState::Continue;
-                }
-            }
-
-            if collect_gitignore_files
-                && !include_hidden
-                && entry
-                    .file_name()
-                    .to_str()
-                    .is_some_and(|name| name.starts_with('.'))
-            {
-                return ignore::WalkState::Continue;
-            }
 
             if !search_binary {
                 if is_binary_extension(path) {
@@ -184,18 +173,23 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
     WalkResult {
         files: files.into_inner().unwrap(),
         gitignore_files: gitignore_files.into_inner().unwrap(),
+        ignore_files: ignore_files.into_inner().unwrap(),
         skipped_binary: skipped_binary.into_inner(),
         skipped_error: skipped_error.into_inner(),
     }
 }
 
-/// Build a point-query gitignore matcher from `.gitignore` files discovered by
-/// an existing walk, avoiding a second full-tree discovery pass.
+/// Build a point-query ignore matcher from `.gitignore` and `.ignore` files
+/// discovered by an existing walk, avoiding a second full-tree discovery pass.
+///
+/// `.ignore` is applied after `.gitignore` so it takes precedence, matching the
+/// `ignore` crate's ordering in the indexing walk.
 pub fn build_gitignore_matcher_from_files(
     root: &Path,
     gitignore_files: &[PathBuf],
+    ignore_files: &[PathBuf],
 ) -> Option<crate::gitignore::IgnoreMatcher> {
-    crate::gitignore::matcher_from_gitignore_paths(root, gitignore_files)
+    crate::gitignore::matcher_from_ignore_paths(root, gitignore_files, ignore_files)
 }
 
 /// Filesystem metadata for a single file (no content read).
@@ -205,19 +199,37 @@ pub struct FileMeta {
     pub size: u64,
 }
 
-/// Walk a directory tree collecting only filesystem metadata (mtime, size).
-/// No file content is read — this is used for stale file detection on startup.
-pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String], no_ignore: bool) -> Vec<FileMeta> {
+/// Result of [`walk_file_metadata`]: per-file metadata plus the `.gitignore` /
+/// `.ignore` files discovered along the way, from which a watcher ignore
+/// matcher can be built (see [`build_gitignore_matcher_from_files`]) without a
+/// second full-tree walk.
+pub struct MetaWalkResult {
+    pub files: Vec<FileMeta>,
+    pub gitignore_files: Vec<PathBuf>,
+    pub ignore_files: Vec<PathBuf>,
+}
+
+/// Walk a directory tree collecting filesystem metadata (mtime, size) plus the
+/// `.gitignore` / `.ignore` files encountered. No file content is read — this
+/// is used for stale file detection on startup.
+///
+/// Hidden entries are visited so dot-files like `.gitignore` / `.ignore` are
+/// seen, but dot-*directories* are skipped and dot-files are excluded from
+/// `files`, so the metadata set still matches a hidden-skipping walk.
+pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String], no_ignore: bool) -> MetaWalkResult {
     let results = std::sync::Mutex::new(Vec::new());
+    let gitignore_files = std::sync::Mutex::new(Vec::new());
+    let ignore_files = std::sync::Mutex::new(Vec::new());
     let exclude: std::sync::Arc<Vec<String>> = std::sync::Arc::new(exclude_dirs.to_vec());
     let p4ignore = (!no_ignore)
         .then(|| crate::gitignore::build_p4ignore_matcher(root))
         .flatten()
         .map(std::sync::Arc::new);
     let match_root = root.to_path_buf();
+    let root = root.to_path_buf();
 
-    let walker = WalkBuilder::new(root)
-        .hidden(true) // skip hidden by default
+    let walker = WalkBuilder::new(&root)
+        .hidden(true)
         .git_ignore(!no_ignore)
         .git_global(!no_ignore)
         .git_exclude(!no_ignore)
@@ -238,7 +250,10 @@ pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String], no_ignore: bool)
 
     walker.run(|| {
         let exclude = exclude.clone();
+        let root = root.clone();
         let results = &results;
+        let gitignore_files = &gitignore_files;
+        let ignore_files = &ignore_files;
         Box::new(move |entry| {
             let entry = match entry {
                 Ok(e) => e,
@@ -248,6 +263,16 @@ pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String], no_ignore: bool)
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
                 if should_skip_dir(&entry, &exclude) {
                     return ignore::WalkState::Skip;
+                }
+                // Probing each descended directory finds ignore files the walk
+                // itself filters out; see `gitignore::ignore_files_in`. It also
+                // keeps `hidden(true)` intact, so the metadata set is unchanged.
+                let (gitignore, dot_ignore) = crate::gitignore::ignore_files_in(entry.path());
+                if let Some(path) = gitignore {
+                    gitignore_files.lock().unwrap().push(path);
+                }
+                if let Some(path) = dot_ignore {
+                    ignore_files.lock().unwrap().push(path);
                 }
                 return ignore::WalkState::Continue;
             }
@@ -262,7 +287,7 @@ pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String], no_ignore: bool)
                 return ignore::WalkState::Continue;
             }
 
-            let rel_path = match path.strip_prefix(root) {
+            let rel_path = match path.strip_prefix(&root) {
                 Ok(p) => p.to_string_lossy().replace('\\', "/"),
                 Err(_) => return ignore::WalkState::Continue,
             };
@@ -288,7 +313,11 @@ pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String], no_ignore: bool)
         })
     });
 
-    results.into_inner().unwrap()
+    MetaWalkResult {
+        files: results.into_inner().unwrap(),
+        gitignore_files: gitignore_files.into_inner().unwrap(),
+        ignore_files: ignore_files.into_inner().unwrap(),
+    }
 }
 
 #[cfg(test)]
@@ -495,6 +524,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().join("testdata");
         fs::create_dir_all(root.join("src")).unwrap();
+        // `.gitignore` rules only apply inside a git repo.
+        fs::create_dir(root.join(".git")).unwrap();
         fs::write(root.join(".gitignore"), "*.log\n").unwrap();
         fs::write(root.join("src").join(".gitignore"), "*.tmp\n").unwrap();
 
@@ -505,8 +536,9 @@ mod tests {
                 ..Default::default()
             },
         );
-        let gi = build_gitignore_matcher_from_files(&root, &walk.gitignore_files)
-            .expect("matcher should build from discovered .gitignore files");
+        let gi =
+            build_gitignore_matcher_from_files(&root, &walk.gitignore_files, &walk.ignore_files)
+                .expect("matcher should build from discovered .gitignore files");
 
         assert!(gi.is_ignored(Path::new("build/output.log"), false));
         assert!(gi.is_ignored(Path::new("src/cache.tmp"), false));
@@ -514,12 +546,135 @@ mod tests {
     }
 
     #[test]
+    fn walk_dir_collects_dot_ignore_files_separately() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("testdata");
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join(".ignore"), "*.log\n").unwrap();
+        fs::write(root.join("src").join(".ignore"), "*.tmp\n").unwrap();
+        fs::write(root.join("src").join("main.rs"), "fn main() {}\n").unwrap();
+
+        let result = walk_dir(
+            &root,
+            &WalkOptions {
+                collect_gitignore_files: true,
+                ..Default::default()
+            },
+        );
+        let mut ignores: Vec<_> = result
+            .ignore_files
+            .iter()
+            .map(|p| {
+                p.strip_prefix(&root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        ignores.sort();
+
+        // `.ignore` files are collected but not indexed, and stay out of
+        // `gitignore_files` so precedence can be applied.
+        assert_eq!(sorted_filenames(&result, &root), vec!["src/main.rs"]);
+        assert_eq!(ignores, vec![".ignore", "src/.ignore"]);
+        assert!(result.gitignore_files.is_empty());
+    }
+
+    #[test]
+    fn dot_ignore_applies_without_a_git_repo() {
+        // No `.git`, so `.gitignore` is inert but `.ignore` still applies —
+        // this is what the indexing walk does.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("testdata");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join(".ignore"), "*.log\nbuild/\n").unwrap();
+        fs::write(root.join(".gitignore"), "*.rs\n").unwrap();
+
+        let walk = walk_dir(
+            &root,
+            &WalkOptions {
+                collect_gitignore_files: true,
+                ..Default::default()
+            },
+        );
+        let gi =
+            build_gitignore_matcher_from_files(&root, &walk.gitignore_files, &walk.ignore_files)
+                .expect("matcher should build from discovered .ignore files");
+
+        assert!(gi.is_ignored(Path::new("server/output.log"), false));
+        assert!(gi.is_ignored(Path::new("build/artifact.bin"), false));
+        // Git-gated: no `.git`, so the `.gitignore` rule must not apply.
+        assert!(!gi.is_ignored(Path::new("src/main.rs"), false));
+    }
+
+    #[test]
+    fn gitignore_applies_in_subdir_of_git_repo() {
+        // `.git` lives in an ancestor of `root`, not `root` itself, as when
+        // serving a subdirectory of a repository.
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join(".git")).unwrap();
+        let root = tmp.path().join("sub");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+
+        let walk = walk_dir(
+            &root,
+            &WalkOptions {
+                collect_gitignore_files: true,
+                ..Default::default()
+            },
+        );
+        let gi =
+            build_gitignore_matcher_from_files(&root, &walk.gitignore_files, &walk.ignore_files)
+                .expect("`.gitignore` should apply in a subdirectory of a git repo");
+        assert!(gi.is_ignored(Path::new("build/out.log"), false));
+    }
+
+    #[test]
+    fn walk_file_metadata_collects_ignore_files_but_omits_them_from_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("testdata");
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        fs::write(root.join(".ignore"), "*.tmp\n").unwrap();
+        fs::write(root.join("src").join(".ignore"), "*.bak\n").unwrap();
+        fs::write(root.join("src").join("main.rs"), "fn main() {}\n").unwrap();
+
+        let result = walk_file_metadata(&root, &[], false);
+
+        // The dot-files themselves stay out of the metadata set, exactly as
+        // they did under the previous `hidden(true)` walk.
+        let names: Vec<_> = result
+            .files
+            .iter()
+            .map(|f| f.relative_path.as_str())
+            .collect();
+        assert_eq!(names, vec!["src/main.rs"]);
+
+        let rel = |v: &[PathBuf]| {
+            let mut out: Vec<_> = v
+                .iter()
+                .map(|p| {
+                    p.strip_prefix(&root)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/")
+                })
+                .collect();
+            out.sort();
+            out
+        };
+        assert_eq!(rel(&result.gitignore_files), vec![".gitignore"]);
+        assert_eq!(rel(&result.ignore_files), vec![".ignore", "src/.ignore"]);
+    }
+
+    #[test]
     fn walk_file_metadata_excludes_dirs() {
         let dir = setup_fixture();
         let root = dir.path().join("testdata");
 
-        let all = walk_file_metadata(&root, &[], false);
-        let excluded = walk_file_metadata(&root, &["vendor".to_string()], false);
+        let all = walk_file_metadata(&root, &[], false).files;
+        let excluded = walk_file_metadata(&root, &["vendor".to_string()], false).files;
 
         assert!(all.iter().any(|f| f.relative_path.starts_with("vendor/")));
         assert!(
@@ -546,7 +701,7 @@ mod tests {
         assert!(!names.contains(&"third_party/lib.rs".to_string()));
         assert!(names.contains(&"src/main.rs".to_string()));
 
-        let metadata = walk_file_metadata(&root, &[], false);
+        let metadata = walk_file_metadata(&root, &[], false).files;
         assert!(
             !metadata
                 .iter()
@@ -578,7 +733,7 @@ mod tests {
                 .any(|name| name == "vendor/dep.rs")
         );
 
-        let metadata = walk_file_metadata(&root, &[], true);
+        let metadata = walk_file_metadata(&root, &[], true).files;
         assert!(
             metadata
                 .iter()

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -16,7 +16,11 @@ const BINARY_EXTENSIONS: &[&str] = &[
 ];
 
 /// Number of parallel walker threads (capped at 12 to avoid diminishing returns).
-fn walker_thread_count() -> usize {
+///
+/// Shared with the `.gitignore` enumeration walk in [`crate::gitignore`] so both
+/// full-tree walks stay in lock-step: they traverse the same trees under the
+/// same I/O constraints, so tuning one without the other would be a bug.
+pub(crate) fn walker_thread_count() -> usize {
     std::thread::available_parallelism().map_or(4, |n| n.get().min(12))
 }
 
@@ -213,9 +217,10 @@ pub struct MetaWalkResult {
 /// `.gitignore` / `.ignore` files encountered. No file content is read — this
 /// is used for stale file detection on startup.
 ///
-/// Hidden entries are visited so dot-files like `.gitignore` / `.ignore` are
-/// seen, but dot-*directories* are skipped and dot-files are excluded from
-/// `files`, so the metadata set still matches a hidden-skipping walk.
+/// Hidden entries are skipped, matching the indexing walk. Ignore files are
+/// still found because every directory the walk descends into is probed
+/// explicitly via [`crate::gitignore::ignore_files_in`], which also catches
+/// ignore files that their own rules would have filtered out of the walk.
 pub fn walk_file_metadata(root: &Path, exclude_dirs: &[String], no_ignore: bool) -> MetaWalkResult {
     let results = std::sync::Mutex::new(Vec::new());
     let gitignore_files = std::sync::Mutex::new(Vec::new());


### PR DESCRIPTION
## Summary

Three related changes to how tgrep discovers and applies ignore rules, and how the file watcher consumes events. Supersedes #88 and #89 — both are incorporated here, adapted to the current architecture.

### 1. Parallelize the gitignore matcher walk

`gitignore::build_matcher` enumerated `.gitignore` files with a single-threaded `WalkBuilder`. The walk is almost pure I/O wait, so one thread serialized every directory read. Everything in `walker.rs` had used `build_parallel()` for a long time; this was the last serial full-tree walk.

The cost was extreme on large or network-backed trees. From a user's trace on a 285k-file repo on a network drive:

```
[trace] gitignore matcher build complete in 205485.7ms
[trace] stale check: ... (walk: 1611ms)
```

Both traversed the same tree, seconds apart — a ~128× gap that is entirely thread count.

### 2. Honor `.ignore` files (supersedes #88)

The walker now collects `.ignore` alongside `.gitignore`, and `IgnoreMatcher` applies both. Where the two collide, `.ignore` wins — within a directory via the nested sort, and at the root by being added last.

`.gitignore` is now **git-gated**, matching the indexing walk's `require_git` default: it applies only inside a repository. Without this the watcher could filter on rules the indexer never applied. `.ignore` applies either way.

### 3. Process watcher events off-thread (supersedes #89)

Events are handed to a worker thread over a bounded queue rather than indexed inside the `notify` callback. That callback runs on the platform's notification thread — on Windows it owns a fixed-size `ReadDirectoryChangesW` buffer — so doing file I/O and trigram extraction there stalls it, and everything arriving meanwhile is dropped by the OS with no error we can observe.

On overflow, events are dropped deliberately and reconciled with a stale check once the burst drains (a quiet interval, so one overflow doesn't trigger a stale check per queued event). The bound is configurable via `--watcher-queue-cap`, default 16384.

## Why these couldn't be replayed as written

Both PRs predate the current nested `IgnoreMatcher`, and #88's flat root-anchored `Gitignore` would have regressed nested anchoring — its own description admits the mis-anchoring. Its `.ignore` idea is grafted onto `IgnoreMatcher` instead.

More seriously, **#88 deletes `build_gitignore_matcher_after_ready`, which is now also called from the ignore-rules-dirty loop** added after that PR was opened. Applying it unchanged would have silently broken runtime `.gitignore` reloads. Both call sites now route through `background_refresh_stale`.

## Bonus: one fewer full-tree walk on warm start

Warm start built the matcher with its own full-tree walk and then walked *again* for the stale check. The matcher is now built from the stale walk's results, so the second traversal is gone. This also required hoisting the walk above `background_refresh_stale`'s early returns, so `gitignore_pending` is released even when the index turns out to be up to date.

## Bug found while testing: self-ignoring ignore files were dropped

An ignore file matched by its own rules — the common `build/.gitignore` containing `*` — is filtered out of the walk's own output, so collecting the ignore files a walk *yields* silently drops it. The indexer still skipped the subtree (the walker reads the file even when it won't emit it), but the matcher built from those paths did not know about it, so **the watcher would index a subtree the indexer deliberately excluded** — exactly the divergence `should_skip_watcher_path` exists to prevent.

Walks now probe each directory they descend into instead. That is also complete (a `.gitignore` only matters when the walk descends into its directory, and every such directory is yielded) and duplicate-free.

This was masked in tests because the fixtures had no `.git` directory, which made the walker's own gitignore filtering inert.

## Measurements

Warm start against a 94,634-file tree (403 `.gitignore` files), pre-built index:

| | before | after |
|---|---|---|
| serial matcher walk | 1942.8ms | — |
| parallel matcher walk (separate) | 616.0ms | — |
| matcher build from stale walk | — | **80.4ms** |
| stale-check walk | 329ms | 342ms |
| **full-tree traversals** | **2** | **1** |

Stale check reports the same 94,637 files before and after, confirming the metadata walk's result set is unchanged.

## Verification

- Full suite green (267 tests), clippy clean with `-D warnings`.
- Parallel vs serial collection A/B-diffed on a real 94k-file tree via a temporary dump: 403 paths each, byte-identical.
- New end-to-end test `watcher_dot_ignore.rs` asserts a file under an `.ignore`d directory is never indexed *and* that an ordinary file created at the same moment is — the second assertion keeps a watcher that simply stopped working from passing the first. Confirmed non-vacuous by disabling `.ignore` support and watching it fail.
- New unit test for the self-ignoring `build/.gitignore` case.
- Smoke-tested on a real tree; the single-walk warm start and the watcher gate behave as intended.

## Note on ordering

An earlier draft of this description claimed collection order affects ignore precedence. That is wrong: `IgnoreMatcher::with_nested` already re-sorts deepest-first, which is what establishes git's between-level precedence. The explicit sort exists only because that re-sort is *stable*, so unsorted parallel-completion order would let the built matcher vary run to run.


---

## 4. Make index flush ~10× faster and halve its peak memory

Diagnosed from the same user trace, where a **single changed file** cost 38s to flush on a 2.7 GB index:

```
[trace] stale check: 1 changed, 0 new, 0 deleted (walk: 1611ms)
[trace] flush: snapshotted 285006 files in 38325.1ms
```

None of that is disk I/O — it is all `HybridIndex::full_snapshot` rebuilding the in-memory index before a byte is written. Three causes:

- **The old→new file id table was a `HashMap<u32, u32>`**, consulted once per posting entry. 170M random-u32 hashes cost 3.4s on their own. Reader ids are the contiguous range `0..num_files`, so a dense `Vec` indexes directly — and the lookups then run in file-id order, sequential rather than scattered.
- **The whole index was decoded into a `Vec<(u32, Vec<PostingEntry>)>` and only then remapped**, so every posting entry existed twice at peak (~1.4 GB × 2 on the tree below, ~7 GB at the user's scale). Decode and remap are now one fused pass, removing the intermediate copy.
- Both that pass and the final sort are per-trigram independent, so they now fan out across cores.

Measured on the linux kernel tree (94,634 files, 446,892 trigrams, 170,005,346 posting entries, 0.97 GB index), one changed file:

| phase | before | after |
|---|---|---|
| decode all postings | 1352.8ms | ┐ |
| remap reader postings | 3424.7ms | ┘ **479.6ms** (fused) |
| overlay merge | 344.7ms | 7.9ms |
| sort postings | 375.6ms | 26.7ms |
| **`full_snapshot`** | **5581.1ms** | **564.6ms** (9.9×) |
| **total flush** | **9.5s** | **2.5s** |

**Correctness check:** rebuilt the same tree from scratch and diffed search results against the incrementally-flushed index — identical output across six queries covering 64k+ hits (`scheduler_tick`, `EXPORT_SYMBOL_GPL`, `struct task_struct`, `kmalloc`, `spin_lock_irqsave`, `netdev_priv`).

### What this does *not* fix

It lowers the constant, not the complexity. A one-file change still costs O(entire index), because the bounded-heap stream merge in `append_overlay_to_index` requires append-only input, and a changed file **supersedes** a reader entry. Teaching that merge to skip superseded file ids would remove the whole-index work entirely — that is the real fix, and it is left as follow-up.

## 5. Fold watcher-recorded stamps into the stale-check baseline

Part of #89 that I initially and wrongly dismissed. `filestamps.json` only advances on flush, but the watcher updates `state.file_stamps` on every change, so mid-session the on-disk copy lags. An overflow-triggered stale check reading only the on-disk stamps re-indexes everything handled since the last flush — and a file created **and** deleted inside that window appears in neither the stamps nor the filesystem, so it is never classified as deleted and lingers in the index indefinitely. The in-memory stamps are the fresher record and now take precedence.
