### PR TITLE
Bound posting decode by index.bin, not by untrusted lookup.bin fields

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [fuzz_trigram, fuzz_query, fuzz_ondisk]
+        target: [fuzz_trigram, fuzz_query, fuzz_ondisk, fuzz_reader]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "0.1.4"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "ignore",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -35,3 +35,9 @@ name = "fuzz_ondisk"
 path = "fuzz_targets/fuzz_ondisk.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_reader"
+path = "fuzz_targets/fuzz_reader.rs"
+test = false
+doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -16,6 +16,7 @@ cargo install cargo-fuzz
 | `fuzz_trigram` | Trigram extraction, mask generation, binary detection |
 | `fuzz_query` | Regex → query plan decomposition (arbitrary patterns) |
 | `fuzz_ondisk` | On-disk format encode/decode roundtrips |
+| `fuzz_reader` | `IndexReader` against arbitrary `lookup.bin`/`index.bin`/`files.bin` bytes |
 
 ## Running
 
@@ -26,6 +27,7 @@ cd fuzz
 cargo fuzz run fuzz_trigram
 cargo fuzz run fuzz_query
 cargo fuzz run fuzz_ondisk
+cargo fuzz run fuzz_reader
 
 # Run with a time limit (e.g., 60 seconds)
 cargo fuzz run fuzz_trigram -- -max_total_time=60

--- a/fuzz/fuzz_targets/fuzz_reader.rs
+++ b/fuzz/fuzz_targets/fuzz_reader.rs
@@ -1,0 +1,100 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::path::PathBuf;
+use tgrep_core::reader::IndexReader;
+
+/// Fuzz the mmap-backed on-disk reader against arbitrary index bytes.
+///
+/// `fuzz_ondisk` only round-trips `PostingEntry` encode/decode, so nothing
+/// reaches `IndexReader` itself — yet that is where untrusted values do damage.
+/// The `offset` (u64) and `length` (u32) fields of a `lookup.bin` entry are the
+/// loop bound and the slice base for decoding `index.bin`, so a corrupt pair
+/// there is what turns a bad file into a panic, an out-of-range slice, or a
+/// multi-gigabyte reservation.
+///
+/// Byte layout the fuzzer is steering (see `tgrep-core/src/ondisk.rs`):
+///   lookup.bin  16-byte records: trigram(u32 LE) offset(u64 LE) length(u32 LE)
+///   index.bin    6-byte records: file_id(u32 LE) loc_mask(u8) next_mask(u8)
+///   files.bin   var records:     file_id(u32 LE) path_len(u16 LE) path bytes
+const POSTING_ENTRY_SIZE: usize = 6;
+
+/// Keep one iteration cheap: the target writes three files and then decodes
+/// every section it wrote, so cost is linear in the input.
+const MAX_INPUT: usize = 8 * 1024;
+
+/// Cap the per-entry decode loop so a lookup table full of maximal `length`
+/// values can't dominate an iteration. `validate_lookup` still walks all of it.
+const MAX_ENTRIES_DECODED: usize = 64;
+
+/// One scratch directory per fuzzer process, reused across iterations. The
+/// reader is dropped at the end of each run, releasing its mmaps before the
+/// next iteration overwrites the files.
+fn index_dir() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tgrep_fuzz_reader_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create scratch index dir");
+    dir
+}
+
+/// Carve the input into the three files of an index. The leading byte steers
+/// how much lands in `lookup.bin` — the section holding the untrusted
+/// offset/length pairs — versus `index.bin`, so the fuzzer can reach both
+/// "pointer far past a tiny postings region" and "huge postings, tiny table".
+fn split(data: &[u8]) -> (&[u8], &[u8], &[u8]) {
+    let Some((control, rest)) = data.split_first() else {
+        return (&[], &[], &[]);
+    };
+    let lookup_len = (*control as usize) * rest.len() / 256;
+    let (lookup, rest) = rest.split_at(lookup_len.min(rest.len()));
+    // files.bin is the least interesting section here, so give it a slice small
+    // enough that most of the budget stays on the lookup/postings pair.
+    let files_len = rest.len() / 8;
+    let (postings, files) = rest.split_at(rest.len() - files_len);
+    (lookup, postings, files)
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > MAX_INPUT {
+        return;
+    }
+    let dir = index_dir();
+    let (lookup, postings, files) = split(data);
+    std::fs::write(dir.join("lookup.bin"), lookup).expect("write lookup.bin");
+    std::fs::write(dir.join("index.bin"), postings).expect("write index.bin");
+    std::fs::write(dir.join("files.bin"), files).expect("write files.bin");
+
+    // `open` rejects the structurally impossible (misaligned lookup.bin,
+    // truncated or non-dense files.bin) with `Error::IndexCorrupted`. Whatever
+    // it accepts must then survive arbitrary queries.
+    let Ok(reader) = IndexReader::open(&dir) else {
+        return;
+    };
+
+    // A pure diagnostic: reports corruption as an error, never by panicking.
+    let _ = reader.validate_lookup();
+
+    let max_decodable = postings.len() / POSTING_ENTRY_SIZE;
+    for i in 0..reader.num_trigrams().min(MAX_ENTRIES_DECODED) {
+        let (trigram, entries) = reader.trigram_posting_at(i);
+        // Every entry returned must have been decoded from inside index.bin,
+        // so the count is bounded by the file — never by the `length` field.
+        assert!(
+            entries.len() <= max_decodable,
+            "entry {i} decoded {} postings from a {}-byte index.bin",
+            entries.len(),
+            postings.len()
+        );
+        // The zero-copy path must agree about what is in range.
+        if let Some((_, raw)) = reader.nth_trigram_raw(i) {
+            assert!(raw.len() <= postings.len());
+        }
+        // Resolving the same trigram through binary search must also be safe.
+        let _ = reader.lookup_trigram_with_masks(trigram);
+    }
+
+    // Misses have to be clean too, including on an unsorted table where the
+    // binary search walks arbitrary entries.
+    for probe in [0u32, 1, u32::MAX / 2, u32::MAX] {
+        let _ = reader.lookup_trigram(probe);
+    }
+});

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -366,20 +366,57 @@ impl IndexReader {
         LookupEntry::decode(buf)
     }
 
+    /// Decode the posting entries a lookup entry points at.
+    ///
+    /// `offset` and `length` are read verbatim out of `lookup.bin`, so on a
+    /// corrupt or truncated index they are arbitrary and must not be trusted
+    /// to describe a range that exists. Two invariants are enforced here:
+    ///
+    /// * The range is validated against the mmap length *before* `offset` is
+    ///   narrowed to `usize`. Adding to a `usize` first and testing
+    ///   `pos + POSTING_ENTRY_SIZE <= postings.len()` is not merely incomplete,
+    ///   it is inverted: the sum wraps, so the further past the end `offset`
+    ///   sits, the smaller the wrapped sum and the more likely the guard is to
+    ///   accept it (`offset = u64::MAX` wraps to `POSTING_ENTRY_SIZE - 1` and
+    ///   then slices out of range). It also truncates rather than wraps on
+    ///   32-bit targets, which can fold an out-of-range offset back into the
+    ///   mapping and decode the wrong region.
+    /// * The trip count and the reserved capacity come from how many entries
+    ///   the postings mmap actually holds, never from `length`. Otherwise a
+    ///   corrupt `length` of `u32::MAX` reserves ~25 GiB and spins through
+    ///   4.29 billion iterations to produce nothing, even against a 60-byte
+    ///   `index.bin`.
+    ///
+    /// Entries past the end of the mapping are dropped, which preserves the
+    /// existing best-effort behaviour for a truncated index: this is the hot
+    /// query path and has no error channel. Callers that want corruption
+    /// surfaced as [`crate::Error::IndexCorrupted`] should run
+    /// [`Self::validate_lookup`] first, as `HybridIndex::open` and the server's
+    /// reader swap already do.
     fn read_posting_entries(&self, offset: u64, length: u32) -> Vec<PostingEntry> {
         let postings = match self.postings.as_ref() {
             Some(p) => p,
             None => return Vec::new(),
         };
-        let mut result = Vec::with_capacity(length as usize);
-        let start = offset as usize;
-        for i in 0..length as usize {
+        // Narrow only after the mmap length has vetted the value, so an offset
+        // wider than `usize` can never truncate into range on a 32-bit target.
+        let Ok(start) = usize::try_from(offset) else {
+            return Vec::new();
+        };
+        // `None` when `start` is past the end of the mapping — no entries.
+        let Some(remaining) = postings.len().checked_sub(start) else {
+            return Vec::new();
+        };
+        let count = (length as usize).min(remaining / POSTING_ENTRY_SIZE);
+        let mut result = Vec::with_capacity(count);
+        for i in 0..count {
+            // `count * POSTING_ENTRY_SIZE <= remaining` and
+            // `start + remaining == postings.len()`, so both `start + i * SIZE`
+            // and its `+ SIZE` end stay within the mapping without overflow.
             let pos = start + i * POSTING_ENTRY_SIZE;
-            if pos + POSTING_ENTRY_SIZE <= postings.len() {
-                let buf: &[u8; POSTING_ENTRY_SIZE] =
-                    postings[pos..pos + POSTING_ENTRY_SIZE].try_into().unwrap();
-                result.push(PostingEntry::decode(buf));
-            }
+            let buf: &[u8; POSTING_ENTRY_SIZE] =
+                postings[pos..pos + POSTING_ENTRY_SIZE].try_into().unwrap();
+            result.push(PostingEntry::decode(buf));
         }
         result
     }
@@ -612,5 +649,152 @@ mod tests {
         write_index(tmp.path(), &[], &[], &[]);
         let reader = IndexReader::open(tmp.path()).unwrap();
         assert!(reader.validate_lookup().is_ok());
+    }
+
+    /// `n` posting entries with `file_id` 0..n so decoded content is checkable.
+    fn make_postings(n: u32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for file_id in 0..n {
+            buf.extend_from_slice(
+                &PostingEntry {
+                    file_id,
+                    loc_mask: 0xFF,
+                    next_mask: 0xFF,
+                }
+                .encode(),
+            );
+        }
+        buf
+    }
+
+    /// A single-entry `lookup.bin` pointing at an arbitrary (possibly corrupt)
+    /// posting range, so the reader's trust in `offset`/`length` can be probed
+    /// through the public API.
+    fn open_with_lookup(dir: &Path, trigram: u32, offset: u64, length: u32, postings: &[u8]) {
+        let lookup = LookupEntry {
+            trigram,
+            offset,
+            length,
+        }
+        .encode();
+        let files = ondisk::encode_file_entry(0, "a.rs").unwrap();
+        write_index(dir, &lookup, postings, &files);
+    }
+
+    #[test]
+    fn lookup_survives_offset_that_overflows_the_bounds_check() {
+        // `offset = u64::MAX` used to wrap `pos + POSTING_ENTRY_SIZE` around to
+        // a small value that passed the guard, then slice far out of range:
+        // "attempt to add with overflow" in debug, an out-of-range slice panic
+        // in release.
+        let tmp = TempDir::new().unwrap();
+        open_with_lookup(tmp.path(), 1, u64::MAX, 5, &make_postings(10));
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        assert!(reader.lookup_trigram_with_masks(1).is_empty());
+        // Every offset in the top of the u64 range must be rejected, not just
+        // the one that happens to wrap to zero.
+        for offset in [u64::MAX, u64::MAX - 1, u64::MAX - 5, u64::MAX / 2] {
+            let tmp = TempDir::new().unwrap();
+            open_with_lookup(tmp.path(), 1, offset, 5, &make_postings(10));
+            let reader = IndexReader::open(tmp.path()).unwrap();
+            assert!(
+                reader.lookup_trigram_with_masks(1).is_empty(),
+                "offset {offset} must decode to nothing"
+            );
+        }
+    }
+
+    #[test]
+    fn lookup_bounds_work_by_postings_len_not_declared_length() {
+        // `length = u32::MAX` used to reserve ~25 GiB and iterate 4.29 billion
+        // times against a 60-byte index.bin (~1.65 s release, ~55 s debug).
+        // Both the trip count and the reservation must derive from the mapping.
+        let tmp = TempDir::new().unwrap();
+        open_with_lookup(tmp.path(), 1, 0, u32::MAX, &make_postings(10));
+        let reader = IndexReader::open(tmp.path()).unwrap();
+
+        let started = std::time::Instant::now();
+        let entries = reader.lookup_trigram_with_masks(1);
+        let elapsed = started.elapsed();
+
+        assert_eq!(entries.len(), 10, "only the 10 entries on disk exist");
+        assert!(
+            entries.capacity() < 1_000,
+            "capacity {} must be bounded by index.bin, not by `length`",
+            entries.capacity()
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "decoding 10 entries took {elapsed:?}; work is scaling with `length`"
+        );
+    }
+
+    #[test]
+    fn lookup_with_offset_past_end_returns_empty() {
+        let postings = make_postings(10);
+        for offset in [postings.len() as u64, postings.len() as u64 + 1, 4096] {
+            let tmp = TempDir::new().unwrap();
+            open_with_lookup(tmp.path(), 1, offset, 5, &postings);
+            let reader = IndexReader::open(tmp.path()).unwrap();
+            assert!(
+                reader.lookup_trigram_with_masks(1).is_empty(),
+                "offset {offset} is not inside index.bin"
+            );
+        }
+    }
+
+    #[test]
+    fn lookup_clamps_length_to_the_entries_that_fit() {
+        // Truncated index.bin: the lookup entry claims 10 postings but only
+        // 4 whole entries follow the offset. Decode the 4, drop the rest.
+        let tmp = TempDir::new().unwrap();
+        let postings = make_postings(6);
+        open_with_lookup(tmp.path(), 1, 2 * POSTING_ENTRY_SIZE as u64, 10, &postings);
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        let ids: Vec<u32> = reader
+            .lookup_trigram_with_masks(1)
+            .into_iter()
+            .map(|e| e.file_id)
+            .collect();
+        assert_eq!(ids, vec![2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn lookup_with_offset_inside_a_partial_trailing_entry_returns_empty() {
+        // Offset lands 1 byte into the last entry, so no whole entry remains.
+        let tmp = TempDir::new().unwrap();
+        let postings = make_postings(2);
+        let offset = postings.len() as u64 - (POSTING_ENTRY_SIZE as u64 - 1);
+        open_with_lookup(tmp.path(), 1, offset, 4, &postings);
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        assert!(reader.lookup_trigram_with_masks(1).is_empty());
+    }
+
+    #[test]
+    fn lookup_still_returns_every_entry_of_a_well_formed_range() {
+        let tmp = TempDir::new().unwrap();
+        let postings = make_postings(10);
+        open_with_lookup(tmp.path(), 1, 0, 10, &postings);
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        let entries = reader.lookup_trigram_with_masks(1);
+        let ids: Vec<u32> = entries.iter().map(|e| e.file_id).collect();
+        assert_eq!(ids, (0..10).collect::<Vec<u32>>());
+        assert!(
+            entries
+                .iter()
+                .all(|e| e.loc_mask == 0xFF && e.next_mask == 0xFF)
+        );
+    }
+
+    #[test]
+    fn validate_lookup_reports_offset_that_overflows_the_range_math() {
+        // The loud-error counterpart: callers that validate up front (as
+        // `HybridIndex::open` does) get `IndexCorrupted` for the same entry
+        // the query path silently skips.
+        let tmp = TempDir::new().unwrap();
+        open_with_lookup(tmp.path(), 1, u64::MAX, 5, &make_postings(10));
+        let reader = IndexReader::open(tmp.path()).unwrap();
+        let err = reader.validate_lookup().unwrap_err();
+        assert!(err.contains("exceeds"), "expected bounds error, got: {err}");
     }
 }

--- a/tgrep-core/tests/corrupt_index_reader.rs
+++ b/tgrep-core/tests/corrupt_index_reader.rs
@@ -1,0 +1,205 @@
+//! `IndexReader` must survive a corrupt or truncated index.
+//!
+//! `lookup.bin` supplies the `offset` (u64) and `length` (u32) that drive
+//! decoding of `index.bin`: `offset` is the slice base and `length` is the loop
+//! bound. Neither is validated by the format itself, so on a damaged index they
+//! are arbitrary. Reading them naively is what made the reader panic on
+//! `offset = u64::MAX` (the bounds check `pos + 6 <= len` wraps, and wraps
+//! *downwards*, so the further out of range the offset the more likely it is to
+//! be accepted) and spin for tens of seconds on `length = u32::MAX`.
+//!
+//! This is the deterministic counterpart to the `fuzz_reader` fuzz target: it
+//! runs the same invariants over a fixed pseudo-random corpus plus the specific
+//! adversarial shapes, so the coverage exists in `cargo test` without needing a
+//! nightly toolchain and `cargo-fuzz`.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+use tgrep_core::reader::IndexReader;
+
+/// `lookup.bin` record: trigram(u32 LE) + offset(u64 LE) + length(u32 LE).
+const LOOKUP_ENTRY_SIZE: usize = 16;
+/// `index.bin` record: file_id(u32 LE) + loc_mask(u8) + next_mask(u8).
+const POSTING_ENTRY_SIZE: usize = 6;
+
+/// No single reader operation in this file should come close to this. The old
+/// unbounded loop took ~55 s in a debug build against a 60-byte `index.bin`.
+const BUDGET: Duration = Duration::from_secs(30);
+
+fn lookup_entry(trigram: u32, offset: u64, length: u32) -> Vec<u8> {
+    let mut v = Vec::with_capacity(LOOKUP_ENTRY_SIZE);
+    v.extend_from_slice(&trigram.to_le_bytes());
+    v.extend_from_slice(&offset.to_le_bytes());
+    v.extend_from_slice(&length.to_le_bytes());
+    v
+}
+
+fn postings_bytes(n: u32) -> Vec<u8> {
+    let mut v = Vec::with_capacity(n as usize * POSTING_ENTRY_SIZE);
+    for file_id in 0..n {
+        v.extend_from_slice(&file_id.to_le_bytes());
+        v.push(0xAA);
+        v.push(0x55);
+    }
+    v
+}
+
+/// `files.bin` record: file_id(u32 LE) + path_len(u16 LE) + path bytes. IDs must
+/// be dense from 0 or `open` rejects the table.
+fn files_bytes(n: u32) -> Vec<u8> {
+    let mut v = Vec::new();
+    for file_id in 0..n {
+        let path = format!("f{file_id}.rs");
+        v.extend_from_slice(&file_id.to_le_bytes());
+        v.extend_from_slice(&(path.len() as u16).to_le_bytes());
+        v.extend_from_slice(path.as_bytes());
+    }
+    v
+}
+
+fn write_index(dir: &Path, lookup: &[u8], postings: &[u8], files: &[u8]) {
+    std::fs::write(dir.join("lookup.bin"), lookup).unwrap();
+    std::fs::write(dir.join("index.bin"), postings).unwrap();
+    std::fs::write(dir.join("files.bin"), files).unwrap();
+}
+
+/// Exercise every read path the way `fuzz_reader` does, and assert the one
+/// invariant that matters: nothing decoded can exceed what `index.bin` holds.
+fn exercise(dir: &Path, postings_len: usize) {
+    let started = Instant::now();
+    let Ok(reader) = IndexReader::open(dir) else {
+        return; // structurally rejected up front — the loud path, also fine
+    };
+    let _ = reader.validate_lookup();
+
+    let max_decodable = postings_len / POSTING_ENTRY_SIZE;
+    for i in 0..reader.num_trigrams() {
+        let (trigram, entries) = reader.trigram_posting_at(i);
+        assert!(
+            entries.len() <= max_decodable,
+            "entry {i} decoded {} postings from a {postings_len}-byte index.bin",
+            entries.len()
+        );
+        assert!(
+            entries.capacity() <= max_decodable.max(1),
+            "entry {i} reserved capacity {} for at most {max_decodable} entries",
+            entries.capacity()
+        );
+        if let Some((_, raw)) = reader.nth_trigram_raw(i) {
+            assert!(raw.len() <= postings_len);
+        }
+        assert_eq!(reader.lookup_trigram(trigram).len(), entries.len());
+    }
+    for probe in [0u32, 1, u32::MAX / 2, u32::MAX] {
+        let _ = reader.lookup_trigram(probe);
+    }
+
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < BUDGET,
+        "reading a {postings_len}-byte index took {elapsed:?}; \
+         work is scaling with the untrusted `length` field"
+    );
+}
+
+/// The two shapes reported in the wild, plus the neighbours that probe the same
+/// arithmetic: offsets that wrap the bounds check, and lengths that dwarf the file.
+#[test]
+fn adversarial_lookup_entries_are_handled_without_panic_or_hang() {
+    let postings = postings_bytes(10);
+    let files = files_bytes(10);
+
+    let offsets = [
+        0,
+        1,
+        5,
+        postings.len() as u64 - 1,
+        postings.len() as u64,
+        postings.len() as u64 + 1,
+        u64::MAX,
+        u64::MAX - 1,
+        u64::MAX - POSTING_ENTRY_SIZE as u64,
+        u64::MAX / 2,
+        u32::MAX as u64,
+        1 << 40,
+    ];
+    let lengths = [0u32, 1, 5, 10, 11, 1 << 16, 1 << 31, u32::MAX - 1, u32::MAX];
+
+    let tmp = tempfile::tempdir().unwrap();
+    for offset in offsets {
+        for length in lengths {
+            write_index(
+                tmp.path(),
+                &lookup_entry(1, offset, length),
+                &postings,
+                &files,
+            );
+            exercise(tmp.path(), postings.len());
+        }
+    }
+}
+
+/// A lookup entry whose range is partly valid must still yield the prefix that
+/// genuinely fits — the fix must not turn graceful degradation into data loss.
+#[test]
+fn truncated_postings_still_yield_the_entries_that_fit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let postings = postings_bytes(6);
+    // Start at entry 2 and claim 100 entries; only 4 whole entries remain.
+    write_index(
+        tmp.path(),
+        &lookup_entry(1, 2 * POSTING_ENTRY_SIZE as u64, 100),
+        &postings,
+        &files_bytes(6),
+    );
+    let reader = IndexReader::open(tmp.path()).unwrap();
+    let ids: Vec<u32> = reader.lookup_trigram(1);
+    assert_eq!(ids, vec![2, 3, 4, 5]);
+    // ...and the same index is reported as corrupt by the validating path.
+    assert!(reader.validate_lookup().is_err());
+}
+
+/// Deterministic pseudo-random index bytes. Mirrors `fuzz_reader` so a
+/// regression is caught by `cargo test` even without a fuzzing run.
+#[test]
+fn random_index_bytes_never_panic() {
+    // xorshift64* — a fixed seed keeps failures reproducible.
+    let mut state = 0x2545_F491_4F6C_DD1Du64;
+    let mut next = move || {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        state.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    };
+
+    let tmp = tempfile::tempdir().unwrap();
+    for _ in 0..300 {
+        let num_entries = (next() % 8) as usize;
+        let num_postings = (next() % 12) as u32;
+        let postings = postings_bytes(num_postings);
+
+        let mut lookup = Vec::with_capacity(num_entries * LOOKUP_ENTRY_SIZE);
+        for i in 0..num_entries {
+            // Ascending trigrams keep the binary search meaningful; the offset
+            // and length are what we want arbitrary.
+            let trigram = (i as u32).wrapping_mul(7).wrapping_add(1);
+            let offset = match next() % 4 {
+                // Biased towards plausible-but-wrong values, since a uniformly
+                // random u64 is almost always trivially out of range.
+                0 => next() % (postings.len() as u64 + 8),
+                1 => u64::MAX - (next() % 8),
+                2 => next(),
+                _ => (next() % 8) * POSTING_ENTRY_SIZE as u64,
+            };
+            let length = match next() % 3 {
+                0 => (next() % 16) as u32,
+                1 => u32::MAX - (next() % 4) as u32,
+                _ => next() as u32,
+            };
+            lookup.extend_from_slice(&lookup_entry(trigram, offset, length));
+        }
+
+        write_index(tmp.path(), &lookup, &postings, &files_bytes(num_postings));
+        exercise(tmp.path(), postings.len());
+    }
+}


### PR DESCRIPTION
Fixes #98.

`IndexReader::read_posting_entries` used `offset` (u64) and `length` (u32) straight from `lookup.bin` as a slice base and a loop bound, without validating either. On a corrupt or truncated index that crashed or stalled the reader instead of degrading.

## The two defects

**1. The bounds check wrapped — and wrapped the wrong way.**

`pos + POSTING_ENTRY_SIZE <= postings.len()` computed `pos` in `usize`, so the sum wrapped. The failure mode is worse than an incomplete guard: a *larger* offset yields a *smaller* wrapped sum, so the further past the end the offset sits, the more likely the check is to accept it. `offset = u64::MAX` wraps to `5`, passes, and slices far out of range.

```
debug:    attempt to add with overflow
release:  range start index 18446744073709551615 out of range for slice of length 60
```

On a 32-bit target `offset as usize` truncates rather than wraps, which can fold an out-of-range offset back *into* the mapping and silently decode the wrong region.

**2. The trip count came from the file, not from the data.**

`length` bounded the loop and the reservation directly, so `length = u32::MAX` reserved ~25 GiB and iterated 4.29 billion times against a **60-byte** `index.bin` — ~1.65 s release, ~55 s debug — to produce nothing.

## The fix

Validate the range against the mmap length *before* narrowing to `usize`, and derive both the trip count and the reserved capacity from the bytes actually present. This is the same checked-`u64` discipline `nth_trigram_raw` and `validate_lookup` already use — `read_posting_entries` was the neighbouring function that never got it.

Out-of-range entries are still dropped rather than reported. This is the hot query path and has no error channel; callers that want corruption surfaced as `Error::IndexCorrupted` run `validate_lookup()` first, as `HybridIndex::open` and the server's reader swap already do (and which already rejects both of these inputs). Results for well-formed indexes are byte-for-byte unchanged, and a merely truncated index still yields the prefix that fits, exactly as before.

## Verification

I confirmed these are genuine regression tests by restoring the old body and re-running them:

```
lookup_survives_offset_that_overflows_the_bounds_check ... FAILED
  panicked at reader.rs:405: attempt to add with overflow

lookup_bounds_work_by_postings_len_not_declared_length ... FAILED
  capacity 4294967295 must be bounded by index.bin, not by `length`
  (test binary took 81s)
```

With the fix, both pass in microseconds. Full workspace suite: **280 passed, 0 failed**. `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` are clean.

## Coverage added

- **Unit tests** (`tgrep-core/src/reader.rs`) for both reported inputs, plus offsets past the end, an offset landing inside a partial trailing entry, clamping on a truncated `index.bin`, and an unchanged-output check for a well-formed range.
- **Integration test** (`tgrep-core/tests/corrupt_index_reader.rs`) replaying adversarial offset × length combinations and a deterministic pseudo-random corpus, asserting nothing decoded can exceed what `index.bin` holds.
- **`fuzz_reader` target.** The issue notes `fuzz_ondisk` never reaches this path — it only round-trips `PostingEntry` and extracts trigrams. The new target drives `IndexReader::open` plus every read path against arbitrary index bytes. Registered in `fuzz/Cargo.toml`, the README table, and the `fuzz.yml` matrix. It compiles clean, and the integration test above exercises the same invariants so they're validated at runtime without needing nightly + `cargo-fuzz`.

`fuzz/Cargo.lock` also picks up the stale `tgrep-core` version (`0.1.4` → `1.0.1`); `cargo fuzz` rewrites it on first run regardless.

Thanks to the reporter for the precise analysis — the observation that the guard is *inverted* rather than merely incomplete is what makes this worth fixing carefully rather than just adding a `checked_add`.