### PR TITLE
Read each file once, cap it at 64 MiB, and bound what serve holds in memory

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -20,18 +20,46 @@ Values below 1.0 mean ripgrep won.
 
 | Repo | Files | Queries | Windows | macOS | Linux |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| chromium/chromium | 503,731 | 30 | **14.9x** | **20.5x** | **3.1x** |
-| mozilla/gecko-dev | 387,841 | 122 | **46.4x** | **57.6x** | **8.5x** |
-| torvalds/linux | 95,531 | 102 | **19.7x** | **24.7x** | **5.2x** |
-| rust-lang/rust | 62,154 | 102 | **8.3x** | **1.49x** | **1.35x** |
-| kubernetes/kubernetes | 31,300 | 97 | **6.8x** | **2.4x** | **1.06x** |
-| golang/go | 15,818 | 103 | **5.2x** | **3.4x** | **1.21x** |
+| chromium/chromium | 503,903 | 30 | **13.5x** | **10.8x** | **2.36x** |
+| mozilla/gecko-dev | 387,841 | 122 | **34.8x** | **42.9x** | **7.5x** |
+| torvalds/linux | 95,776 | 102 | **25.1x** | **22.4x** | **5.5x** |
+| rust-lang/rust | 62,179 | 102 | **8.1x** | **1.78x** | **1.36x** |
+| kubernetes/kubernetes | 31,300 | 97 | **5.9x** | **1.72x** | **1.00x** |
+| golang/go | 15,826 | 103 | **6.2x** | **3.2x** | **1.34x** |
 
-All 18 cells were measured on GitHub-hosted runners (`windows-latest`, `macos-latest`,
-`ubuntu-latest`). Geometric mean speedup across the six repos: **12.6x on Windows,
-8.4x on macOS, 2.5x on Linux**. tgrep wins every cell; the narrowest is
-kubernetes on Linux at 1.1x. What separates a 1.1x cell from a 58x one is explained
-in [What decides the margin](#what-decides-the-margin).
+All 18 cells are from the complete 22 August 2026 sweep at `90a41a6`, measured on
+GitHub-hosted runners (`windows-latest`, `macos-latest`, `ubuntu-latest`). Every
+headline latency, ratio, file count, and primary run link in the repo sections
+below comes from that same sweep rather than mixing the latest totals with minima
+from older runs. Older runs are cited only to show the kernel suite's variance.
+Geometric mean speedup across the six repos is **12.3x on Windows, 6.8x on macOS,
+and 2.4x on Linux**. Kubernetes on Linux is effectively tied (1.004x); the largest
+margin is Gecko on macOS at 42.9x. See
+[What decides the margin](#what-decides-the-margin).
+
+Shared-runner results are not controlled-machine measurements. Compare tgrep with
+ripgrep **within a row**, not absolute milliseconds between workflow runs: CPU,
+storage and page-cache variance move both tools, particularly on macOS.
+
+### Index-build peak memory in the latest sweep
+
+The benchmark logs also record the indexer's OS high-water mark. Each cell shows
+the previously published sweep → the latest sweep, in MiB:
+
+| Repo | Windows | macOS | Linux |
+| --- | ---: | ---: | ---: |
+| chromium/chromium | 359.7 → **362.4** | 437.3 → **440.2** | 337.6 → **339.7** |
+| mozilla/gecko-dev | 304.8 → **304.5** | 396.2 → **359.7** | 271.7 → **273.4** |
+| torvalds/linux | 142.6 → **173.8** | 175.6 → **195.8** | 141.6 → **192.3** |
+| rust-lang/rust | 110.5 → **113.1** | 151.3 → **148.8** | 103.3 → **111.9** |
+| kubernetes/kubernetes | 113.3 → **115.5** | 150.8 → **148.5** | 112.6 → **120.2** |
+| golang/go | 106.7 → **105.4** | 123.0 → **126.5** | 115.1 → **114.4** |
+
+The kernel moved most because the latest build admits the 110 files that the old
+1 MiB default cap skipped; Chromium changed by only 2–3 MiB despite admitting
+more formerly capped files. These are peak working-set/RSS figures, so mapped
+file pages count even though the OS can reclaim them. They are not private bytes
+or heap usage.
 
 ---
 
@@ -343,242 +371,243 @@ baseline by about 51%.
 
 ## chromium/chromium (504K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32481343406)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32481339571)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580646448)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580644568)
 
-- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (503,731 files)
+- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (503,903 files)
 - **Queries**: 30 (mix of literals, multi-word, and regex)
-- **Index build time**: ~92s (Linux), ~125s (Windows), ~220s (macOS)
-- **Index size**: 2,559 MB (~2.6 GB)
+- **Index build time**: ~82s (Linux), ~142s (Windows), ~247s (macOS)
+- **Index size**: 2,581 MB (~2.6 GB)
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 757,862 | 25,262.1 | 0 |
-| tgrep (client → serve) | 50,706 | 1,690.2 | — |
+| ripgrep | 769,549 | 25,651.6 | 0 |
+| tgrep (client → serve) | 57,187 | 1,906.2 | — |
 
-**tgrep is ~15x faster**
+**tgrep is ~13.5x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 1,371,825 | 45,727.5 | 0 |
-| tgrep (client → serve) | 66,794 | 2,226.5 | — |
+| ripgrep | 1,046,616 | 34,887.2 | 0 |
+| tgrep (client → serve) | 97,204 | 3,240.1 | — |
 
-**tgrep is ~21x faster**
+**tgrep is ~10.8x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 71,312 | 2,377.1 | 0 |
-| tgrep (client → serve) | 22,868 | 762.3 | — |
+| ripgrep | 46,294 | 1,543.1 | 0 |
+| tgrep (client → serve) | 19,646 | 654.9 | — |
 
-**tgrep is ~3.1x faster**
+**tgrep is ~2.36x faster**
 
 ---
 
 ## mozilla/gecko-dev (388K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32481351626)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32481347580)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580650472)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580648298)
 
 - **Repo**: [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev) (387,841 files)
 - **Queries**: 122 (mix of C++, JavaScript, and Python patterns)
-- **Index build time**: ~69s (Linux), ~90s (Windows), ~160s (macOS)
-- **Index size**: ~1,930 MB (~1.9 GB)
+- **Index build time**: ~73s (Linux), ~101s (Windows), ~201s (macOS)
+- **Index size**: ~1,953 MB (~2.0 GB)
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 2,128,508 | 17,446.8 | 0 |
-| tgrep (client → serve) | 45,888 | 376.1 | — |
+| ripgrep | 2,196,618 | 18,005.1 | 0 |
+| tgrep (client → serve) | 63,088 | 517.1 | — |
 
-**tgrep is ~46x faster**
+**tgrep is ~34.8x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 3,826,431 | 31,364.2 | 0 |
-| tgrep (client → serve) | 66,412 | 544.4 | — |
+| ripgrep | 4,183,208 | 34,288.6 | 0 |
+| tgrep (client → serve) | 97,407 | 798.4 | — |
 
-**tgrep is ~58x faster**
+**tgrep is ~42.9x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 214,734 | 1,760.1 | 0 |
-| tgrep (client → serve) | 25,243 | 206.9 | — |
+| ripgrep | 215,729 | 1,768.3 | 0 |
+| tgrep (client → serve) | 28,639 | 234.7 | — |
 
-**tgrep is ~8.5x faster**
+**tgrep is ~7.5x faster**
 
 ---
 
 ## torvalds/linux (96K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32481335460)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32481331031)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580642696)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580641264)
 
-- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (95,531 files)
+- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (95,776 files)
 - **Queries**: 102 (mix of literals, multi-word, and regex)
-- **Index build time**: ~30s (Linux), ~36s (Windows), ~44s (macOS)
-- **Index size**: ~995 MB
+- **Index build time**: ~42s (Linux), ~53s (Windows), ~37s (macOS)
+- **Index size**: ~1,005 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 265,133 | 2,599.3 | 0 |
-| tgrep (client → serve) | 13,430 | 131.7 | — |
+| ripgrep | 333,512 | 3,269.7 | 0 |
+| tgrep (client → serve) | 13,283 | 130.2 | — |
 
-**tgrep is ~20x faster**
+**tgrep is ~25.1x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 387,958 | 3,803.5 | 0 |
-| tgrep (client → serve) | 15,733 | 154.2 | — |
+| ripgrep | 384,507 | 3,769.7 | 0 |
+| tgrep (client → serve) | 17,142 | 168.1 | — |
 
-**tgrep is ~25x faster**
+**tgrep is ~22.4x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 33,482 | 328.3 | 0 |
-| tgrep (client → serve) | 6,500 | 63.7 | — |
+| ripgrep | 44,343 | 434.7 | 0 |
+| tgrep (client → serve) | 8,085 | 79.3 | — |
 
-**tgrep is ~5.2x faster**
+**tgrep is ~5.5x faster**
 
-This suite has now been measured three times on separate runner sessions. Linux
-came out at 5.2x, 5.7x and 6.2x; macOS at 24.7x, 27.3x and 31.7x
-([32456274534](https://github.com/microsoft/tgrep/actions/runs/32456274534),
+This suite has now been measured four times on separate runner sessions. Linux
+came out at 5.2x, 5.5x, 5.7x and 6.2x; macOS at 22.4x, 24.7x, 27.3x and 31.7x
+([32481331031](https://github.com/microsoft/tgrep/actions/runs/32481331031),
+[32456274534](https://github.com/microsoft/tgrep/actions/runs/32456274534),
 [32457317972](https://github.com/microsoft/tgrep/actions/runs/32457317972)).
-The figures above are the lowest of the three, so the published ratio is the
-conservative end of that spread rather than the flattering one.
+The tables now report the linked latest run consistently; the spread is retained
+to show why a shared-runner ratio should not be read as a controlled benchmark.
 
 ---
 
 ## rust-lang/rust (62K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32481375754)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32481371684)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580663644)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580661455)
 
-- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (62,154 files)
+- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (62,179 files)
 - **Queries**: 102 (mix of Rust patterns, macros, traits, and regex)
-- **Index build time**: ~7s (Linux), ~10s (Windows), ~11s (macOS)
-- **Index size**: ~199 MB
+- **Index build time**: ~8s (Linux), ~11s (Windows), ~12s (macOS)
+- **Index size**: ~199.4 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 193,494 | 1,897.0 | 0 |
-| tgrep (client → serve) | 23,391 | 229.3 | — |
+| ripgrep | 203,510 | 1,995.2 | 0 |
+| tgrep (client → serve) | 25,145 | 246.5 | — |
 
-**tgrep is ~8.3x faster**
+**tgrep is ~8.1x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 39,904 | 391.2 | 0 |
-| tgrep (client → serve) | 26,750 | 262.3 | — |
+| ripgrep | 62,400 | 611.8 | 0 |
+| tgrep (client → serve) | 34,982 | 343.0 | — |
 
-**tgrep is ~1.49x faster**
+**tgrep is ~1.78x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 18,545 | 181.8 | 0 |
-| tgrep (client → serve) | 13,781 | 135.1 | — |
+| ripgrep | 18,607 | 182.4 | 0 |
+| tgrep (client → serve) | 13,730 | 134.6 | — |
 
-**tgrep is ~1.35x faster**
+**tgrep is ~1.36x faster**
 
 ---
 
 ## kubernetes/kubernetes (31K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32481367454)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32481363397)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580659311)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580657354)
 
 - **Repo**: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (31,300 files)
 - **Queries**: 97 (mix of Go patterns, Kubernetes API types, and regex)
-- **Index build time**: ~8s (Linux), ~10s (Windows), ~10s (macOS)
-- **Index size**: ~215 MB
+- **Index build time**: ~6s (Linux), ~11s (Windows), ~7s (macOS)
+- **Index size**: ~215.8 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 133,623 | 1,377.6 | 0 |
-| tgrep (client → serve) | 19,608 | 202.1 | — |
+| ripgrep | 135,099 | 1,392.8 | 0 |
+| tgrep (client → serve) | 22,925 | 236.3 | — |
 
-**tgrep is ~6.8x faster**
+**tgrep is ~5.9x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 31,320 | 322.9 | 0 |
-| tgrep (client → serve) | 13,175 | 135.8 | — |
+| ripgrep | 25,634 | 264.3 | 0 |
+| tgrep (client → serve) | 14,898 | 153.6 | — |
 
-**tgrep is ~2.4x faster**
+**tgrep is ~1.72x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 14,101 | 145.4 | 0 |
-| tgrep (client → serve) | 13,357 | 137.7 | — |
+| ripgrep | 11,062 | 114.0 | 0 |
+| tgrep (client → serve) | 11,018 | 113.6 | — |
 
-**tgrep is ~1.06x faster**
+**tgrep and ripgrep are effectively tied (1.004x)**
 
 ---
 
 ## golang/go (16K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32481359674)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32481355528)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580655162)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580653074)
 
-- **Repo**: [golang/go](https://github.com/golang/go) (15,818 files)
+- **Repo**: [golang/go](https://github.com/golang/go) (15,826 files)
 - **Queries**: 103 (mix of Go stdlib patterns, testing, and regex)
-- **Index build time**: ~4s (Linux), ~5s (Windows), ~5s (macOS)
-- **Index size**: ~110 MB
+- **Index build time**: ~4s (Linux), ~5s (Windows), ~3s (macOS)
+- **Index size**: ~113.7 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 49,461 | 480.2 | 0 |
-| tgrep (client → serve) | 9,576 | 93.0 | — |
+| ripgrep | 61,702 | 599.0 | 0 |
+| tgrep (client → serve) | 10,020 | 97.3 | — |
 
-**tgrep is ~5.2x faster**
+**tgrep is ~6.2x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 23,685 | 230.0 | 0 |
-| tgrep (client → serve) | 7,056 | 68.5 | — |
+| ripgrep | 14,939 | 145.0 | 0 |
+| tgrep (client → serve) | 4,641 | 45.1 | — |
 
-**tgrep is ~3.4x faster**
+**tgrep is ~3.2x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 6,854 | 66.5 | 0 |
-| tgrep (client → serve) | 5,644 | 54.8 | — |
+| ripgrep | 6,706 | 65.1 | 0 |
+| tgrep (client → serve) | 5,019 | 48.7 | — |
 
-**tgrep is ~1.21x faster**
+**tgrep is ~1.34x faster**
 
 ---
 
@@ -586,25 +615,25 @@ conservative end of that spread rather than the flattering one.
 
 - **Repo size is the strongest predictor.** The trigram index eliminates scanning files
   that can't match, so the advantage grows with the corpus. On the two largest repos
-  (Chromium 504K files, gecko-dev 388K files) tgrep wins on every platform, by 3.1–58x.
-  On the smallest (Go, 16K files) the Linux margin narrows to 1.2x.
-- **Windows benefits most consistently** — geometric mean **12.6x**, and never below
-  5.2x in any cell. Windows per-file open/read overhead is high, so skipping 90%+ of
+  (Chromium 504K files, gecko-dev 388K files) tgrep wins on every platform, by 2.36–42.9x.
+  On the smallest (Go, 16K files) the Linux margin narrows to 1.34x.
+- **Windows benefits most consistently** — geometric mean **12.3x**, and never below
+  5.9x in any cell. Windows per-file open/read overhead is high, so skipping 90%+ of
   the files pays off everywhere.
-- **macOS has the highest peak but more spread** — geometric mean **8.4x**, range
-  1.5–58x.
-- **Linux is the weakest case** — geometric mean **2.5x**, range 1.06–8.5x. Linux's
+- **macOS has the highest peak but more spread** — geometric mean **6.8x**, range
+  1.72–42.9x.
+- **Linux is the weakest case** — geometric mean **2.4x**, range 1.004–7.5x. Linux's
   page cache plus ripgrep's parallel scan make brute force genuinely cheap on a warm
   repo, so the index buys less.
 - ripgrep never hit the 120s per-query cap in any run (Timeouts = 0 in every table),
   so every ratio here is a true measured value, not a censored one.
-- Index build is a one-time cost — ~4s for Go, ~220s for Chromium on macOS — and the
+- Index build is a one-time cost — ~3s for Go on macOS, ~247s for Chromium there — and the
   server then watches for file changes and updates incrementally.
 
 ### What decides the margin
 
-tgrep wins every cell in the matrix, but the margin ranges from 1.1x to 58x. Two
-things move it.
+tgrep does not lose a cell in the latest matrix, but Kubernetes/Linux is effectively
+parity and the measured margin ranges from 1.004x to 42.9x. Two things move it.
 
 **Repo size**, as above: more files means more files the index can skip.
 
@@ -628,13 +657,13 @@ a different set of 102 queries returning 188,862 matches, none above 6,000.
 ripgrep's Linux total barely moved — 33–46s across the five most recent runs
 spanning both query sets, with a single 103s outlier in the earliest, because it
 scans every file whichever pattern it gets — while tgrep's fell from 49–128s on
-the old set to 6.5–7.5s on the new one. That difference is the delivery cost,
+the old set to 6.5–8.1s on the new one. That difference is the delivery cost,
 isolated.
 
 A caution on reading the ratios: the ripgrep baselines themselves move between
-runner sessions, and macOS moves most. Three runs of the *identical* kernel suite
-measured macOS ripgrep at 388s, 495s and 500s — a 1.3x spread from runner variance
-alone — so treat a single macOS column as an order of magnitude rather than a
+runner sessions, and macOS moves most. Four runs of the *identical* kernel suite
+measured macOS ripgrep at 385s, 388s, 495s and 500s — a 1.3x spread from runner
+variance alone — so treat a single macOS column as an order of magnitude rather than a
 precise figure. The Linux column is the stable one, and it is also the least
 flattering.
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -214,8 +214,12 @@ large files are a rare minority and the extra headroom bought no parallelism.
 **Removing the cap.** Bounding the bytes in flight made the peak predictable but
 left it proportional to the largest files, which is why a cap still looked
 necessary. Mapping files past 1 MiB instead of reading them removes that link,
-and with it the reason for the cap. ripgrep has no default `--max-filesize`
-either, and this is the mechanism that lets it not need one.
+and with it the memory argument for a cap. ripgrep has no default
+`--max-filesize` either, and this is the mechanism that lets it not need one.
+
+(A 64 MiB default was later reinstated for a different reason: not build memory,
+which mapping had solved, but repeated *scan* time on the pathological tail. See
+"File size limits" in the README.)
 
 From here the two metrics diverge and have to be reported separately. Resident
 set counts mapped file pages, so it barely moves; *private* bytes — the memory

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -211,8 +211,6 @@ not just smaller. The budget is deliberately a flat 64 MiB rather than something
 that scales with the thread pool — a larger, pool-scaled budget was measured and
 was both slower *and* hungrier here (38.4 s, 254.0 MiB), because the kernel's
 large files are a rare minority and the extra headroom bought no parallelism.
-It only pays off on a tree that is nothing but oversized generated headers, where
-it recovers about half the throughput cost for double the memory.
 
 **Removing the cap.** Bounding the bytes in flight made the peak predictable but
 left it proportional to the largest files, which is why a cap still looked
@@ -250,6 +248,48 @@ that proportional rather than multiplied — the repaired buffer is now sized
 exactly instead of doubling out of a `bytes.len()` guess, and indexing skips the
 per-repair offset table it never reads. On a 135 MB Latin-1 file that took
 private bytes from 504.2 MiB (3.7x the file) to 204.6 MiB (1.5x).
+
+**Indexing large files at speed.** Admitting large files exposed a throughput
+problem the cap had been hiding. Two causes, both only visible once a tree is
+mostly large files:
+
+*The byte budget charged mapped bytes it never allocated.* A mapped file costs no
+heap, but it was charged its full length against the 64 MiB budget, so a batch of
+32 MiB files held two — and a batch is a barrier, so a 16-core pool ran two files
+at a time. Mapped files are now charged a saturating stand-in for the one thing
+they *do* put on the heap, their extracted trigram map, against a second budget
+that caps mapped bytes in flight at 256 MiB.
+
+*Extraction hashed every byte twice with SipHash.* A trigram key is its own
+24-bit hash, so the collision resistance was paying for nothing, and the
+lowercase pass re-walked the whole file even though most windows in real source
+lower to the same key. Extraction now uses a multiply-xorshift hasher and folds
+both cases into one pass, doing real work only for windows that actually contain
+an uppercase byte.
+
+Interleaved A/B runs, 512 MiB per corpus, minimum of alternating runs:
+
+| Corpus | Before | After | |
+| --- | ---: | ---: | ---: |
+| 16 x 32 MiB, mixed case | 24.1 s | **1.7 s** | 14.2x |
+| 16 x 32 MiB, lowercase | 9.4 s | **1.0 s** | 9.4x |
+| 512 x 1 MiB, lowercase | 2.7 s | **1.9 s** | 1.4x |
+| 20,000 x 8 KiB, mixed case | 12.5 s | 12.6 s | — |
+
+The last row is the point: ordinary source trees are bound by file I/O and the
+external sort, not by extraction, so they neither gain nor lose. The gain is
+concentrated exactly where the old cap used to hide the cost.
+
+This is what the reported case was made of. A `tgrep serve` opening an index
+built under the old cap sees every formerly-oversized file as new and absorbs
+them in one stale merge; on a 40,300-file index absorbing 16 x 32 MiB of new
+mixed-case files, that merge went from 26.3 s to 3.4 s (7.7x), producing the same
+79,078 trigrams over 40,316 files.
+
+Memory moves the way mapping implies. On the mixed-case corpus, private bytes
+went 71.4 MiB to 78.1 MiB while resident set went 59.3 MiB to 228.1 MiB: the
+increase is entirely file-backed pages the kernel can reclaim, held by the
+256 MiB mapped budget, and the heap the process actually owns barely moved.
 
 
 **Why the merge shares one read budget.** The first implementation gave every
@@ -357,15 +397,22 @@ already-normalized posting lists.
 
 ### Trigram extraction
 
+Interleaved A/B on one machine, before and after replacing SipHash with a
+multiply-xorshift hasher over the 24-bit trigram key and fusing the case-folding
+pass into the main window loop:
+
 | Case | 1 KiB | 16 KiB | 256 KiB |
 | --- | ---: | ---: | ---: |
-| Extract masks, lowercase ASCII | 14.253us | 206.39us | 2.9378ms |
-| Extract merged masks, lowercase ASCII | 30.271us | 399.31us | 6.0330ms |
-| Extract merged masks, mixed case | 29.960us | 374.22us | 6.1909ms |
+| Extract masks, lowercase ASCII | 18.860us → **6.7010us** | 240.73us → **73.384us** | 3.7818ms → **1.1429ms** |
+| Extract merged masks, lowercase ASCII | 37.896us → **9.2151us** | 530.06us → **124.74us** | 8.4003ms → **2.0132ms** |
+| Extract merged masks, mixed case | 38.483us → **9.9965us** | 536.00us → **139.44us** | 8.4413ms → **2.2813ms** |
 
-For lowercase-only content, merged-mask extraction skips the lowercase copy and
-second extraction pass. In the 256 KiB case, that improved the local Criterion
-baseline by about 51%.
+A trigram packs three bytes into 24 bits, so the key is already collision-free
+and SipHash's collision resistance bought nothing while running once per input
+byte. Merged extraction previously walked the file a second time whenever it held
+any uppercase byte; folding that into one pass means a window costs extra work
+only if it actually lowers to a different trigram, which closes most of the gap
+between the mixed-case and lowercase rows.
 
 ---
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -101,7 +101,8 @@ results, not postings.
 
 **Real-world scale: the Linux kernel.** 94,634 indexed files / 446,892 trigrams
 / 990 MiB index (`C:\repos\linux`, v7.2-rc7, warm page cache, peak working set
-sampled from the child process):
+sampled from the child process, under the 1 MiB indexing cap that was the
+default at the time):
 
 | Strategy | Spill segments | Peak working set | Build |
 | --- | ---: | ---: | ---: |
@@ -139,6 +140,28 @@ Peak figures here are the OS process high-water mark (`PeakWorkingSetSize` on
 Windows, `VmHWM` on Linux), sampled externally. `tgrep index` now reports the
 same counter itself on completion, so these numbers are reproducible without
 external tooling; the self-reported and externally-sampled values agree exactly.
+
+**What the 64 MiB file-size cap costs.** The table above holds the arena fixed
+and varies the budget. Raising the *indexing* cap from 1 MiB to the current
+64 MiB default moves the floor under all of it, because the builder reads each
+file whole and in parallel, so several 20 MB generated headers are resident at
+once. Same host and repo, default arena:
+
+| `--max-filesize` | Files indexed | Skipped as too large | Peak working set | Build |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 MiB (old default) | 94,637 | 110 | 151.2 MiB | 25.5 s |
+| 8 MiB | 94,736 | 11 | 304.1 MiB | 24.4 s |
+| 16 MiB | 94,745 | 2 | 341.2 MiB | 24.5 s |
+| 64 MiB (**default**) | 94,747 | 0 | 338.8 MiB | 25.5 s |
+
+The cost is a step, not a slope: almost all of it is paid on the first megabyte
+past the old cap, and 16 MiB and 64 MiB are within noise of each other. So a cap
+between the two gives up files without buying memory back — 8 MiB still drops 11
+kernel files for 89% of the peak. Build time is flat throughout, and the index
+grew 990.4 MB to 996.7 MB (+0.6%) for 110 more files totalling 437.9 MB, because
+the files a size cap catches are generated and repetitive: `dcn_3_2_0_sh_mask.h`
+is 24 MB and contributes 7,263 distinct trigrams, fewer than the 10,936 of the
+224 KB `fs/ext4/super.c`.
 
 **Why the merge shares one read budget.** The first implementation gave every
 open segment a fixed 256 KiB read-ahead buffer, which made merge memory

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -20,21 +20,23 @@ Values below 1.0 mean ripgrep won.
 
 | Repo | Files | Queries | Windows | macOS | Linux |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| chromium/chromium | 503,903 | 30 | **13.5x** | **10.8x** | **2.36x** |
-| mozilla/gecko-dev | 387,841 | 122 | **34.8x** | **42.9x** | **7.5x** |
-| torvalds/linux | 95,776 | 102 | **25.1x** | **22.4x** | **5.5x** |
-| rust-lang/rust | 62,179 | 102 | **8.1x** | **1.78x** | **1.36x** |
-| kubernetes/kubernetes | 31,300 | 97 | **5.9x** | **1.72x** | **1.00x** |
-| golang/go | 15,826 | 103 | **6.2x** | **3.2x** | **1.34x** |
+| chromium/chromium | 504,351 | 30 | **17.6x** | **15.8x** | **3.81x** |
+| mozilla/gecko-dev | 387,841 | 122 | **38.6x** | **51.9x** | **7.36x** |
+| torvalds/linux | 95,831 | 102 | **34.8x** | **21.0x** | **9.38x** |
+| rust-lang/rust | 62,326 | 102 | **7.69x** | **2.69x** | **1.61x** |
+| kubernetes/kubernetes | 31,300 | 97 | **7.08x** | **2.81x** | **0.93x** |
+| golang/go | 15,833 | 103 | **7.53x** | **3.12x** | **1.29x** |
 
-All 18 cells are from the complete 22 August 2026 sweep at `90a41a6`, measured on
+All 18 cells are from the complete 24 August 2026 sweep at `82b88a1`, measured on
 GitHub-hosted runners (`windows-latest`, `macos-latest`, `ubuntu-latest`). Every
 headline latency, ratio, file count, and primary run link in the repo sections
 below comes from that same sweep rather than mixing the latest totals with minima
 from older runs. Older runs are cited only to show the kernel suite's variance.
-Geometric mean speedup across the six repos is **12.3x on Windows, 6.8x on macOS,
-and 2.4x on Linux**. Kubernetes on Linux is effectively tied (1.004x); the largest
-margin is Gecko on macOS at 42.9x. See
+Geometric mean speedup across the six repos is **14.6x on Windows, 8.61x on macOS,
+and 2.82x on Linux**. The largest margin is Gecko on macOS at 51.9x.
+**Kubernetes on Linux is the one cell ripgrep wins**, at 0.93x — a near-tie
+(101.8 ms versus 94.4 ms per query) on a warm page cache, where match volume costs
+tgrep more in delivery than the index saves in file selection. See
 [What decides the margin](#what-decides-the-margin).
 
 Shared-runner results are not controlled-machine measurements. Compare tgrep with
@@ -43,23 +45,28 @@ storage and page-cache variance move both tools, particularly on macOS.
 
 ### Index-build peak memory in the latest sweep
 
-The benchmark logs also record the indexer's OS high-water mark. Each cell shows
-the previously published sweep → the latest sweep, in MiB:
+The benchmark logs also record the indexer's peak memory, in MiB:
 
 | Repo | Windows | macOS | Linux |
 | --- | ---: | ---: | ---: |
-| chromium/chromium | 359.7 → **362.4** | 437.3 → **440.2** | 337.6 → **339.7** |
-| mozilla/gecko-dev | 304.8 → **304.5** | 396.2 → **359.7** | 271.7 → **273.4** |
-| torvalds/linux | 142.6 → **173.8** | 175.6 → **195.8** | 141.6 → **192.3** |
-| rust-lang/rust | 110.5 → **113.1** | 151.3 → **148.8** | 103.3 → **111.9** |
-| kubernetes/kubernetes | 113.3 → **115.5** | 150.8 → **148.5** | 112.6 → **120.2** |
-| golang/go | 106.7 → **105.4** | 123.0 → **126.5** | 115.1 → **114.4** |
+| chromium/chromium | **402.9** | **462.6** | **332.2** |
+| mozilla/gecko-dev | **347.8** | **416.3** | **256.9** |
+| torvalds/linux | **135.4** | **216.7** | **129.6** |
+| rust-lang/rust | **114.7** | **150.8** | **109.4** |
+| kubernetes/kubernetes | **109.1** | **145.3** | **110.7** |
+| golang/go | **108.0** | **137.2** | **108.7** |
 
-The kernel moved most because the latest build admits the 110 files that the old
-1 MiB default cap skipped; Chromium changed by only 2–3 MiB despite admitting
-more formerly capped files. These are peak working-set/RSS figures, so mapped
-file pages count even though the OS can reclaim them. They are not private bytes
-or heap usage.
+These are **not comparable to figures published before this sweep**, which were
+peak working set / RSS and so counted mapped file pages the OS can reclaim.
+`index` now reports private bytes — `PagefileUsage` on Windows, `RssAnon` on Linux
+— and names the working set separately only when it is materially larger. None of
+these six repos holds a file big enough to make the two diverge, so the numbers
+land close to the old ones by coincidence; they measure the memory tgrep owns
+rather than what the OS happened to have resident.
+
+Peak memory tracks corpus size rather than query count, and stays bounded: the
+largest here is Chromium at 504K files and 2.6 GB of index, which builds in under
+470 MiB on every platform.
 
 ---
 
@@ -468,59 +475,98 @@ between the mixed-case and lowercase rows.
 
 ## chromium/chromium (504K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580646448)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580644568)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32763938779)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32763934524)
 
-- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (503,903 files)
+- **Repo**: [chromium/chromium](https://github.com/chromium/chromium) (504,351 files)
 - **Queries**: 30 (mix of literals, multi-word, and regex)
-- **Index build time**: ~82s (Linux), ~142s (Windows), ~247s (macOS)
-- **Index size**: 2,581 MB (~2.6 GB)
+- **Index build time**: ~52s (Linux), ~73s (Windows), ~248s (macOS)
+- **Index size**: ~2,584 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 769,549 | 25,651.6 | 0 |
-| tgrep (client → serve) | 57,187 | 1,906.2 | — |
+| ripgrep | 737,275 | 24,575.8 | 0 |
+| tgrep (client → serve) | 41,884 | 1,396.1 | — |
 
-**tgrep is ~13.5x faster**
+**tgrep is ~17.6x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 1,046,616 | 34,887.2 | 0 |
-| tgrep (client → serve) | 97,204 | 3,240.1 | — |
+| ripgrep | 1,254,185 | 41,806.2 | 0 |
+| tgrep (client → serve) | 79,293 | 2,643.1 | — |
 
-**tgrep is ~10.8x faster**
+**tgrep is ~15.8x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 46,294 | 1,543.1 | 0 |
-| tgrep (client → serve) | 19,646 | 654.9 | — |
+| ripgrep | 72,127 | 2,404.2 | 0 |
+| tgrep (client → serve) | 18,942 | 631.4 | — |
 
-**tgrep is ~2.36x faster**
+**tgrep is ~3.81x faster**
 
 ---
 
 ## mozilla/gecko-dev (388K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580650472)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580648298)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32763946964)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32763942874)
 
 - **Repo**: [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev) (387,841 files)
 - **Queries**: 122 (mix of C++, JavaScript, and Python patterns)
-- **Index build time**: ~73s (Linux), ~101s (Windows), ~201s (macOS)
-- **Index size**: ~1,953 MB (~2.0 GB)
+- **Index build time**: ~35s (Linux), ~58s (Windows), ~165s (macOS)
+- **Index size**: ~1,952 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 2,196,618 | 18,005.1 | 0 |
-| tgrep (client → serve) | 63,088 | 517.1 | — |
+| ripgrep | 2,176,629 | 17,841.2 | 0 |
+| tgrep (client → serve) | 56,435 | 462.6 | — |
+
+**tgrep is ~38.6x faster**
+
+### macOS Apple Silicon (Darwin arm64)
+
+| Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
+| --- | ---: | ---: | ---: |
+| ripgrep | 4,075,017 | 33,401.8 | 0 |
+| tgrep (client → serve) | 78,447 | 643.0 | — |
+
+**tgrep is ~51.9x faster**
+
+### Linux x86_64
+
+| Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
+| --- | ---: | ---: | ---: |
+| ripgrep | 145,774 | 1,194.9 | 0 |
+| tgrep (client → serve) | 19,815 | 162.4 | — |
+
+**tgrep is ~7.36x faster**
+
+---
+
+## torvalds/linux (96K files)
+
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32763930116)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32763926423)
+
+- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (95,831 files)
+- **Queries**: 102 (mix of literals, multi-word, and regex)
+- **Index build time**: ~21s (Linux), ~26s (Windows), ~37s (macOS)
+- **Index size**: ~1,000 MB
+
+### Windows AMD64
+
+| Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
+| --- | ---: | ---: | ---: |
+| ripgrep | 334,555 | 3,280.0 | 0 |
+| tgrep (client → serve) | 9,612 | 94.2 | — |
 
 **tgrep is ~34.8x faster**
 
@@ -528,183 +574,146 @@ between the mixed-case and lowercase rows.
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 4,183,208 | 34,288.6 | 0 |
-| tgrep (client → serve) | 97,407 | 798.4 | — |
+| ripgrep | 549,813 | 5,390.3 | 0 |
+| tgrep (client → serve) | 26,124 | 256.1 | — |
 
-**tgrep is ~42.9x faster**
-
-### Linux x86_64
-
-| Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
-| --- | ---: | ---: | ---: |
-| ripgrep | 215,729 | 1,768.3 | 0 |
-| tgrep (client → serve) | 28,639 | 234.7 | — |
-
-**tgrep is ~7.5x faster**
-
----
-
-## torvalds/linux (96K files)
-
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580642696)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580641264)
-
-- **Repo**: [torvalds/linux](https://github.com/torvalds/linux) (95,776 files)
-- **Queries**: 102 (mix of literals, multi-word, and regex)
-- **Index build time**: ~42s (Linux), ~53s (Windows), ~37s (macOS)
-- **Index size**: ~1,005 MB
-
-### Windows AMD64
-
-| Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
-| --- | ---: | ---: | ---: |
-| ripgrep | 333,512 | 3,269.7 | 0 |
-| tgrep (client → serve) | 13,283 | 130.2 | — |
-
-**tgrep is ~25.1x faster**
-
-### macOS Apple Silicon (Darwin arm64)
-
-| Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
-| --- | ---: | ---: | ---: |
-| ripgrep | 384,507 | 3,769.7 | 0 |
-| tgrep (client → serve) | 17,142 | 168.1 | — |
-
-**tgrep is ~22.4x faster**
+**tgrep is ~21.0x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 44,343 | 434.7 | 0 |
-| tgrep (client → serve) | 8,085 | 79.3 | — |
+| ripgrep | 43,542 | 426.9 | 0 |
+| tgrep (client → serve) | 4,643 | 45.5 | — |
 
-**tgrep is ~5.5x faster**
+**tgrep is ~9.38x faster**
 
-This suite has now been measured four times on separate runner sessions. Linux
-came out at 5.2x, 5.5x, 5.7x and 6.2x; macOS at 22.4x, 24.7x, 27.3x and 31.7x
-([32481331031](https://github.com/microsoft/tgrep/actions/runs/32481331031),
+This suite has now been measured five times on separate runner sessions. Linux came
+out at 5.2x, 5.5x, 5.7x, 6.2x and 9.38x; macOS at 21.0x, 22.4x, 24.7x, 27.3x and
+31.7x ([32481331031](https://github.com/microsoft/tgrep/actions/runs/32481331031),
 [32456274534](https://github.com/microsoft/tgrep/actions/runs/32456274534),
 [32457317972](https://github.com/microsoft/tgrep/actions/runs/32457317972)).
-The tables now report the linked latest run consistently; the spread is retained
-to show why a shared-runner ratio should not be read as a controlled benchmark.
+Only the latest run carries this branch's read-once and lazy-line-index work, so
+its Linux figure is not purely runner variance; the earlier four are. The tables
+report the linked latest run consistently, and the spread is retained to show why a
+shared-runner ratio should not be read as a controlled benchmark.
 
 ---
 
 ## rust-lang/rust (62K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580663644)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580661455)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32763971982)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32763967731)
 
-- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (62,179 files)
+- **Repo**: [rust-lang/rust](https://github.com/rust-lang/rust) (62,326 files)
 - **Queries**: 102 (mix of Rust patterns, macros, traits, and regex)
-- **Index build time**: ~8s (Linux), ~11s (Windows), ~12s (macOS)
-- **Index size**: ~199.4 MB
+- **Index build time**: ~4s (Linux), ~6s (Windows), ~8s (macOS)
+- **Index size**: ~199 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 203,510 | 1,995.2 | 0 |
-| tgrep (client → serve) | 25,145 | 246.5 | — |
+| ripgrep | 151,921 | 1,489.4 | 0 |
+| tgrep (client → serve) | 19,759 | 193.7 | — |
 
-**tgrep is ~8.1x faster**
+**tgrep is ~7.69x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 62,400 | 611.8 | 0 |
-| tgrep (client → serve) | 34,982 | 343.0 | — |
+| ripgrep | 66,769 | 654.6 | 0 |
+| tgrep (client → serve) | 24,849 | 243.6 | — |
 
-**tgrep is ~1.78x faster**
+**tgrep is ~2.69x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 18,607 | 182.4 | 0 |
-| tgrep (client → serve) | 13,730 | 134.6 | — |
+| ripgrep | 14,708 | 144.2 | 0 |
+| tgrep (client → serve) | 9,115 | 89.4 | — |
 
-**tgrep is ~1.36x faster**
+**tgrep is ~1.61x faster**
 
 ---
 
 ## kubernetes/kubernetes (31K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580659311)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580657354)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32763963292)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32763959155)
 
 - **Repo**: [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (31,300 files)
 - **Queries**: 97 (mix of Go patterns, Kubernetes API types, and regex)
-- **Index build time**: ~6s (Linux), ~11s (Windows), ~7s (macOS)
-- **Index size**: ~215.8 MB
+- **Index build time**: ~4s (Linux), ~7s (Windows), ~5s (macOS)
+- **Index size**: ~215 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 135,099 | 1,392.8 | 0 |
-| tgrep (client → serve) | 22,925 | 236.3 | — |
+| ripgrep | 130,200 | 1,342.3 | 0 |
+| tgrep (client → serve) | 18,381 | 189.5 | — |
 
-**tgrep is ~5.9x faster**
+**tgrep is ~7.08x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 25,634 | 264.3 | 0 |
-| tgrep (client → serve) | 14,898 | 153.6 | — |
+| ripgrep | 27,731 | 285.9 | 0 |
+| tgrep (client → serve) | 9,881 | 101.9 | — |
 
-**tgrep is ~1.72x faster**
+**tgrep is ~2.81x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 11,062 | 114.0 | 0 |
-| tgrep (client → serve) | 11,018 | 113.6 | — |
+| ripgrep | 9,158 | 94.4 | 0 |
+| tgrep (client → serve) | 9,878 | 101.8 | — |
 
-**tgrep and ripgrep are effectively tied (1.004x)**
+**ripgrep is ~1.08x faster** — tgrep is 0.93x
 
 ---
 
 ## golang/go (16K files)
 
-[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32580655162)
-[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32580653074)
+[Benchmark Run (Windows)](https://github.com/microsoft/tgrep/actions/runs/32763954981)
+[Benchmark Run (Linux/macOS)](https://github.com/microsoft/tgrep/actions/runs/32763950876)
 
-- **Repo**: [golang/go](https://github.com/golang/go) (15,826 files)
+- **Repo**: [golang/go](https://github.com/golang/go) (15,833 files)
 - **Queries**: 103 (mix of Go stdlib patterns, testing, and regex)
-- **Index build time**: ~4s (Linux), ~5s (Windows), ~3s (macOS)
-- **Index size**: ~113.7 MB
+- **Index build time**: ~2s (Linux), ~3s (Windows), ~3s (macOS)
+- **Index size**: ~113 MB
 
 ### Windows AMD64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 61,702 | 599.0 | 0 |
-| tgrep (client → serve) | 10,020 | 97.3 | — |
+| ripgrep | 60,949 | 591.7 | 0 |
+| tgrep (client → serve) | 8,093 | 78.6 | — |
 
-**tgrep is ~6.2x faster**
+**tgrep is ~7.53x faster**
 
 ### macOS Apple Silicon (Darwin arm64)
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 14,939 | 145.0 | 0 |
-| tgrep (client → serve) | 4,641 | 45.1 | — |
+| ripgrep | 21,075 | 204.6 | 0 |
+| tgrep (client → serve) | 6,753 | 65.6 | — |
 
-**tgrep is ~3.2x faster**
+**tgrep is ~3.12x faster**
 
 ### Linux x86_64
 
 | Tool | Total (ms) | Avg per query (ms) | Timeouts (120s) |
 | --- | ---: | ---: | ---: |
-| ripgrep | 6,706 | 65.1 | 0 |
-| tgrep (client → serve) | 5,019 | 48.7 | — |
+| ripgrep | 4,541 | 44.1 | 0 |
+| tgrep (client → serve) | 3,516 | 34.1 | — |
 
-**tgrep is ~1.34x faster**
+**tgrep is ~1.29x faster**
 
 ---
 
@@ -712,25 +721,25 @@ to show why a shared-runner ratio should not be read as a controlled benchmark.
 
 - **Repo size is the strongest predictor.** The trigram index eliminates scanning files
   that can't match, so the advantage grows with the corpus. On the two largest repos
-  (Chromium 504K files, gecko-dev 388K files) tgrep wins on every platform, by 2.36–42.9x.
-  On the smallest (Go, 16K files) the Linux margin narrows to 1.34x.
-- **Windows benefits most consistently** — geometric mean **12.3x**, and never below
-  5.9x in any cell. Windows per-file open/read overhead is high, so skipping 90%+ of
+  (Chromium 504K files, gecko-dev 388K files) tgrep wins on every platform, by 3.81–51.9x.
+  On the smallest (Go, 16K files) the Linux margin narrows to 1.29x.
+- **Windows benefits most consistently** — geometric mean **14.6x**, and never below
+  7.08x in any cell. Windows per-file open/read overhead is high, so skipping 90%+ of
   the files pays off everywhere.
-- **macOS has the highest peak but more spread** — geometric mean **6.8x**, range
-  1.72–42.9x.
-- **Linux is the weakest case** — geometric mean **2.4x**, range 1.004–7.5x. Linux's
-  page cache plus ripgrep's parallel scan make brute force genuinely cheap on a warm
-  repo, so the index buys less.
+- **macOS has the highest peak but more spread** — geometric mean **8.61x**, range
+  2.69–51.9x.
+- **Linux is the weakest case** — geometric mean **2.82x**, range 0.93–9.38x, and it
+  holds the matrix's only loss. Linux's page cache plus ripgrep's parallel scan make
+  brute force genuinely cheap on a warm repo, so the index buys less.
 - ripgrep never hit the 120s per-query cap in any run (Timeouts = 0 in every table),
   so every ratio here is a true measured value, not a censored one.
-- Index build is a one-time cost — ~3s for Go on macOS, ~247s for Chromium there — and the
+- Index build is a one-time cost — ~3s for Go on macOS, ~248s for Chromium there — and the
   server then watches for file changes and updates incrementally.
 
 ### What decides the margin
 
-tgrep does not lose a cell in the latest matrix, but Kubernetes/Linux is effectively
-parity and the measured margin ranges from 1.004x to 42.9x. Two things move it.
+tgrep loses exactly one of the eighteen cells — Kubernetes on Linux, at 0.93x — and
+the measured margin elsewhere ranges from 1.29x to 51.9x. Two things move it.
 
 **Repo size**, as above: more files means more files the index can skip.
 
@@ -743,23 +752,23 @@ file selection.
 The kernel suite used to demonstrate this the hard way. Its queries were generic
 tokens — `read`, `write`, `^#define\s+[A-Z_]+` — that matched most of the tree:
 5,398,512 matches across 102 queries, with a single query returning 2,089,941.
-Kernel Linux is the only cell tgrep has ever lost, and on that query set it lost
-every run: 0.81x, 0.74x and 0.95x, the closest being 48.6s against ripgrep's
-46.4s. Index pruning was not the problem; measured directly on a local kernel
-checkout, the index still narrowed to **4–12% of the 95K files**.
+On that query set kernel Linux lost every run: 0.81x, 0.74x and 0.95x, the closest
+being 48.6s against ripgrep's 46.4s. Index pruning was not the problem; measured
+directly on a local kernel checkout, the index still narrowed to **4–12% of the
+95K files**.
 
 The suite now uses queries a kernel developer would actually run
 (`devm_platform_ioremap_resource`, `netif_napi_add`, `blk_mq_alloc_tag_set`):
 a different set of 102 queries returning 188,862 matches, none above 6,000.
-ripgrep's Linux total barely moved — 33–46s across the five most recent runs
+ripgrep's Linux total barely moved — 33–46s across the six most recent runs
 spanning both query sets, with a single 103s outlier in the earliest, because it
 scans every file whichever pattern it gets — while tgrep's fell from 49–128s on
-the old set to 6.5–8.1s on the new one. That difference is the delivery cost,
+the old set to 4.6–8.1s on the new one. That difference is the delivery cost,
 isolated.
 
 A caution on reading the ratios: the ripgrep baselines themselves move between
-runner sessions, and macOS moves most. Four runs of the *identical* kernel suite
-measured macOS ripgrep at 385s, 388s, 495s and 500s — a 1.3x spread from runner
+runner sessions, and macOS moves most. Five runs of the *identical* kernel suite
+measured macOS ripgrep at 385s, 388s, 495s, 500s and 550s — a 1.4x spread from runner
 variance alone — so treat a single macOS column as an order of magnitude rather than a
 precise figure. The Linux column is the stable one, and it is also the least
 flattering.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -140,19 +140,21 @@ Peak figures here are the OS process high-water mark (`PeakWorkingSetSize` on
 Windows, `VmHWM` on Linux), sampled externally. `tgrep index` now reports the
 same counter itself on completion, so these numbers are reproducible without
 external tooling; the self-reported and externally-sampled values agree exactly.
+Since large files became memory-mapped, resident set also counts mapped file
+pages, so it overstates what the process holds — where that matters below,
+private bytes are reported alongside it.
 
-**What the 64 MiB file-size cap costs.** The table above holds the arena fixed
-and varies the budget. Raising the *indexing* cap from 1 MiB to the current
-64 MiB default moves the floor under all of it, because the builder reads each
-file whole and in parallel, so several 20 MB generated headers are resident at
-once. Same host and repo, default arena:
+**What a file-size cap costs.** The table above holds the arena fixed and varies
+the budget. Raising the *indexing* cap from 1 MiB moved the floor under all of
+it, because the builder read each file whole and in parallel, so several 20 MB
+generated headers were resident at once. Same host and repo, default arena:
 
 | `--max-filesize` | Files indexed | Skipped as too large | Peak working set | Build |
 | ---: | ---: | ---: | ---: | ---: |
-| 1 MiB (old default) | 94,637 | 110 | 151.2 MiB | 25.5 s |
+| 1 MiB (oldest default) | 94,637 | 110 | 151.2 MiB | 25.5 s |
 | 8 MiB | 94,736 | 11 | 304.1 MiB | 24.4 s |
 | 16 MiB | 94,745 | 2 | 341.2 MiB | 24.5 s |
-| 64 MiB (**default**) | 94,747 | 0 | 338.8 MiB | 25.5 s |
+| 64 MiB | 94,747 | 0 | 338.8 MiB | 25.5 s |
 
 The cost is a step, not a slope: almost all of it is paid on the first megabyte
 past the old cap, and 16 MiB and 64 MiB are within noise of each other. So a cap
@@ -164,7 +166,7 @@ is 24 MB and contributes 7,263 distinct trigrams, fewer than the 10,936 of the
 224 KB `fs/ext4/super.c`.
 
 **Bounding what the cap admits.** Those peaks are what the cap cost *before* the
-builder was taught to bound it. Two changes since: trigram extraction no longer
+builder was taught to bound it. Two changes: trigram extraction no longer
 materialises a lowercased copy of each file, and batches are bounded by
 cumulative bytes rather than file count, so the raw bytes in flight are capped
 however large the files are. Same host and repo, minimum of three runs:
@@ -183,6 +185,44 @@ was both slower *and* hungrier here (38.4 s, 254.0 MiB), because the kernel's
 large files are a rare minority and the extra headroom bought no parallelism.
 It only pays off on a tree that is nothing but oversized generated headers, where
 it recovers about half the throughput cost for double the memory.
+
+**Removing the cap.** Bounding the bytes in flight made the peak predictable but
+left it proportional to the largest files, which is why a cap still looked
+necessary. Mapping files past 1 MiB instead of reading them removes that link,
+and with it the reason for the cap. ripgrep has no default `--max-filesize`
+either, and this is the mechanism that lets it not need one.
+
+From here the two metrics diverge and have to be reported separately. Resident
+set counts mapped file pages, so it barely moves; *private* bytes — the memory
+the process actually holds and cannot hand back — is what the change targets.
+Interleaved A/B runs on the kernel, alternating binaries to keep the page cache
+from favouring whichever ran second:
+
+| | Private bytes | Resident set | Build |
+| --- | ---: | ---: | ---: |
+| 64 MiB cap, heap reads | 197.2 / 199.5 MiB | 202.8 / 205.1 MiB | 41.1 / 42.2 s |
+| No cap, mapped over 1 MiB | **152.4 / 152.4 MiB (−23%)** | 192.2 / 195.7 MiB | **27.0 / 27.0 s (−36%)** |
+
+Both produce the same index (447,080 trigrams over 94,744 files), because the
+kernel has nothing above 64 MiB — the time and memory come from the mapping, not
+from indexing more. The effect is far larger where the files are: on a single
+192 MB file, private bytes are 67.1 MiB, and searching one fell from 291.3 MiB
+to 58.2 MiB.
+
+The threshold is 1 MiB because that is where the measurement pointed. In the AMD
+register headers, the worst case in the tree, an 8 MiB threshold mapped only 11
+of 488 files and left 69% of the bytes on the heap, while 1 MiB maps 102 files
+covering 87%. It stays cheap on ordinary trees because only 110 of the kernel's
+94,747 files reach it at all.
+
+**What removing the cap still costs.** A file that is neither valid UTF-8 nor
+detectably binary cannot be mapped: the index must hold the same `U+FFFD`-repaired
+bytes a search will match against, so it is decoded onto the heap. Two fixes keep
+that proportional rather than multiplied — the repaired buffer is now sized
+exactly instead of doubling out of a `bytes.len()` guess, and indexing skips the
+per-repair offset table it never reads. On a 135 MB Latin-1 file that took
+private bytes from 504.2 MiB (3.7x the file) to 204.6 MiB (1.5x).
+
 
 **Why the merge shares one read budget.** The first implementation gave every
 open segment a fixed 256 KiB read-ahead buffer, which made merge memory

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -165,12 +165,11 @@ including at 1,946-segment fan-in; re-verified after `external` became the
 default with 7 queries over 100,130 matches.
 
 Peak figures here are the OS process high-water mark (`PeakWorkingSetSize` on
-Windows, `VmHWM` on Linux), sampled externally. `tgrep index` now reports the
-same counter itself on completion, so these numbers are reproducible without
-external tooling; the self-reported and externally-sampled values agree exactly.
-Since large files became memory-mapped, resident set also counts mapped file
-pages, so it overstates what the process holds — where that matters below,
-private bytes are reported alongside it.
+Windows, `VmHWM` on Linux), sampled externally. Since large files became
+memory-mapped, that counter also counts mapped file pages, so it overstates what
+the process holds — where that matters below, private bytes are reported
+alongside it. `tgrep index` and `tgrep serve` now lead with private bytes for
+that reason; see "What `peak memory` reports" below.
 
 **What a file-size cap costs.** The table above holds the arena fixed and varies
 the budget. Raising the *indexing* cap from 1 MiB moved the floor under all of
@@ -290,6 +289,53 @@ Memory moves the way mapping implies. On the mixed-case corpus, private bytes
 went 71.4 MiB to 78.1 MiB while resident set went 59.3 MiB to 228.1 MiB: the
 increase is entirely file-backed pages the kernel can reclaim, held by the
 256 MiB mapped budget, and the heap the process actually owns barely moved.
+
+**What `peak memory` reports.** Mapping large files made the number tgrep printed
+wrong. It was `PeakWorkingSetSize` / `VmHWM`, which counts resident mapped file
+pages, so once indexing mapped files it tracked the size of the files rather than
+the memory tgrep held. A `tgrep serve` bootstrap over a 290k-file internal
+monorepo reported `peak memory 13.49 GiB`, which prompted this investigation.
+
+Reproducing at that scale showed the build itself was never the problem. On a
+generated 290,700-file / 4.2 GB corpus:
+
+| | Reported peak | Private bytes | Wall |
+| --- | ---: | ---: | ---: |
+| `tgrep index` | 305.1 MiB | 318.0 MiB | 816 s |
+| `tgrep serve` bootstrap | 382.3 MiB | 386.8 MiB | 609 s |
+
+The builder is bounded by construction — batches cap at 1,024 files and 64 MiB of
+heap, the sort arena is 64 MiB, and the merge reads through buffers sized from
+that same budget — so scale alone cannot produce gigabytes. Isolating a single
+oversized file does, because `batch_ranges` gives a file larger than a budget a
+batch of its own and the whole file is then mapped and scanned:
+
+| Corpus | Reported peak (old) | Private bytes | Overstatement |
+| --- | ---: | ---: | ---: |
+| 1 x 2 GiB file | 1.99 GiB | **77.8 MiB** | 26x |
+| 200 x 8 MiB files | 470.2 MiB | **365.4 MiB** | 1.3x |
+| 290,700 files, 4.2 GB | 305.1 MiB | 318.0 MiB | none |
+
+So the metric, not the build, is what scales with file size. Two consequences
+were fixed:
+
+*Reporting.* Both commands now lead with private bytes — `PagefileUsage` on
+Windows, `RssAnon` on Linux — and name the working set separately only when it is
+both 25% and 64 MiB larger, so the mapped-page component is visible instead of
+being folded into a figure that reads as tgrep's own use. The 2 GiB case now
+prints `77.8 MiB private, 1.99 GiB working set incl. memory-mapped files`.
+Linux has no kernel high-water mark for anonymous memory alone, so the peak is
+sampled on a background thread for the duration of a build; without it the
+reported peak would be whatever survived the build, which is a small fraction of
+the true high point once the sorter drops its arena. macOS exposes the split only
+through Mach `TASK_VM_INFO`, which `libc` does not surface, so it still reports
+resident set.
+
+*The memory cap.* It was enforced against the working set too. Mapped pages are
+file-backed and reclaimable, so charging them against a heap budget fires the cap
+on memory no flush can return — the build pays for a full overlay flush and is
+still over budget on the next check, which is exactly the "flush did not reclaim
+memory" path the code warns about. The cap now charges private bytes.
 
 
 **Why the merge shares one read budget.** The first implementation gave every

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -532,18 +532,20 @@ file selection.
 
 The kernel suite used to demonstrate this the hard way. Its queries were generic
 tokens — `read`, `write`, `^#define\s+[A-Z_]+` — that matched most of the tree:
-5,398,512 matches across 102 queries, with a single query returning 2,089,941. On
-that set tgrep took 60.2s on Linux against ripgrep's 45.4s, the only losing cell
-we ever measured. Index pruning was not the problem; measured directly on a local
-kernel checkout, the index still narrowed to **4–12% of the 95K files**.
+5,398,512 matches across 102 queries, with a single query returning 2,089,941.
+Kernel Linux is the only cell tgrep has ever lost, and on that query set it lost
+every run: 0.81x, 0.74x and 0.95x, the closest being 48.6s against ripgrep's
+46.4s. Index pruning was not the problem; measured directly on a local kernel
+checkout, the index still narrowed to **4–12% of the 95K files**.
 
 The suite now uses queries a kernel developer would actually run
 (`devm_platform_ioremap_resource`, `netif_napi_add`, `blk_mq_alloc_tag_set`):
-188,862 matches over the same 102 queries, none above 6,000. ripgrep's Linux total
-was unmoved by the change — across six runs spanning both query sets it has stayed
-between 28s and 46s, because it scans every file whichever pattern it gets — while
-tgrep's fell from 43–90s on the old set to 6.5–7.5s on the new one. That difference
-is the delivery cost, isolated.
+a different set of 102 queries returning 188,862 matches, none above 6,000.
+ripgrep's Linux total barely moved — 33–46s across the five most recent runs
+spanning both query sets, with a single 103s outlier in the earliest, because it
+scans every file whichever pattern it gets — while tgrep's fell from 49–128s on
+the old set to 6.5–7.5s on the new one. That difference is the delivery cost,
+isolated.
 
 A caution on reading the ratios: the ripgrep baselines themselves move between
 runner sessions, and macOS moves most. Three runs of the *identical* kernel suite

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -163,6 +163,27 @@ the files a size cap catches are generated and repetitive: `dcn_3_2_0_sh_mask.h`
 is 24 MB and contributes 7,263 distinct trigrams, fewer than the 10,936 of the
 224 KB `fs/ext4/super.c`.
 
+**Bounding what the cap admits.** Those peaks are what the cap cost *before* the
+builder was taught to bound it. Two changes since: trigram extraction no longer
+materialises a lowercased copy of each file, and batches are bounded by
+cumulative bytes rather than file count, so the raw bytes in flight are capped
+however large the files are. Same host and repo, minimum of three runs:
+
+| | Peak working set | Build |
+| --- | ---: | ---: |
+| Before | 291.5 MiB | 36.2 s |
+| After | 198.1 MiB (−32%) | 37.8 s (+4%) |
+
+The variance matters as much as the mean. Across those runs the old path ranged
+291.5–400.5 MiB while the new one ranged 198.1–203.5 MiB, so a 109 MiB spread
+became a 5 MiB one: bounding the bytes in flight makes peak memory repeatable,
+not just smaller. The budget is deliberately a flat 64 MiB rather than something
+that scales with the thread pool — a larger, pool-scaled budget was measured and
+was both slower *and* hungrier here (38.4 s, 254.0 MiB), because the kernel's
+large files are a rare minority and the extra headroom bought no parallelism.
+It only pays off on a tree that is nothing but oversized generated headers, where
+it recovers about half the throughput cost for double the memory.
+
 **Why the merge shares one read budget.** The first implementation gave every
 open segment a fixed 256 KiB read-ahead buffer, which made merge memory
 `segments * 256 KiB` — unbounded in fan-in. Since a smaller arena spills *more*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,7 @@ dependencies = [
  "encoding_rs",
  "globset",
  "ignore",
+ "memchr",
  "memmap2",
  "rayon",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,8 @@ dependencies = [
  "globset",
  "libc",
  "lru",
+ "memchr",
+ "memmap2",
  "notify",
  "predicates",
  "rayon",

--- a/README.md
+++ b/README.md
@@ -226,24 +226,30 @@ reduction in peak memory, and no slower**:
 identical runs because `Vec` growth doubles and both buffers are briefly
 resident during the final reallocation, while `external` varied by 8 MiB.
 
-The indexing cap has since been removed entirely, which changes the peaks quoted
-in this section. Files past 1 MiB are memory-mapped rather than read onto the
-heap, so the `external` build on the same repo now settles at roughly **152 MiB
-of private memory in 27 s**, against 197-200 MiB and 41-42 s when a 64 MiB cap
-was still in force. The arena bound is unchanged; what changed is that a handful
-of 20 MB generated headers no longer cost their full size in heap in every
-worker that touches one.
+The 1 MiB indexing cap those rows were measured under is now 64 MiB, and files
+past 1 MiB are memory-mapped rather than read onto the heap. On the same repo the
+`external` build now settles at roughly **152 MiB of private memory in 27 s**,
+against 197-200 MiB and 41-42 s when every admitted file was read onto the heap.
+The arena bound is unchanged; what changed is that a handful of 20 MB generated
+headers no longer cost their full size in heap in every worker that touches one.
+The 152 MiB figure was taken with no cap at all, and the 64 MiB default excludes
+only files *above* 64 MiB, so it leaves these numbers alone here: the largest file
+in the kernel tree is a 22.9 MiB generated AMD register header, and nothing in its
+95,862 files reaches the cap.
 
-Two caveats on reading those numbers. The peak tgrep prints is *resident set*,
-which counts mapped file pages, so it now reads higher than the memory the
-process actually holds — the same build reports ~192 MiB resident against
-152 MiB private. Mapped pages are file-backed and reclaimable under pressure,
-which heap is not. And a very large file that is neither valid UTF-8 nor
-detectably binary still costs about its own size, because the index has to hold
-the same repaired bytes a search will match against; a 135 MB Latin-1 file
-indexes at roughly 205 MiB.
+Two caveats on reading those numbers. The peak tgrep prints is *private bytes*,
+which excludes mapped file pages, so it reports what the process actually holds
+rather than the size of the files it is reading — the same build is 152 MiB
+private against ~192 MiB resident, and the working set is named alongside only
+when it is substantially larger, as in [Build the index](#build-the-index).
+macOS is the exception: `libc` does not surface the Mach counter that separates
+the two, so it still reports resident set there. And a very large file that is
+neither valid UTF-8 nor detectably binary still costs about its own size, because
+the index has to hold the same repaired bytes a search will match against; a
+135 MB Latin-1 file indexes at roughly 205 MiB.
 
-Pass `--max-filesize` if a build has to fit a tighter budget.
+Pass `--max-filesize` if a build has to fit a tighter budget, or
+`--no-max-filesize` to lift the 64 MiB default entirely.
 
 `--index-strategy=memory` remains available as an escape hatch for environments
 where spilling is undesirable or impossible, such as a read-only or full index

--- a/README.md
+++ b/README.md
@@ -283,6 +283,23 @@ Resource use during that initial build can be tuned. These apply to both
 | `--auto-save-mutations <N>` | `5000` | Accumulated index changes that trigger a background save; higher means fewer pauses but more to redo if killed |
 | `--watcher-queue-cap <N>` | `16384` | Filesystem events buffered between the OS watcher and the indexing worker; raise it if bulk changes log watcher queue overflows, since each overflow forces a full stale check |
 
+#### Staying in step with the filesystem
+
+Once the index is built, everything that changes it arrives as an OS
+notification, and a notification can go missing — a queue overflow, a network
+or virtualised filesystem that declines to report a change, a tree replaced
+wholesale by a branch switch or a build. Overflow is detected and repaired at
+once; the rest is silent, and nothing else in the server revisits a file it
+believes it already knows. A missed change would otherwise last until that
+file happened to change again, which for a deleted file is never.
+
+So a watching server also reconciles on a timer: about once an hour it walks
+the tree and compares it against the index, which finds any drift regardless
+of what the watcher heard. It waits for a two-minute gap in queries first, and
+gives up waiting after four hours so a continuously busy server still
+reconciles. On an unchanged tree it finds nothing and leaves the index alone.
+`--no-watch` turns it off along with the watcher.
+
 ### Search
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,28 +17,29 @@ tgrep serve .            # start server (watches for file changes)
 tgrep "fn main" .        # instant — auto-connects to running server
 ```
 
-See [full benchmark results](BENCHMARKS.md) — up to **58x faster** than ripgrep on large repos.
+See [full benchmark results](BENCHMARKS.md) — up to **43x faster** than ripgrep on large repos.
 
 ### Benchmark highlights (avg latency per query, index pre-built)
 
 | Repo | Files | Platform | ripgrep | tgrep | Speedup |
 | --- | ---: | --- | ---: | ---: | ---: |
-| gecko-dev | 388K | macOS arm64 | 31,364ms | 544ms | **58x** |
-| gecko-dev | 388K | Windows | 17,447ms | 376ms | **46x** |
-| gecko-dev | 388K | Linux | 1,760ms | 207ms | **8.5x** |
-| chromium | 504K | macOS arm64 | 45,728ms | 2,226ms | **21x** |
-| chromium | 504K | Windows | 25,262ms | 1,690ms | **15x** |
-| chromium | 504K | Linux | 2,377ms | 762ms | **3.1x** |
-| go | 16K | Windows | 480ms | 93ms | **5.2x** |
-| rust | 62K | Windows | 1,897ms | 229ms | **8.3x** |
-| kubernetes | 31K | Windows | 1,378ms | 202ms | **6.8x** |
-| linux | 96K | macOS arm64 | 3,804ms | 154ms | **25x** |
-| linux | 96K | Windows | 2,599ms | 132ms | **20x** |
-| linux | 96K | Linux | 328ms | 64ms | **5.2x** |
+| gecko-dev | 388K | macOS arm64 | 34,289ms | 798ms | **42.9x** |
+| gecko-dev | 388K | Windows | 18,005ms | 517ms | **34.8x** |
+| gecko-dev | 388K | Linux | 1,768ms | 235ms | **7.5x** |
+| chromium | 504K | macOS arm64 | 34,887ms | 3,240ms | **10.8x** |
+| chromium | 504K | Windows | 25,652ms | 1,906ms | **13.5x** |
+| chromium | 504K | Linux | 1,543ms | 655ms | **2.36x** |
+| go | 16K | Windows | 599ms | 97ms | **6.2x** |
+| rust | 62K | Windows | 1,995ms | 247ms | **8.1x** |
+| kubernetes | 31K | Windows | 1,393ms | 236ms | **5.9x** |
+| linux | 96K | macOS arm64 | 3,770ms | 168ms | **22.4x** |
+| linux | 96K | Windows | 3,270ms | 130ms | **25.1x** |
+| linux | 96K | Linux | 435ms | 79ms | **5.5x** |
 
-tgrep is faster in all 18 measured cells. The margin depends on repo size and on how
-many matches a query returns — a search that returns tens of thousands of matches
-spends more on delivering them than the index saves on finding them. See
+tgrep does not lose any of the 18 measured cells; Kubernetes/Linux is effectively
+tied at 1.004x. The margin depends on repo size and on how many matches a query
+returns — a search that returns tens of thousands of matches spends more on
+delivering them than the index saves on finding them. See
 [What decides the margin](BENCHMARKS.md#what-decides-the-margin).
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -17,27 +17,27 @@ tgrep serve .            # start server (watches for file changes)
 tgrep "fn main" .        # instant — auto-connects to running server
 ```
 
-See [full benchmark results](BENCHMARKS.md) — up to **43x faster** than ripgrep on large repos.
+See [full benchmark results](BENCHMARKS.md) — up to **52x faster** than ripgrep on large repos.
 
 ### Benchmark highlights (avg latency per query, index pre-built)
 
 | Repo | Files | Platform | ripgrep | tgrep | Speedup |
 | --- | ---: | --- | ---: | ---: | ---: |
-| gecko-dev | 388K | macOS arm64 | 34,289ms | 798ms | **42.9x** |
-| gecko-dev | 388K | Windows | 18,005ms | 517ms | **34.8x** |
-| gecko-dev | 388K | Linux | 1,768ms | 235ms | **7.5x** |
-| chromium | 504K | macOS arm64 | 34,887ms | 3,240ms | **10.8x** |
-| chromium | 504K | Windows | 25,652ms | 1,906ms | **13.5x** |
-| chromium | 504K | Linux | 1,543ms | 655ms | **2.36x** |
-| go | 16K | Windows | 599ms | 97ms | **6.2x** |
-| rust | 62K | Windows | 1,995ms | 247ms | **8.1x** |
-| kubernetes | 31K | Windows | 1,393ms | 236ms | **5.9x** |
-| linux | 96K | macOS arm64 | 3,770ms | 168ms | **22.4x** |
-| linux | 96K | Windows | 3,270ms | 130ms | **25.1x** |
-| linux | 96K | Linux | 435ms | 79ms | **5.5x** |
+| gecko-dev | 388K | macOS arm64 | 33,402ms | 643ms | **51.9x** |
+| gecko-dev | 388K | Windows | 17,841ms | 463ms | **38.6x** |
+| gecko-dev | 388K | Linux | 1,195ms | 162ms | **7.36x** |
+| chromium | 504K | macOS arm64 | 41,806ms | 2,643ms | **15.8x** |
+| chromium | 504K | Windows | 24,576ms | 1,396ms | **17.6x** |
+| chromium | 504K | Linux | 2,404ms | 631ms | **3.81x** |
+| go | 16K | Windows | 592ms | 79ms | **7.53x** |
+| rust | 62K | Windows | 1,489ms | 194ms | **7.69x** |
+| kubernetes | 31K | Windows | 1,342ms | 190ms | **7.08x** |
+| linux | 96K | macOS arm64 | 5,390ms | 256ms | **21.0x** |
+| linux | 96K | Windows | 3,280ms | 94ms | **34.8x** |
+| linux | 96K | Linux | 427ms | 46ms | **9.38x** |
 
-tgrep does not lose any of the 18 measured cells; Kubernetes/Linux is effectively
-tied at 1.004x. The margin depends on repo size and on how many matches a query
+tgrep wins 17 of the 18 measured cells; the exception is Kubernetes on Linux, a
+near-tie at 0.93x. The margin depends on repo size and on how many matches a query
 returns — a search that returns tens of thousands of matches spends more on
 delivering them than the index saves on finding them. See
 [What decides the margin](BENCHMARKS.md#what-decides-the-margin).

--- a/README.md
+++ b/README.md
@@ -557,6 +557,12 @@ reported no match on a file ripgrep would have matched. Files past 1 MiB are
 memory-mapped during both indexing and searching, which is what makes indexing
 them affordable.
 
+Mapped files are also batched by what they actually put on the heap rather than
+by their length, so a build over large files fills its worker pool instead of
+running two files at a time. Combined with a faster trigram extractor, that made
+indexing a tree of 32 MiB source files about 14x faster; ordinary small-file
+trees are unchanged. See [BENCHMARKS.md](BENCHMARKS.md).
+
 ### Exit codes
 
 Same as ripgrep:

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ tgrep is designed to be significantly faster than ripgrep on large repos:
   sorted postings, file entries, and lookup entries instead of retaining the full
   inverted index in memory
 - **Smart file walking** — extension-based binary rejection (50+ formats) and an
-  8KB content check, with no size cap on either indexing or searching (see
-  `--max-filesize` to opt into one)
+  8KB content check, with a 64 MiB size cap on both indexing and searching
+  (`--no-max-filesize` removes it)
 - **Lock-free reads** — `RwLock<HashMap>` cache allows concurrent reads
   without contention
 - **Hot serving** — queries work immediately during background index building;
@@ -157,7 +157,8 @@ index` that built an index and the `tgrep serve` that serves it.
 The server compares the index against the filesystem at startup and treats an
 indexed file it cannot see as deleted. So serving an index built without a cap
 under a `--max-filesize 8M` server drops every file above 8 MiB from that index,
-permanently. Pass the same flags to both:
+permanently. Both sides default to 64 MiB, so this only bites when one side
+names a limit; pass the same flags to both:
 
 ```bash
 tgrep index . --max-filesize 8M
@@ -369,7 +370,8 @@ Prints the count to stdout (scriptable) and details to stderr:
 | `-a, --text` | Search binary files as if they were text |
 | `--binary` | Search binary files, reporting a note instead of their contents |
 | `-u, --unrestricted` | Unrestricted: `-u` = no-ignore, `-uu` = +hidden, `-uuu` = +binary |
-| `--max-filesize <SIZE>` | Skip files larger than `SIZE` (`K`/`M`/`G` suffixes) |
+| `--max-filesize <SIZE>` | Skip files larger than `SIZE` (`K`/`M`/`G` suffixes); default 64M |
+| `--no-max-filesize` | Apply no size limit, as ripgrep does |
 | `-L, --follow` | Follow symbolic links |
 | `--no-messages` | Suppress error messages about unreadable/missing paths |
 | `--no-index` | Skip index, grep all files |
@@ -554,22 +556,43 @@ lines that are not valid UTF-8:
 
 ### File size limits
 
-Neither searching nor indexing has a size limit by default — every text file is
-read regardless of size, matching ripgrep. Pass `--max-filesize` to opt into one.
+Searching and indexing both skip files larger than **64 MiB** by default. This
+is a deliberate divergence from ripgrep, which has no default limit.
 
-`tgrep index` used to cap indexed files, which bought little and cost
-correctness: large files are usually generated and repetitive, so they
-contribute far fewer distinct trigrams per byte than ordinary source, while an
-oversized file was counted but never recorded — so an indexed search silently
-reported no match on a file ripgrep would have matched. Files past 1 MiB are
-memory-mapped during both indexing and searching, which is what makes indexing
-them affordable.
+The divergence is affordable because tgrep is not a one-shot scanner. A file a
+walk picks up is also a file the index carries and re-reads on every query whose
+trigrams make it a candidate, so an outlier's cost is paid repeatedly rather
+than once. On a 292,911-file enlistment where one 13.41 GiB generated build
+artifact was 71% of all searchable bytes, the cap cut a cold index build from
+214.5 s to 64.2 s and a warm query from 21.30 s to 0.55 s — a 39x difference —
+at the cost of one match in one generated file, and it excluded 2 files out of
+292,911.
 
-Mapped files are also batched by what they actually put on the heap rather than
-by their length, so a build over large files fills its worker pool instead of
+The cost is real: an oversized file is counted but its path is never recorded,
+so a match inside one is reported as no match. Two rules keep that from being
+silent:
+
+- `--no-max-filesize` restores the uncapped, ripgrep-identical behaviour, and
+  `--max-filesize` sets a different bound.
+- A file named directly on the command line is never dropped by the *inherited*
+  default, only by a limit you passed. `tgrep pattern ./huge.log` searches
+  `huge.log`.
+
+The limit is resolved once, before the walk and the search diverge, so an index
+and the queries against it always agree on which files exist. A walk that capped
+where the search did not would be indistinguishable from "this file contains no
+match".
+
+The cap is not what bounds memory. Files past 1 MiB are memory-mapped during
+both indexing and searching, so their pages are file-backed and reclaimable, and
+mapped files are batched by what they actually put on the heap rather than by
+their length — so a build over large files fills its worker pool instead of
 running two files at a time. Combined with a faster trigram extractor, that made
-indexing a tree of 32 MiB source files about 14x faster; ordinary small-file
-trees are unchanged. See [BENCHMARKS.md](BENCHMARKS.md).
+indexing a tree of 32 MiB source files about 14x faster. Nor is size a good
+proxy for *index* cost: oversized files are overwhelmingly generated and
+therefore repetitive, contributing far fewer distinct trigrams per byte than
+ordinary source. What the cap buys is bounded *scan* time. See
+[BENCHMARKS.md](BENCHMARKS.md).
 
 ### Exit codes
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ tgrep is designed to be significantly faster than ripgrep on large repos:
 - **Memory-efficient full builds** — index builds batch extraction and stream
   sorted postings, file entries, and lookup entries instead of retaining the full
   inverted index in memory
-- **Smart file walking** — extension-based binary rejection (50+ formats),
-  8KB content check, and a 64 MiB size cap when *indexing* (searching is
-  uncapped by default; see `--max-filesize`)
+- **Smart file walking** — extension-based binary rejection (50+ formats) and an
+  8KB content check, with no size cap on either indexing or searching (see
+  `--max-filesize` to opt into one)
 - **Lock-free reads** — `RwLock<HashMap>` cache allows concurrent reads
   without contention
 - **Hot serving** — queries work immediately during background index building;
@@ -128,7 +128,7 @@ tgrep says so rather than leaving you to guess:
 Walking /src/enlistment...
 warning: /src/enlistment has a .gitignore but is not a git repository, so it is
 not applied (this matches ripgrep). Pass --no-require-git to apply it.
-Found 289320 text files (2893 binary skipped, 698 too large, 0 errors)
+Found 290018 text files (2893 binary skipped, 0 too large, 0 errors)
 ```
 
 `--no-require-git` applies the rules anyway, and works on `index`, `serve`, and
@@ -146,13 +146,13 @@ Flags that decide *which files belong in the index* — `--no-require-git`,
 index` that built an index and the `tgrep serve` that serves it.
 
 The server compares the index against the filesystem at startup and treats an
-indexed file it cannot see as deleted. So serving an index built with
-`--max-filesize 128M` under the 64 MiB default drops every file above 64 MiB
-from that index, permanently. Pass the same flags to both:
+indexed file it cannot see as deleted. So serving an index built without a cap
+under a `--max-filesize 8M` server drops every file above 8 MiB from that index,
+permanently. Pass the same flags to both:
 
 ```bash
-tgrep index . --max-filesize 128M
-tgrep serve   --max-filesize 128M
+tgrep index . --max-filesize 8M
+tgrep serve   --max-filesize 8M
 ```
 
 #### Memory use on very large repos
@@ -187,15 +187,24 @@ reduction in peak memory, and no slower**:
 identical runs because `Vec` growth doubles and both buffers are briefly
 resident during the final reallocation, while `external` varied by 8 MiB.
 
-The indexing cap is now 64 MiB, which raises the peaks quoted in this section:
-the `external` build on the same repo peaks at roughly 198 MiB rather than 160.
-The arena bound is unchanged; the difference is that the builder reads each file
-whole, so a handful of 20 MB generated headers are resident at once. That is
-bounded on purpose — extraction no longer materialises a lowercased copy of each
-file, and batches are capped by cumulative bytes rather than file count, which
-holds the peak near 198 MiB (and within a 5 MiB spread across runs) instead of
-the ~291-400 MiB the unbounded path reached. Lower `--max-filesize` if a build
-has to fit a tighter budget.
+The indexing cap has since been removed entirely, which changes the peaks quoted
+in this section. Files past 1 MiB are memory-mapped rather than read onto the
+heap, so the `external` build on the same repo now settles at roughly **152 MiB
+of private memory in 27 s**, against 197-200 MiB and 41-42 s when a 64 MiB cap
+was still in force. The arena bound is unchanged; what changed is that a handful
+of 20 MB generated headers no longer cost their full size in heap in every
+worker that touches one.
+
+Two caveats on reading those numbers. The peak tgrep prints is *resident set*,
+which counts mapped file pages, so it now reads higher than the memory the
+process actually holds — the same build reports ~192 MiB resident against
+152 MiB private. Mapped pages are file-backed and reclaimable under pressure,
+which heap is not. And a very large file that is neither valid UTF-8 nor
+detectably binary still costs about its own size, because the index has to hold
+the same repaired bytes a search will match against; a 135 MB Latin-1 file
+indexes at roughly 205 MiB.
+
+Pass `--max-filesize` if a build has to fit a tighter budget.
 
 `--index-strategy=memory` remains available as an escape hatch for environments
 where spilling is undesirable or impossible, such as a read-only or full index
@@ -536,14 +545,16 @@ lines that are not valid UTF-8:
 
 ### File size limits
 
-Searching has **no size limit** by default — every text file is searched
-regardless of size. Pass `--max-filesize` to opt into one.
+Neither searching nor indexing has a size limit by default — every text file is
+read regardless of size, matching ripgrep. Pass `--max-filesize` to opt into one.
 
-`tgrep index` caps indexed files at 64 MiB by default; `--max-filesize`
-overrides that too. The cap is a guard against pathological inputs, not a cost
-control — large files are usually generated and repetitive, so they contribute
-far fewer distinct trigrams per byte than ordinary source, and a lower cap
-mainly bought silent misses on files ripgrep would have matched.
+`tgrep index` used to cap indexed files, which bought little and cost
+correctness: large files are usually generated and repetitive, so they
+contribute far fewer distinct trigrams per byte than ordinary source, while an
+oversized file was counted but never recorded — so an indexed search silently
+reported no match on a file ripgrep would have matched. Files past 1 MiB are
+memory-mapped during both indexing and searching, which is what makes indexing
+them affordable.
 
 ### Exit codes
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,16 @@ Index built successfully at /tmp/idx
 Indexed in 22.6s using external strategy (peak memory 160.1 MiB)
 ```
 
-The peak is the operating system's own high-water mark for the process, so it
-reflects the true maximum rather than a sampled snapshot.
+The peak is the memory the process itself holds — private/committed bytes, not
+resident set. The two differ once large files are memory-mapped: mapped pages are
+file-backed and reclaimable, so counting them would report the size of the files
+being indexed rather than tgrep's own use. Indexing a single 2 GiB file holds
+77.8 MiB while its working set reaches 1.99 GiB. When the working set is
+substantially larger it is named alongside, so nothing is hidden:
+
+```
+Indexed in 46.1s using external strategy (peak memory 77.8 MiB private, 1.99 GiB working set incl. memory-mapped files)
+```
 
 #### Repositories without a `.git` directory
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,35 @@ tgrep index . --no-require-git
 tgrep serve --no-require-git
 ```
 
+#### Case-insensitive repositories
+
+When git clones onto a filesystem that does not distinguish case — which on
+Windows is every clone — it sets `core.ignorecase` and stops distinguishing case
+when it matches ignore rules. A rule spelled `QLogs` then hides a directory
+named `qlogs`.
+
+Most tools, ripgrep included, always match ignore rules case-sensitively, so
+that directory is walked, read and indexed even though `git status` never
+mentions it. On one Windows enlistment that was a single 13.4 GiB build
+artifact, 71% of the corpus, adding about 16 seconds to *every* query.
+
+tgrep reads `core.ignorecase` and matches the way the repository itself does.
+Files git **tracks** are exempt, which is git's own rule — ignore rules only
+decide the fate of files git does not already know about. Without that
+exemption the same change would have hidden 273 tracked `.JPG`, `.PNG` and
+`.RLL` files caught by rules written in lower case.
+
+On that enlistment the walk went from listing one file more than
+`git ls-files --cached --others --exclude-standard` to matching it exactly, at a
+cost of roughly 0.4 s on a 293k-file walk. `--no-ignore` turns it off along with
+every other ignore source, and repositories that distinguish case are unaffected
+and pay nothing.
+
+Only the repository's own root `.gitignore` and `.git/info/exclude` are matched
+this way. Rules in nested `.gitignore` files are not, because the walk does not
+know they exist until it reaches their directory. Missing one only leaves a file
+visible that git would hide, which is what every other tool does anyway.
+
 #### Keep `index` and `serve` flags in step
 
 Flags that decide *which files belong in the index* — `--no-require-git`,

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ tgrep is designed to be significantly faster than ripgrep on large repos:
   sorted postings, file entries, and lookup entries instead of retaining the full
   inverted index in memory
 - **Smart file walking** — extension-based binary rejection (50+ formats),
-  8KB content check, and a 1 MB size cap when *indexing* (searching is
+  8KB content check, and a 64 MiB size cap when *indexing* (searching is
   uncapped by default; see `--max-filesize`)
 - **Lock-free reads** — `RwLock<HashMap>` cache allows concurrent reads
   without contention
@@ -147,12 +147,12 @@ index` that built an index and the `tgrep serve` that serves it.
 
 The server compares the index against the filesystem at startup and treats an
 indexed file it cannot see as deleted. So serving an index built with
-`--max-filesize 10M` under the 1 MB default drops every file above 1 MB from
-that index, permanently. Pass the same flags to both:
+`--max-filesize 128M` under the 64 MiB default drops every file above 64 MiB
+from that index, permanently. Pass the same flags to both:
 
 ```bash
-tgrep index . --max-filesize 10M
-tgrep serve   --max-filesize 10M
+tgrep index . --max-filesize 128M
+tgrep serve   --max-filesize 128M
 ```
 
 #### Memory use on very large repos
@@ -172,7 +172,8 @@ tgrep index . --index-buffer 16               # smaller arena, lower peak
 tgrep index . --index-strategy=memory         # opt out: sort entirely in RAM
 ```
 
-On the Linux kernel (94,634 files, 990 MiB index) the default is a **~17x
+On the Linux kernel (94,634 files, 990 MiB index), measured under the 1 MiB
+indexing cap that was the default at the time, the default strategy is a **~17x
 reduction in peak memory, and no slower**:
 
 | Strategy | Spill segments | Peak working set | Build |
@@ -185,6 +186,15 @@ reduction in peak memory, and no slower**:
 *predictable* memory — the `memory` row varied by over a gigabyte across
 identical runs because `Vec` growth doubles and both buffers are briefly
 resident during the final reallocation, while `external` varied by 8 MiB.
+
+The indexing cap is now 64 MiB, which raises the peaks quoted in this section —
+the `external` build on the same repo now peaks at roughly 340 MiB. The arena
+bound is unchanged; the difference is that the builder reads each file whole and
+in parallel, so a handful of 20 MB generated headers are resident at once. The
+rise is a step, not a slope — an 8 MiB cap already costs ~304 MiB, and 16 MiB
+and 64 MiB are within noise of each other — so a lower cap gives up files
+without buying much back. Lower `--max-filesize` if a build has to fit a tighter
+budget.
 
 `--index-strategy=memory` remains available as an escape hatch for environments
 where spilling is undesirable or impossible, such as a read-only or full index
@@ -525,8 +535,11 @@ lines that are not valid UTF-8:
 Searching has **no size limit** by default — every text file is searched
 regardless of size. Pass `--max-filesize` to opt into one.
 
-`tgrep index` still caps indexed files at 1 MiB by default (large files are
-mostly generated data and bloat the index); `--max-filesize` overrides that too.
+`tgrep index` caps indexed files at 64 MiB by default; `--max-filesize`
+overrides that too. The cap is a guard against pathological inputs, not a cost
+control — large files are usually generated and repetitive, so they contribute
+far fewer distinct trigrams per byte than ordinary source, and a lower cap
+mainly bought silent misses on files ripgrep would have matched.
 
 ### Exit codes
 

--- a/README.md
+++ b/README.md
@@ -187,18 +187,22 @@ reduction in peak memory, and no slower**:
 identical runs because `Vec` growth doubles and both buffers are briefly
 resident during the final reallocation, while `external` varied by 8 MiB.
 
-The indexing cap is now 64 MiB, which raises the peaks quoted in this section —
-the `external` build on the same repo now peaks at roughly 340 MiB. The arena
-bound is unchanged; the difference is that the builder reads each file whole and
-in parallel, so a handful of 20 MB generated headers are resident at once. The
-rise is a step, not a slope — an 8 MiB cap already costs ~304 MiB, and 16 MiB
-and 64 MiB are within noise of each other — so a lower cap gives up files
-without buying much back. Lower `--max-filesize` if a build has to fit a tighter
-budget.
+The indexing cap is now 64 MiB, which raises the peaks quoted in this section:
+the `external` build on the same repo peaks at roughly 198 MiB rather than 160.
+The arena bound is unchanged; the difference is that the builder reads each file
+whole, so a handful of 20 MB generated headers are resident at once. That is
+bounded on purpose — extraction no longer materialises a lowercased copy of each
+file, and batches are capped by cumulative bytes rather than file count, which
+holds the peak near 198 MiB (and within a 5 MiB spread across runs) instead of
+the ~291-400 MiB the unbounded path reached. Lower `--max-filesize` if a build
+has to fit a tighter budget.
 
 `--index-strategy=memory` remains available as an escape hatch for environments
 where spilling is undesirable or impossible, such as a read-only or full index
-volume. Both strategies produce byte-identical indexes. See
+volume. Both strategies produce byte-identical indexes from the same walk —
+note that file IDs follow walk order, which the parallel walker does not fix
+between runs, so two builds of the same tree need not be byte-identical to each
+other. See
 [BENCHMARKS.md](BENCHMARKS.md#index-build-strategies) for full numbers.
 
 `tgrep serve` uses the same bounded builder when it has to create an index from

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -27,6 +27,8 @@ fancy-regex = "0.14"
 lru = "0.16.3"
 fs2 = "0.4.3"
 globset = "0.4.18"
+memmap2 = "0.9"
+memchr = "2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_ProcessStatus", "Win32_System_SystemInformation", "Win32_System_Threading"] }

--- a/tgrep-cli/src/index.rs
+++ b/tgrep-cli/src/index.rs
@@ -66,6 +66,9 @@ pub fn run(opts: RunOptions<'_>) -> Result<()> {
     }
 
     let started = Instant::now();
+    // Dropped after the build so the sampled peak (on platforms without a
+    // kernel high-water mark) covers the whole of it.
+    let sampler = mem::PrivatePeakSampler::start();
     builder::build_index_with_options(
         root,
         index_path,
@@ -81,6 +84,7 @@ pub fn run(opts: RunOptions<'_>) -> Result<()> {
         },
     )?;
     let elapsed = started.elapsed();
+    drop(sampler);
 
     let strategy_label = match strategy {
         IndexStrategy::InMemory => "memory",
@@ -88,12 +92,12 @@ pub fn run(opts: RunOptions<'_>) -> Result<()> {
     };
     // Peak is an OS high-water mark for the whole process. `tgrep index` does
     // nothing substantial before the build, so it reads as the build's peak.
-    match mem::peak_rss_bytes() {
+    match mem::format_peak_memory() {
         Some(peak) => eprintln!(
             "Indexed in {:.1}s using {} strategy (peak memory {})",
             elapsed.as_secs_f64(),
             strategy_label,
-            mem::format_bytes(peak)
+            peak
         ),
         None => eprintln!(
             "Indexed in {:.1}s using {} strategy",

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -895,6 +895,75 @@ impl Cli {
             line_buffered: self.line_buffered,
         }
     }
+
+    /// File-discovery flags that are declared globally (so every subcommand
+    /// accepts them) but that `index` and `serve` do not plumb into their
+    /// walks.
+    ///
+    /// These change *which files exist* as far as the tool is concerned, so
+    /// accepting one and ignoring it produces an index that silently disagrees
+    /// with what was asked for — and, for `serve`, one that then disagrees with
+    /// `tgrep search` over the same tree. That is indistinguishable from a
+    /// corpus with no matches, so the only safe answer is to refuse.
+    ///
+    /// `--hidden` is honoured by `index` but not by `serve`, hence the
+    /// parameter. `--threads` is excluded deliberately: it is documented as
+    /// accepted-for-compatibility and ignored everywhere, not just here.
+    fn unsupported_discovery_flags(&self, hidden_supported: bool) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        if self.hidden && !hidden_supported {
+            out.push("--hidden");
+        }
+        if self.follow {
+            out.push("--follow");
+        }
+        if self.max_depth.is_some() {
+            out.push("--max-depth");
+        }
+        if self.one_file_system {
+            out.push("--one-file-system");
+        }
+        if !self.ignore_file.is_empty() {
+            out.push("--ignore-file");
+        }
+        if self.ignore_file_case_insensitive {
+            out.push("--ignore-file-case-insensitive");
+        }
+        if self.no_ignore_dot {
+            out.push("--no-ignore-dot");
+        }
+        if self.no_ignore_exclude {
+            out.push("--no-ignore-exclude");
+        }
+        if self.no_ignore_files {
+            out.push("--no-ignore-files");
+        }
+        if self.no_ignore_global {
+            out.push("--no-ignore-global");
+        }
+        if self.no_ignore_parent {
+            out.push("--no-ignore-parent");
+        }
+        if self.no_ignore_vcs {
+            out.push("--no-ignore-vcs");
+        }
+        out
+    }
+}
+
+/// Exit with a clear error rather than building an index under settings the
+/// caller did not ask for. See [`Cli::unsupported_discovery_flags`].
+fn reject_unsupported_discovery_flags(cli: &Cli, subcommand: &str, hidden_supported: bool) {
+    let unsupported = cli.unsupported_discovery_flags(hidden_supported);
+    if unsupported.is_empty() {
+        return;
+    }
+    eprintln!(
+        "tgrep: `{subcommand}` does not support {}; \
+         it would be ignored and the index would not match what you asked for",
+        unsupported.join(", ")
+    );
+    process::exit(2);
 }
 
 fn main() {
@@ -960,6 +1029,14 @@ fn run_cli() {
     };
     let max_filesize = resolved.max_filesize;
 
+    // Refuse discovery flags the index-building subcommands can't honour. Done
+    // before the match so the arms keep consuming `cli.command` by value.
+    match &cli.command {
+        Some(Command::Index { .. }) => reject_unsupported_discovery_flags(&cli, "index", true),
+        Some(Command::Serve { .. }) => reject_unsupported_discovery_flags(&cli, "serve", false),
+        _ => {}
+    }
+
     let result = match cli.command {
         Some(Command::Index {
             path,
@@ -967,18 +1044,20 @@ fn run_cli() {
             strategy,
             index_buffer_mb,
             ..
-        }) => index::run(index::RunOptions {
-            root: &path,
-            index_path: cli.index_path.as_deref(),
-            include_hidden: cli.hidden,
-            no_ignore,
-            no_require_git: cli.no_require_git,
-            exclude_dirs: &exclude,
-            strategy: strategy.into(),
-            index_buffer_mb,
-            // Neither indexing nor searching caps file size by default.
-            max_file_size: max_filesize.or(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE),
-        }),
+        }) => {
+            index::run(index::RunOptions {
+                root: &path,
+                index_path: cli.index_path.as_deref(),
+                include_hidden: cli.hidden,
+                no_ignore,
+                no_require_git: cli.no_require_git,
+                exclude_dirs: &exclude,
+                strategy: strategy.into(),
+                index_buffer_mb,
+                // Neither indexing nor searching caps file size by default.
+                max_file_size: max_filesize.or(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE),
+            })
+        }
         Some(Command::Serve {
             path,
             no_watch,

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -976,8 +976,8 @@ fn run_cli() {
             exclude_dirs: &exclude,
             strategy: strategy.into(),
             index_buffer_mb,
-            // Indexing keeps a size cap by default; searching does not.
-            max_file_size: max_filesize.or(Some(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE)),
+            // Neither indexing nor searching caps file size by default.
+            max_file_size: max_filesize.or(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE),
         }),
         Some(Command::Serve {
             path,
@@ -1002,9 +1002,8 @@ fn run_cli() {
                     index_threads,
                     no_ignore,
                     no_require_git: cli.no_require_git,
-                    // Same default as `index`: serve builds and stale-checks
-                    // with a size cap unless the user raises it.
-                    max_file_size: max_filesize.or(Some(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE)),
+                    // Same default as `index`: no size cap unless asked for.
+                    max_file_size: max_filesize.or(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE),
                     auto_save_mutations,
                     // Clap's range bound guarantees this fits; saturating keeps
                     // the conversion total, and errs toward a large cap rather

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -1181,7 +1181,6 @@ fn run_search(
             report_missing_path(&target.path, opts.no_messages);
             continue;
         }
-        opts.path_display = target.display();
         writer.set_path_display(target.display());
         match search::run(&target.path, cli.index_path.as_deref(), &opts, &mut writer) {
             Ok(true) => {

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -773,6 +773,19 @@ impl Cli {
         let binary = self.binary || self.unrestricted >= 3;
         let text = self.text;
 
+        // ripgrep implements `-c`, `--count-matches`, `-l`, `--files-without-match`
+        // and `--files` in a printer that predates `--json` and has no JSON form,
+        // so those flags win outright and the whole invocation produces no JSON —
+        // not even a `summary`. Dropping the flag here rather than only in
+        // `make_output_config` keeps every other `json`-conditional decision
+        // (binary handling, match detail) consistent with the printer in use.
+        let json = self.json
+            && !(self.count
+                || self.count_matches
+                || self.files_only
+                || self.files_without_match
+                || self.list_files);
+
         search::SearchOptions {
             pattern,
             extra_patterns: self.regexp.clone(),
@@ -786,7 +799,7 @@ impl Cli {
             count: self.count,
             word_boundary: self.word_regexp,
             max_count: self.max_count,
-            json: self.json,
+            json,
             vimgrep: self.vimgrep,
             stats: self.stats || self.debug || self.trace,
             no_index: self.no_index,
@@ -1157,16 +1170,26 @@ fn run_search(
     opts.no_filename = cli.no_filename
         || (!cli.with_filename && !cli.vimgrep && targets.len() == 1 && targets[0].path.is_file());
 
+    // One writer for the whole invocation: ripgrep emits a single JSON
+    // `summary` covering every path it was given, so per-path writers would
+    // report one summary each and a consumer reading "the" summary would see
+    // only the first path's numbers.
+    let mut writer = search::new_writer(&opts);
+
     for target in targets {
         if !target.path.exists() {
             report_missing_path(&target.path, opts.no_messages);
             continue;
         }
         opts.path_display = target.display();
-        match search::run(&target.path, cli.index_path.as_deref(), &opts) {
+        writer.set_path_display(target.display());
+        match search::run(&target.path, cli.index_path.as_deref(), &opts, &mut writer) {
             Ok(true) => {
                 had_matches = true;
                 if opts.quiet {
+                    // `process::exit` skips destructors, so the summary and any
+                    // buffered output have to be committed explicitly.
+                    let _ = writer.finish();
                     process::exit(0);
                 }
             }
@@ -1175,10 +1198,13 @@ fn run_search(
                 if !opts.no_messages {
                     eprintln!("tgrep: {e}");
                 }
+                let _ = writer.finish();
                 process::exit(2);
             }
         }
     }
+
+    writer.finish()?;
 
     // ripgrep's exit code: 0 on a match with no errors, 2 if anything was
     // reported to stderr, otherwise 1 for "no matches".

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -161,7 +161,11 @@ struct Cli {
     max_filesize: Option<String>,
 
     /// Apply no file size limit, as ripgrep does.
-    #[arg(long = "no-max-filesize", global = true, overrides_with = "max_filesize")]
+    #[arg(
+        long = "no-max-filesize",
+        global = true,
+        overrides_with = "max_filesize"
+    )]
     no_max_filesize: bool,
 
     /// Text encoding to use: `auto` (BOM sniffing), `none`, or a label like `utf-16le`.

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -151,8 +151,18 @@ struct Cli {
     type_list: bool,
 
     /// Ignore files larger than NUM bytes (suffixes K, M, G allowed).
-    #[arg(long = "max-filesize", global = true, value_name = "NUM")]
+    /// Defaults to 64M; use --no-max-filesize for no limit.
+    #[arg(
+        long = "max-filesize",
+        global = true,
+        value_name = "NUM",
+        overrides_with = "no_max_filesize"
+    )]
     max_filesize: Option<String>,
+
+    /// Apply no file size limit, as ripgrep does.
+    #[arg(long = "no-max-filesize", global = true, overrides_with = "max_filesize")]
+    no_max_filesize: bool,
 
     /// Text encoding to use: `auto` (BOM sniffing), `none`, or a label like `utf-16le`.
     #[arg(
@@ -489,6 +499,11 @@ struct Cli {
 /// Every argument that needs parsing and can fail, resolved once up front.
 struct ResolvedArgs {
     max_filesize: Option<u64>,
+    /// Whether the size limit was asked for rather than inherited from
+    /// [`tgrep_core::walker::DEFAULT_MAX_FILE_SIZE`]. A file named directly on
+    /// the command line ignores the inherited limit — pointing at a file is an
+    /// unambiguous request to search it — but honours one the user set.
+    max_filesize_requested: bool,
     encoding: tgrep_core::encoding::EncodingMode,
     engine: matching::RegexEngine,
     regex_size_limit: Option<usize>,
@@ -676,11 +691,19 @@ enum Command {
 impl Cli {
     /// Resolve `--max-filesize` once, so a malformed value is reported instead
     /// of silently falling back to a different limit than the user asked for.
+    ///
+    /// Absent both flags this is [`walker::DEFAULT_MAX_FILE_SIZE`], not `None`.
+    /// Resolving the default *here* rather than at each use is what keeps the
+    /// index and the search agreeing: a walk that capped at 64 MiB while the
+    /// search did not would look exactly like "this file contains no match".
     fn max_filesize_bytes(&self) -> Result<Option<u64>> {
-        self.max_filesize
-            .as_deref()
-            .map(|s| parse_byte_size("--max-filesize", s))
-            .transpose()
+        if self.no_max_filesize {
+            return Ok(None);
+        }
+        match self.max_filesize.as_deref() {
+            Some(s) => Ok(Some(parse_byte_size("--max-filesize", s)?)),
+            None => Ok(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE),
+        }
     }
 
     /// Resolve `-E/--encoding`. `--no-encoding` means `auto`, and clap's
@@ -715,6 +738,7 @@ impl Cli {
 
         Ok(ResolvedArgs {
             max_filesize: self.max_filesize_bytes()?,
+            max_filesize_requested: self.max_filesize.is_some(),
             encoding: self.encoding_mode()?,
             engine,
             regex_size_limit: self
@@ -840,6 +864,7 @@ impl Cli {
             // Replaced per path argument in `run_search`.
             path_display: crate::output::PathDisplay::Bare,
             max_filesize: resolved.max_filesize,
+            max_filesize_requested: resolved.max_filesize_requested,
             encoding: resolved.encoding,
             follow: self.follow,
             no_messages: self.no_messages,
@@ -1054,8 +1079,9 @@ fn run_cli() {
                 exclude_dirs: &exclude,
                 strategy: strategy.into(),
                 index_buffer_mb,
-                // Neither indexing nor searching caps file size by default.
-                max_file_size: max_filesize.or(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE),
+                // Already carries `walker::DEFAULT_MAX_FILE_SIZE` when the user
+                // named no limit, so indexing and searching cap identically.
+                max_file_size: max_filesize,
             })
         }
         Some(Command::Serve {
@@ -1081,8 +1107,9 @@ fn run_cli() {
                     index_threads,
                     no_ignore,
                     no_require_git: cli.no_require_git,
-                    // Same default as `index`: no size cap unless asked for.
-                    max_file_size: max_filesize.or(tgrep_core::walker::DEFAULT_MAX_FILE_SIZE),
+                    // Same resolved value the search path uses, so the index
+                    // and the queries against it agree on what exists.
+                    max_file_size: max_filesize,
                     auto_save_mutations,
                     // Clap's range bound guarantees this fits; saturating keeps
                     // the conversion total, and errs toward a large cap rather

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -789,6 +789,100 @@ impl<'a> FileMatches<'a> {
     }
 }
 
+/// Whether `pattern` is free of anchors whose meaning depends on where the
+/// haystack starts and ends.
+///
+/// Line-oriented matching runs the pattern against one line at a time, so `^`,
+/// `$`, `\A`, `\z` and `\Z` all bind to the line. Running the identical regex
+/// over the whole buffer instead would bind them to the buffer, which *narrows*
+/// what matches - the one direction a prescan must never take. Without them the
+/// two haystacks agree, because nothing else in the pattern can observe where
+/// the haystack was cut.
+///
+/// Character classes are not tracked: a `^` or `$` inside one is a literal and
+/// would be safe, but treating it as an anchor only costs the optimisation, not
+/// correctness. Erring toward "not anchor-free" is always sound.
+fn pattern_is_anchor_free(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => {
+                // `\A`, `\z` and `\Z` stay bound to the haystack ends even under
+                // `(?m)`, so they can never be made line-relative.
+                match bytes.get(i + 1) {
+                    Some(b'A') | Some(b'z') | Some(b'Z') => return false,
+                    Some(_) => i += 2,
+                    None => return false,
+                }
+            }
+            b'^' | b'$' => return false,
+            _ => i += 1,
+        }
+    }
+    true
+}
+
+/// The lines that could possibly contain a match, or `None` for "check them
+/// all".
+///
+/// The line-oriented loop asks the regex engine once per line. On a
+/// multi-gigabyte file that is billions of calls, and the engine's SIMD
+/// prefilter never gets a run long enough to pay for itself - which is most of
+/// why a whole-file scan costs several times what ripgrep charges. Scanning the
+/// buffer once and verifying only the lines a match touches collapses that to a
+/// single pass.
+///
+/// Soundness rests on two things. The pattern must be anchor-free, so that a
+/// line and the buffer are interchangeable haystacks. And every line a returned
+/// match *spans* is a candidate, not just the line it starts on: `find_iter`
+/// yields leftmost non-overlapping matches, so a match beginning on an earlier
+/// line can be the one that covers this line's match, and a pattern that can
+/// cross `\n` (via `\s`, a negated class, or `-s`) can span several. Under those
+/// rules every line that really matches is covered, and the per-line matcher
+/// still has the final say, so extra candidates cost time and never accuracy.
+fn candidate_lines<'a>(
+    content: &'a str,
+    index: &'a LineIndex,
+    matcher: &'a SearchMatcher,
+    opts: &MatchOptions,
+) -> Option<impl Iterator<Item = usize> + 'a> {
+    // `--stop-on-nonmatch` has to see the first line that *fails*, which a
+    // candidate list by construction skips over.
+    if opts.stop_on_nonmatch {
+        return None;
+    }
+    let SearchMatcher::Standard(re) = matcher else {
+        return None;
+    };
+    if !pattern_is_anchor_free(re.as_str()) {
+        return None;
+    }
+    // A pattern that matches the empty string matches at every offset, so the
+    // prescan would yield every line and the real loop is cheaper.
+    if re.is_match("") {
+        return None;
+    }
+
+    let mut last: Option<usize> = None;
+    Some(
+        re.find_iter(content)
+            .flat_map(move |m| {
+                let first = index.line_of(m.start());
+                // Matches are non-empty here, so `end - 1` is inside the match.
+                let last_line = index.line_of(m.end() - 1);
+                first..=last_line
+            })
+            .filter(move |&li| {
+                let fresh = last != Some(li);
+                if fresh {
+                    last = Some(li);
+                }
+                fresh
+            }),
+    )
+}
+
 /// Find every matching line together with the match ranges inside it.
 fn collect_hits(
     content: &str,
@@ -848,7 +942,7 @@ fn collect_hits(
     // Line-oriented mode: match each line separately so `^` and `$` anchor
     // per line, as ripgrep does.
     let mut out = Vec::new();
-    for i in 0..index.line_count() {
+    let visit = |i: usize, out: &mut Vec<LineHit>| -> Result<bool> {
         let spans = if opts.all_spans {
             matcher.find_spans(index.line_text(content, i))?
         } else {
@@ -860,9 +954,27 @@ fn collect_hits(
         if !spans.is_empty() {
             out.push(LineHit { idx: i, spans });
             if max.is_some_and(|m| out.len() >= m) {
-                break;
+                return Ok(false);
             }
         } else if opts.stop_on_nonmatch && !out.is_empty() {
+            return Ok(false);
+        }
+        Ok(true)
+    };
+
+    // The prescan is lazy, so `--max-count` still stops early instead of
+    // scanning the rest of the file for candidates it will never look at.
+    if let Some(candidates) = candidate_lines(content, index, matcher, opts) {
+        for i in candidates {
+            if !visit(i, &mut out)? {
+                break;
+            }
+        }
+        return Ok(out);
+    }
+
+    for i in 0..index.line_count() {
+        if !visit(i, &mut out)? {
             break;
         }
     }
@@ -874,7 +986,165 @@ mod tests {
     use super::*;
 
     // -----------------------------------------------------------------------
-    // The backtracking-engine prefilter
+    // The whole-buffer line prescan
+    //
+    // Asking the regex engine once per line is billions of calls on a large
+    // file. Scanning the buffer once and verifying only the lines a match
+    // touches is equivalent *only* when the pattern cannot tell where the
+    // haystack was cut, so these pin down both the gate and the equivalence.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn anchors_disable_the_prescan() {
+        assert!(pattern_is_anchor_free("needle"));
+        assert!(pattern_is_anchor_free(r"\bneedle\b"));
+        assert!(pattern_is_anchor_free(r"a\\b"));
+        assert!(pattern_is_anchor_free(r"\^literal"));
+        assert!(pattern_is_anchor_free(r"\$literal"));
+
+        assert!(!pattern_is_anchor_free("^needle"));
+        assert!(!pattern_is_anchor_free("needle$"));
+        assert!(!pattern_is_anchor_free(r"\Aneedle"));
+        assert!(!pattern_is_anchor_free(r"needle\z"));
+        assert!(!pattern_is_anchor_free(r"needle\Z"));
+        // A class member is a literal, but rejecting it only loses speed.
+        assert!(!pattern_is_anchor_free("[$]"));
+        // A trailing backslash is malformed; refuse rather than index past it.
+        assert!(!pattern_is_anchor_free("needle\\"));
+    }
+
+    // The property that makes the prescan safe: for every pattern it accepts,
+    // the lines it proposes are a superset of the lines that actually match.
+    // Brute-forced against the per-line loop the prescan replaces.
+    #[test]
+    fn prescan_never_drops_a_matching_line() {
+        let patterns = [
+            "a",
+            "ab",
+            "a.c",
+            "a+b",
+            "[abc]+",
+            "a|bc",
+            r"\bword\b",
+            r"\s+x",
+            "a\nb",
+            r"[^q]z",
+            "(?i)ABC",
+            r"\d+",
+            "xyz",
+        ];
+        let haystacks = [
+            "",
+            "a",
+            "abc\n",
+            "abc\ndef\n",
+            "a\nb\nc\n",
+            "aaa\nbbb\nccc",
+            "word here\nno match\nanother word\n",
+            "x\r\ny\r\n",
+            " x\n  x\nq\n",
+            "az\nqz\nbz\n",
+            "ABC\nabc\nAbC\n",
+            "12\n34a\n\n56\n",
+            "no matches at all\nnothing here\n",
+            "a\n\n\na\n",
+        ];
+
+        for pat in patterns {
+            let re = regex::Regex::new(pat).expect("test pattern compiles");
+            let matcher = SearchMatcher::Standard(re);
+            for hay in haystacks {
+                let index = LineIndex::new(hay);
+                let opts = MatchOptions::default();
+
+                // Lines that genuinely match, computed the slow, obvious way.
+                let mut expected = Vec::new();
+                for i in 0..index.line_count() {
+                    if matcher
+                        .is_match(index.line_text(hay, i))
+                        .expect("standard matcher cannot error")
+                    {
+                        expected.push(i);
+                    }
+                }
+
+                // Declining is always allowed; it just means the full loop.
+                if let Some(iter) = candidate_lines(hay, &index, &matcher, &opts) {
+                    let proposed: Vec<usize> = iter.collect();
+                    // Ascending and deduplicated, so `--max-count` can stop
+                    // early and still return the first N matching lines.
+                    assert!(
+                        proposed.windows(2).all(|w| w[0] < w[1]),
+                        "pattern {pat:?} on {hay:?}: candidates {proposed:?} not ascending"
+                    );
+                    for want in &expected {
+                        assert!(
+                            proposed.contains(want),
+                            "pattern {pat:?} on {hay:?}: line {want} matches but was not proposed \
+                             (candidates {proposed:?})"
+                        );
+                    }
+                }
+
+                // Whichever path it took, the answer must be the same.
+                let hits = collect_hits(hay, &index, &matcher, &opts)
+                    .expect("standard matcher cannot error");
+                let got: Vec<usize> = hits.iter().map(|h| h.idx).collect();
+                assert_eq!(got, expected, "pattern {pat:?} on {hay:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn prescan_respects_max_count_and_stop_on_nonmatch() {
+        let hay = "hit\nhit\nmiss\nhit\n";
+        let matcher = SearchMatcher::Standard(regex::Regex::new("hit").unwrap());
+        let index = LineIndex::new(hay);
+
+        let opts = MatchOptions {
+            max_count: Some(2),
+            ..MatchOptions::default()
+        };
+        let hits = collect_hits(hay, &index, &matcher, &opts).unwrap();
+        assert_eq!(hits.iter().map(|h| h.idx).collect::<Vec<_>>(), vec![0, 1]);
+
+        // `--stop-on-nonmatch` must see line 2 fail, which a candidate list
+        // skips, so the prescan has to decline outright.
+        let opts = MatchOptions {
+            stop_on_nonmatch: true,
+            ..MatchOptions::default()
+        };
+        assert!(candidate_lines(hay, &index, &matcher, &opts).is_none());
+        let hits = collect_hits(hay, &index, &matcher, &opts).unwrap();
+        assert_eq!(hits.iter().map(|h| h.idx).collect::<Vec<_>>(), vec![0, 1]);
+    }
+
+    #[test]
+    fn prescan_declines_when_every_line_matches_anyway() {
+        // An empty-matching pattern matches at every offset, so a prescan would
+        // propose every line at the cost of an extra pass.
+        let hay = "a\nb\n";
+        let index = LineIndex::new(hay);
+        let matcher = SearchMatcher::Standard(regex::Regex::new("x*").unwrap());
+        let opts = MatchOptions::default();
+        assert!(candidate_lines(hay, &index, &matcher, &opts).is_none());
+    }
+
+    #[test]
+    fn prescan_proposes_every_line_a_match_spans() {
+        // `\s+` matches across the newline, so one match covers both lines and
+        // both have to be offered.
+        let hay = "a \n b\nzzz\n";
+        let index = LineIndex::new(hay);
+        let matcher = SearchMatcher::Standard(regex::Regex::new(r"\s+").unwrap());
+        let opts = MatchOptions::default();
+        let proposed: Vec<usize> = candidate_lines(hay, &index, &matcher, &opts)
+            .expect("anchor-free and non-empty")
+            .collect();
+        assert!(proposed.contains(&0));
+        assert!(proposed.contains(&1));
+    }
+
     //
     // `fancy_regex`'s VM has no literal prefilter, so a pattern like
     // `(?<!//)Needle` is tried at every byte offset. Gating it on a relaxed,

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -23,11 +23,15 @@ impl LineIndex {
     pub fn new(content: &str) -> Self {
         let mut starts = Vec::new();
         if !content.is_empty() {
+            // Size the index up front. It holds one `usize` per line, so
+            // growing it by doubling both overshoots — up to twice what is
+            // needed — and copies the whole thing on the way there. On a large
+            // file that transient is tens of megabytes, which is pure waste
+            // when the exact count is one SIMD scan away.
+            starts.reserve_exact(1 + memchr::memchr_iter(b'\n', content.as_bytes()).count());
             starts.push(0);
-            for (i, b) in content.bytes().enumerate() {
-                if b == b'\n' {
-                    starts.push(i + 1);
-                }
+            for i in memchr::memchr_iter(b'\n', content.as_bytes()) {
+                starts.push(i + 1);
             }
             // A trailing newline opens a final empty line that `str::lines`
             // does not yield. Drop it so line counts agree with the rest of

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -224,7 +224,23 @@ pub fn expand_context_window(
 /// `fancy_regex` is the fallback for backreferences and lookaround.
 pub enum SearchMatcher {
     Standard(regex::Regex),
-    Fancy(fancy_regex::Regex),
+    /// A backtracking match, optionally gated by a linear-time prefilter.
+    ///
+    /// `fancy_regex` already delegates to `regex` when a pattern needs nothing
+    /// fancy, so this variant only really costs anything when a construct like
+    /// lookaround forces the backtracking VM. That VM has no literal prefilter,
+    /// so it tries to match at *every* byte offset - on a multi-gigabyte file
+    /// that is the difference between seconds and never finishing.
+    ///
+    /// `prefilter` is the pattern relaxed into a form the linear-time engine can
+    /// compile (see `tgrep_core::query::relax_for_indexing`). Relaxation only
+    /// widens the language, so a haystack the prefilter rejects cannot possibly
+    /// match the real pattern - which makes it sound to use for negative
+    /// answers, and only for negative answers.
+    Fancy {
+        re: fancy_regex::Regex,
+        prefilter: Option<regex::Regex>,
+    },
 }
 
 impl SearchMatcher {
@@ -232,12 +248,24 @@ impl SearchMatcher {
         matches!(self, SearchMatcher::Standard(_))
     }
 
+    /// Whether the prefilter has already ruled this haystack out.
+    ///
+    /// A `false` from the prefilter is conclusive; a `true` means nothing, and
+    /// the real matcher still has to run.
+    fn ruled_out(prefilter: &Option<regex::Regex>, hay: &str) -> bool {
+        prefilter.as_ref().is_some_and(|re| !re.is_match(hay))
+    }
+
     pub fn is_match(&self, hay: &str) -> Result<bool> {
         match self {
             SearchMatcher::Standard(re) => Ok(re.is_match(hay)),
-            SearchMatcher::Fancy(re) => re
-                .is_match(hay)
-                .map_err(|e| anyhow::anyhow!("regex match error: {e}")),
+            SearchMatcher::Fancy { re, prefilter } => {
+                if Self::ruled_out(prefilter, hay) {
+                    return Ok(false);
+                }
+                re.is_match(hay)
+                    .map_err(|e| anyhow::anyhow!("regex match error: {e}"))
+            }
         }
     }
 
@@ -250,7 +278,10 @@ impl SearchMatcher {
                     spans.push((m.start(), m.end()));
                 }
             }
-            SearchMatcher::Fancy(re) => {
+            SearchMatcher::Fancy { re, prefilter } => {
+                if Self::ruled_out(prefilter, hay) {
+                    return Ok(spans);
+                }
                 for m in re.find_iter(hay) {
                     let m = m.map_err(|e| anyhow::anyhow!("regex match error: {e}"))?;
                     spans.push((m.start(), m.end()));
@@ -267,10 +298,14 @@ impl SearchMatcher {
     pub fn find_first_span(&self, hay: &str) -> Result<Option<(usize, usize)>> {
         match self {
             SearchMatcher::Standard(re) => Ok(re.find(hay).map(|m| (m.start(), m.end()))),
-            SearchMatcher::Fancy(re) => re
-                .find(hay)
-                .map(|m| m.map(|m| (m.start(), m.end())))
-                .map_err(|e| anyhow::anyhow!("regex match error: {e}")),
+            SearchMatcher::Fancy { re, prefilter } => {
+                if Self::ruled_out(prefilter, hay) {
+                    return Ok(None);
+                }
+                re.find(hay)
+                    .map(|m| m.map(|m| (m.start(), m.end())))
+                    .map_err(|e| anyhow::anyhow!("regex match error: {e}"))
+            }
         }
     }
 
@@ -310,7 +345,10 @@ impl SearchMatcher {
                     out.push((m.start(), m.end(), dst));
                 }
             }
-            SearchMatcher::Fancy(re) => {
+            SearchMatcher::Fancy { re, prefilter } => {
+                if Self::ruled_out(prefilter, hay) {
+                    return Ok(out);
+                }
                 for caps in re.captures_iter(hay) {
                     let caps = caps.map_err(|e| anyhow::anyhow!("regex match error: {e}"))?;
                     let m = caps.get(0).expect("group 0 always participates");
@@ -419,14 +457,34 @@ fn build_fancy(combined: &str, cfg: &MatcherConfig) -> Result<SearchMatcher> {
     if cfg.dotall {
         flags.push('s');
     }
-    let pattern = if flags.is_empty() {
-        combined.to_string()
-    } else {
-        format!("(?{flags}:{combined})")
+    let wrap = |body: &str| {
+        if flags.is_empty() {
+            body.to_string()
+        } else {
+            format!("(?{flags}:{body})")
+        }
     };
-    fancy_regex::Regex::new(&pattern)
-        .map(SearchMatcher::Fancy)
-        .map_err(|e| anyhow::anyhow!("{e}"))
+    let pattern = wrap(combined);
+    let re = fancy_regex::Regex::new(&pattern).map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(SearchMatcher::Fancy {
+        re,
+        prefilter: build_fancy_prefilter(combined, &wrap),
+    })
+}
+
+/// Compile a linear-time approximation of `combined` to use as a prefilter.
+///
+/// Only worth building when relaxation actually removed something: if the
+/// relaxed pattern is identical, `fancy_regex` is already delegating to `regex`
+/// internally and a second engine would be pure overhead. Anything that fails to
+/// relax or fails to compile simply yields no prefilter, which costs performance
+/// and never correctness.
+fn build_fancy_prefilter(combined: &str, wrap: &dyn Fn(&str) -> String) -> Option<regex::Regex> {
+    let relaxed = tgrep_core::query::relax_for_indexing(combined)?;
+    if relaxed == combined {
+        return None;
+    }
+    regex::Regex::new(&wrap(&relaxed)).ok()
 }
 
 fn combine_patterns(
@@ -814,6 +872,257 @@ fn collect_hits(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // The backtracking-engine prefilter
+    //
+    // `fancy_regex`'s VM has no literal prefilter, so a pattern like
+    // `(?<!//)Needle` is tried at every byte offset. Gating it on a relaxed,
+    // linear-time approximation makes the common "this haystack has nothing"
+    // case cheap. The prefilter is only ever allowed to answer *no*, so these
+    // tests care about one thing above all: the answers must not change.
+    // -----------------------------------------------------------------------
+
+    fn pcre(pattern: &str) -> SearchMatcher {
+        build_search_matcher(
+            &[pattern.to_string()],
+            &MatcherConfig {
+                engine: RegexEngine::Pcre2,
+                ..Default::default()
+            },
+        )
+        .expect("pattern compiles")
+    }
+
+    #[test]
+    fn a_lookaround_pattern_gets_a_prefilter() {
+        match pcre(r"(?<!//)Needle") {
+            SearchMatcher::Fancy { prefilter, .. } => {
+                let re = prefilter.expect("lookaround is relaxable, so it is worth prefiltering");
+                assert!(re.is_match("x Needle"), "the prefilter admits real matches");
+                assert!(
+                    re.is_match("//Needle"),
+                    "and admits near-misses too - it only rules things out"
+                );
+                assert!(!re.is_match("nothing here"));
+            }
+            _ => panic!("expected a fancy matcher"),
+        }
+    }
+
+    #[test]
+    fn a_pattern_with_nothing_to_relax_gets_no_prefilter() {
+        // `fancy_regex` already delegates these to `regex`; a second engine
+        // would be pure overhead.
+        for pattern in ["Needle", r"Needle\d+"] {
+            match pcre(pattern) {
+                SearchMatcher::Fancy { prefilter, .. } => {
+                    assert!(prefilter.is_none(), "{pattern} needs no prefilter")
+                }
+                _ => panic!("expected a fancy matcher"),
+            }
+        }
+    }
+
+    #[test]
+    fn an_unrelaxable_pattern_gets_no_prefilter() {
+        match pcre(r"(Needle)\1") {
+            SearchMatcher::Fancy { prefilter, .. } => assert!(prefilter.is_none()),
+            _ => panic!("expected a fancy matcher"),
+        }
+    }
+
+    #[test]
+    fn the_prefilter_does_not_change_any_answer() {
+        // Each case pairs a haystack with whether the real pattern matches it.
+        // A prefilter that ever turned a `true` into a `false` would be silently
+        // losing results, which is the failure mode worth guarding.
+        let cases: [(&str, &[(&str, bool)]); 5] = [
+            (
+                r"(?<!//)Needle",
+                &[
+                    ("let x = Needle;", true),
+                    ("//Needle", false),
+                    ("nothing at all", false),
+                    ("//Needle and Needle", true),
+                ],
+            ),
+            (
+                r"Needle(?=::)",
+                &[("Needle::new", true), ("Needle.new", false)],
+            ),
+            (
+                r"Needle(?!::)",
+                &[("Needle::new", false), ("Needle.new", true)],
+            ),
+            (
+                r"(?>Nee)dle",
+                &[("Needle", true), ("Needle", true), ("nope", false)],
+            ),
+            (
+                r"(?=.*Haystack)Needle",
+                &[
+                    ("Needle in a Haystack", true),
+                    ("Needle alone", false),
+                    ("Haystack alone", false),
+                ],
+            ),
+        ];
+
+        for (pattern, haystacks) in cases {
+            let gated = pcre(pattern);
+            // The same pattern with the prefilter removed, as the control.
+            let ungated = match pcre(pattern) {
+                SearchMatcher::Fancy { re, .. } => SearchMatcher::Fancy {
+                    re,
+                    prefilter: None,
+                },
+                other => other,
+            };
+            for (hay, expected) in haystacks {
+                assert_eq!(
+                    gated.is_match(hay).unwrap(),
+                    *expected,
+                    "{pattern:?} against {hay:?}"
+                );
+                assert_eq!(
+                    gated.is_match(hay).unwrap(),
+                    ungated.is_match(hay).unwrap(),
+                    "prefilter changed is_match for {pattern:?} against {hay:?}"
+                );
+                assert_eq!(
+                    gated.find_spans(hay).unwrap(),
+                    ungated.find_spans(hay).unwrap(),
+                    "prefilter changed find_spans for {pattern:?} against {hay:?}"
+                );
+                assert_eq!(
+                    gated.find_first_span(hay).unwrap(),
+                    ungated.find_first_span(hay).unwrap(),
+                    "prefilter changed find_first_span for {pattern:?} against {hay:?}"
+                );
+            }
+        }
+    }
+
+    /// The subset property, checked by brute force over a broad pattern corpus.
+    ///
+    /// This is the assumption the whole optimisation rests on, in both places it
+    /// is used - candidate planning and the prefilter - so it is worth checking
+    /// against the real backtracking engine rather than by inspection. For every
+    /// pattern and every haystack: if `fancy_regex` matches, the relaxed pattern
+    /// compiled with `regex` must match too. The converse is allowed and
+    /// expected; that is what makes it a *relaxation*.
+    #[test]
+    fn relaxation_is_a_superset_of_every_pattern_it_accepts() {
+        let patterns = [
+            r"(?<!//)Needle",
+            r"(?<=//)Needle",
+            r"Needle(?=::)",
+            r"Needle(?!::)",
+            r"(?=.*Hay)Needle",
+            r"(?!.*Hay)Needle",
+            r"^(?=.*a)(?=.*b).*$",
+            r"(?>Nee)dle",
+            r"a(?>b|bc)d",
+            r"(?:Nee(?=d))+dle",
+            r"\bNeedle\b(?!s)",
+            r"(?i)(?<!x)needle",
+            r"[Nn](?<!x)eedle",
+            r"(?<!\w)Needle",
+            r"Needle(?=\s*[;,])",
+            r"(?<name>Nee)(?=dle)dle",
+            r"(a(?=b)|c)d",
+            r"^(?!#)\s*Needle",
+            r"Needle(?![)])",
+            r"(?=[(])\(Needle",
+            // Character-class forms: `(?=` and friends are ordinary members here.
+            r"[](?=a)]n",
+            r"[^](?<!a)]n",
+            r"[[:digit:](?=a)]n",
+            r"[]a]n",
+            r"[[:alpha:]]eedle(?!s)",
+            r"\p{L}+(?=dle)",
+        ];
+        let haystacks = [
+            "",
+            "Needle",
+            "//Needle",
+            " Needle ",
+            "Needle::new()",
+            "Needle.new()",
+            "Needle in a Hay stack",
+            "ab",
+            "ba",
+            "abd",
+            "abcd",
+            "cd",
+            "needle",
+            "xneedle",
+            "Needles",
+            "Needle;",
+            "Needle , x",
+            "# Needle",
+            "  Needle",
+            "Needle)",
+            "(Needle",
+            "NeeNeedle",
+            "no match at all",
+            "]Needle[",
+            "]n",
+            "an",
+            "(n",
+            "?n",
+            "=n",
+            "3n",
+            "Needle(?=a)",
+            "\u{3b1}\u{3b2}dle",
+        ];
+
+        for pattern in patterns {
+            let fancy = fancy_regex::Regex::new(pattern).expect("pattern compiles as PCRE");
+            let Some(relaxed_src) = tgrep_core::query::relax_for_indexing(pattern) else {
+                continue; // bailing out is always safe
+            };
+            let Ok(relaxed) = regex::Regex::new(&relaxed_src) else {
+                continue; // failing to compile degrades to a full scan
+            };
+            for hay in haystacks {
+                if fancy.is_match(hay).unwrap() {
+                    assert!(
+                        relaxed.is_match(hay),
+                        "relaxation NARROWED {pattern:?} to {relaxed_src:?}: it drops {hay:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn the_prefilter_inherits_the_case_insensitive_flag() {
+        // A prefilter compiled without `-i` would reject `NEEDLE` outright and
+        // hide a match the real pattern would have found.
+        let matcher = build_search_matcher(
+            &[r"(?<!//)Needle".to_string()],
+            &MatcherConfig {
+                engine: RegexEngine::Pcre2,
+                case_insensitive: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(matcher.is_match("let x = NEEDLE;").unwrap());
+        assert!(!matcher.is_match("//NEEDLE").unwrap());
+    }
+
+    #[test]
+    fn the_prefilter_survives_replacement() {
+        let matcher = pcre(r"(?<!//)Needle");
+        let (out, _) = matcher.replace_all("a Needle here", "Pin").unwrap();
+        assert_eq!(out, "a Pin here");
+        let (out, spans) = matcher.replace_all("no match here", "Pin").unwrap();
+        assert_eq!(out, "no match here");
+        assert!(spans.is_empty());
+    }
 
     #[test]
     fn line_blocks_merge_matches_that_share_a_line() {

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -14,48 +14,64 @@ use regex::RegexBuilder;
 /// Search results are produced as byte ranges over the whole file so a single
 /// match can span lines (`--multiline`). This maps those ranges back to line
 /// numbers and columns.
-pub struct LineIndex {
-    starts: Vec<usize>,
-    len: usize,
+///
+/// The table is built on first use rather than up front, because most searches
+/// never need it. It costs one `usize` per line — 670 MB on a 13.4 GiB file
+/// with 83.8M lines — plus two `memchr` passes over the whole buffer, and a
+/// file with no match asks it nothing at all: the whole-buffer prescan finds no
+/// match, so no offset is ever mapped to a line. Building it eagerly was 4.7 s
+/// of the 30.7 s that file took to search, spent entirely on an answer nobody
+/// wanted.
+pub struct LineIndex<'a> {
+    content: &'a str,
+    starts: std::cell::OnceCell<Vec<usize>>,
 }
 
-impl LineIndex {
-    pub fn new(content: &str) -> Self {
-        let mut starts = Vec::new();
-        if !content.is_empty() {
-            // Size the index up front. It holds one `usize` per line, so
-            // growing it by doubling both overshoots — up to twice what is
-            // needed — and copies the whole thing on the way there. On a large
-            // file that transient is tens of megabytes, which is pure waste
-            // when the exact count is one SIMD scan away.
-            starts.reserve_exact(1 + memchr::memchr_iter(b'\n', content.as_bytes()).count());
-            starts.push(0);
-            for i in memchr::memchr_iter(b'\n', content.as_bytes()) {
-                starts.push(i + 1);
-            }
-            // A trailing newline opens a final empty line that `str::lines`
-            // does not yield. Drop it so line counts agree with the rest of
-            // the pipeline, which is still line-oriented.
-            if starts.len() > 1 && starts[starts.len() - 1] == content.len() {
-                starts.pop();
-            }
-        }
+impl<'a> LineIndex<'a> {
+    pub fn new(content: &'a str) -> Self {
         Self {
-            starts,
-            len: content.len(),
+            content,
+            starts: std::cell::OnceCell::new(),
         }
     }
 
+    fn starts(&self) -> &[usize] {
+        self.starts.get_or_init(|| {
+            let content = self.content;
+            let mut starts = Vec::new();
+            if !content.is_empty() {
+                // Size the index up front. It holds one `usize` per line, so
+                // growing it by doubling both overshoots — up to twice what is
+                // needed — and copies the whole thing on the way there. On a
+                // large file that transient is tens of megabytes, which is pure
+                // waste when the exact count is one SIMD scan away.
+                starts.reserve_exact(1 + memchr::memchr_iter(b'\n', content.as_bytes()).count());
+                starts.push(0);
+                for i in memchr::memchr_iter(b'\n', content.as_bytes()) {
+                    starts.push(i + 1);
+                }
+                // A trailing newline opens a final empty line that `str::lines`
+                // does not yield. Drop it so line counts agree with the rest of
+                // the pipeline, which is still line-oriented.
+                if starts.len() > 1 && starts[starts.len() - 1] == content.len() {
+                    starts.pop();
+                }
+            }
+            starts
+        })
+    }
+
     pub fn line_count(&self) -> usize {
-        self.starts.len()
+        self.starts().len()
     }
 
     /// 0-based index of the line containing `offset`.
     pub fn line_of(&self, offset: usize) -> usize {
-        if self.starts.is_empty() {
+        let starts = self.starts();
+        if starts.is_empty() {
             return 0;
         }
-        match self.starts.binary_search(&offset) {
+        match starts.binary_search(&offset) {
             Ok(i) => i,
             // `starts[0]` is always 0, so a miss can never land at index 0.
             Err(i) => i - 1,
@@ -63,14 +79,18 @@ impl LineIndex {
     }
 
     pub fn line_start(&self, idx: usize) -> usize {
-        self.starts.get(idx).copied().unwrap_or(self.len)
+        self.starts().get(idx).copied().unwrap_or(self.content.len())
     }
 
     /// End offset of line `idx`, excluding its `\n` or `\r\n` terminator.
-    pub fn line_end(&self, content: &str, idx: usize) -> usize {
+    pub fn line_end(&self, idx: usize) -> usize {
         let start = self.line_start(idx);
-        let mut end = self.starts.get(idx + 1).copied().unwrap_or(self.len);
-        let bytes = content.as_bytes();
+        let mut end = self
+            .starts()
+            .get(idx + 1)
+            .copied()
+            .unwrap_or(self.content.len());
+        let bytes = self.content.as_bytes();
         if end > start && bytes[end - 1] == b'\n' {
             end -= 1;
         }
@@ -80,18 +100,22 @@ impl LineIndex {
         end
     }
 
-    /// Byte length of line `idx`'s terminator in `content`: 2 for `\r\n`, 1 for
-    /// a bare `\n`, 0 for a final line that the file does not terminate.
+    /// Byte length of line `idx`'s terminator in the buffer: 2 for `\r\n`, 1
+    /// for a bare `\n`, 0 for a final line that the file does not terminate.
     ///
     /// `-M/--max-columns` measures the line *including* its terminator, so this
     /// is needed to decide whether a line is over the limit.
-    pub fn line_terminator_len(&self, content: &str, idx: usize) -> usize {
-        let end = self.starts.get(idx + 1).copied().unwrap_or(self.len);
-        end - self.line_end(content, idx)
+    pub fn line_terminator_len(&self, idx: usize) -> usize {
+        let end = self
+            .starts()
+            .get(idx + 1)
+            .copied()
+            .unwrap_or(self.content.len());
+        end - self.line_end(idx)
     }
 
-    pub fn line_text<'a>(&self, content: &'a str, idx: usize) -> &'a str {
-        &content[self.line_start(idx)..self.line_end(content, idx)]
+    pub fn line_text(&self, idx: usize) -> &'a str {
+        &self.content[self.line_start(idx)..self.line_end(idx)]
     }
 }
 
@@ -112,7 +136,7 @@ pub struct LineHit {
 /// for `--max-count`, so several matches sharing a line spend one unit between
 /// them, and a match straddling two lines also spends just one.
 fn limit_to_line_blocks(
-    index: &LineIndex,
+    index: &LineIndex<'_>,
     spans: &[(usize, usize)],
     max: Option<usize>,
 ) -> Vec<(usize, usize)> {
@@ -147,14 +171,13 @@ fn limit_to_line_blocks(
 /// single line. ripgrep keeps the line the match *starts* on, which is the
 /// position an editor should jump to.
 fn clip_spans_to_start_line(
-    content: &str,
-    index: &LineIndex,
+    index: &LineIndex<'_>,
     spans: &[(usize, usize)],
 ) -> Vec<(usize, usize)> {
     spans
         .iter()
         .map(|&(s, e)| {
-            let line_end = index.line_end(content, index.line_of(s));
+            let line_end = index.line_end(index.line_of(s));
             (s, e.min(line_end))
         })
         .collect()
@@ -166,8 +189,7 @@ fn clip_spans_to_start_line(
 /// it touches has to be printed. Overlapping ranges on the same line are
 /// merged so highlighting never emits nested escape sequences.
 pub fn group_spans_by_line(
-    content: &str,
-    index: &LineIndex,
+    index: &LineIndex<'_>,
     spans: &[(usize, usize)],
 ) -> Vec<LineHit> {
     let mut by_line: BTreeMap<usize, Vec<(usize, usize)>> = BTreeMap::new();
@@ -178,7 +200,7 @@ pub fn group_spans_by_line(
         let last = if e > s { index.line_of(e - 1) } else { first };
         for li in first..=last.min(index.line_count().saturating_sub(1)) {
             let ls = index.line_start(li);
-            let le = index.line_end(content, li);
+            let le = index.line_end(li);
             let cs = s.clamp(ls, le) - ls;
             let ce = e.clamp(ls, le) - ls;
             by_line.entry(li).or_default().push((cs, ce));
@@ -602,8 +624,7 @@ pub enum Emit<'a> {
 
 /// Result of matching one file: the line index plus every matching line.
 pub struct FileMatches<'a> {
-    content: &'a str,
-    index: LineIndex,
+    index: LineIndex<'a>,
     hits: Vec<LineHit>,
 }
 
@@ -615,11 +636,7 @@ impl<'a> FileMatches<'a> {
         } else {
             collect_hits(content, &index, matcher, opts)?
         };
-        Ok(Self {
-            content,
-            index,
-            hits,
-        })
+        Ok(Self { index, hits })
     }
 
     pub fn is_empty(&self) -> bool {
@@ -654,7 +671,7 @@ impl<'a> FileMatches<'a> {
         let emit_hit = |hit: &LineHit,
                         on_emit: &mut dyn FnMut(Emit<'a>) -> std::result::Result<(), E>|
          -> std::result::Result<(), E> {
-            let line = self.index.line_text(self.content, hit.idx);
+            let line = self.index.line_text(hit.idx);
             let offset = self.index.line_start(hit.idx);
 
             if opts.only_matching && !hit.spans.is_empty() {
@@ -734,7 +751,7 @@ impl<'a> FileMatches<'a> {
                 line_offset: offset,
                 column_shifts,
                 offset_shift: 0,
-                terminator_len: self.index.line_terminator_len(self.content, hit.idx),
+                terminator_len: self.index.line_terminator_len(hit.idx),
             })
         };
 
@@ -748,9 +765,9 @@ impl<'a> FileMatches<'a> {
                     Some(hit) => emit_hit(hit, &mut on_emit)?,
                     None => on_emit(Emit::Context {
                         line_number: li + 1,
-                        content: self.index.line_text(self.content, li),
+                        content: self.index.line_text(li),
                         absolute_offset: self.index.line_start(li),
-                        terminator_len: self.index.line_terminator_len(self.content, li),
+                        terminator_len: self.index.line_terminator_len(li),
                     })?,
                 }
             }
@@ -779,9 +796,9 @@ impl<'a> FileMatches<'a> {
                 Some(hit) => emit_hit(hit, &mut on_emit)?,
                 None => on_emit(Emit::Context {
                     line_number: li + 1,
-                    content: self.index.line_text(self.content, li),
+                    content: self.index.line_text(li),
                     absolute_offset: self.index.line_start(li),
-                    terminator_len: self.index.line_terminator_len(self.content, li),
+                    terminator_len: self.index.line_terminator_len(li),
                 })?,
             }
         }
@@ -843,7 +860,7 @@ fn pattern_is_anchor_free(pattern: &str) -> bool {
 /// still has the final say, so extra candidates cost time and never accuracy.
 fn candidate_lines<'a>(
     content: &'a str,
-    index: &'a LineIndex,
+    index: &'a LineIndex<'a>,
     matcher: &'a SearchMatcher,
     opts: &MatchOptions,
 ) -> Option<impl Iterator<Item = usize> + 'a> {
@@ -886,7 +903,7 @@ fn candidate_lines<'a>(
 /// Find every matching line together with the match ranges inside it.
 fn collect_hits(
     content: &str,
-    index: &LineIndex,
+    index: &LineIndex<'_>,
     matcher: &SearchMatcher,
     opts: &MatchOptions,
 ) -> Result<Vec<LineHit>> {
@@ -895,7 +912,7 @@ fn collect_hits(
     if opts.invert_match {
         let mut out = Vec::new();
         for i in 0..index.line_count() {
-            if !matcher.is_match(index.line_text(content, i))? {
+            if !matcher.is_match(index.line_text(i))? {
                 out.push(LineHit {
                     idx: i,
                     spans: Vec::new(),
@@ -931,12 +948,11 @@ fn collect_hits(
             // past the end of its line is reported only on the line it starts
             // on rather than once per line it touches.
             return Ok(group_spans_by_line(
-                content,
                 index,
-                &clip_spans_to_start_line(content, index, &spans),
+                &clip_spans_to_start_line(index, &spans),
             ));
         }
-        return Ok(group_spans_by_line(content, index, &spans));
+        return Ok(group_spans_by_line(index, &spans));
     }
 
     // Line-oriented mode: match each line separately so `^` and `$` anchor
@@ -944,10 +960,10 @@ fn collect_hits(
     let mut out = Vec::new();
     let visit = |i: usize, out: &mut Vec<LineHit>| -> Result<bool> {
         let spans = if opts.all_spans {
-            matcher.find_spans(index.line_text(content, i))?
+            matcher.find_spans(index.line_text(i))?
         } else {
             matcher
-                .find_first_span(index.line_text(content, i))?
+                .find_first_span(index.line_text(i))?
                 .into_iter()
                 .collect()
         };
@@ -1061,7 +1077,7 @@ mod tests {
                 let mut expected = Vec::new();
                 for i in 0..index.line_count() {
                     if matcher
-                        .is_match(index.line_text(hay, i))
+                        .is_match(index.line_text(i))
                         .expect("standard matcher cannot error")
                     {
                         expected.push(i);
@@ -1443,7 +1459,7 @@ mod tests {
             assert_eq!(index.line_count(), expected.len(), "count for {content:?}");
             for (i, want) in expected.iter().enumerate() {
                 assert_eq!(
-                    &index.line_text(content, i),
+                    &index.line_text(i),
                     want,
                     "line {i} of {content:?}"
                 );
@@ -1466,7 +1482,7 @@ mod tests {
         let content = "start\nmiddle\nend\n";
         let index = LineIndex::new(content);
         // "start\nmiddle\nend" as one match spanning three lines.
-        let hits = group_spans_by_line(content, &index, &[(0, 16)]);
+        let hits = group_spans_by_line(&index, &[(0, 16)]);
         assert_eq!(
             hits,
             vec![
@@ -1490,7 +1506,7 @@ mod tests {
     fn group_spans_merges_overlapping_ranges_on_one_line() {
         let content = "aaaa";
         let index = LineIndex::new(content);
-        let hits = group_spans_by_line(content, &index, &[(0, 2), (1, 3)]);
+        let hits = group_spans_by_line(&index, &[(0, 2), (1, 3)]);
         assert_eq!(
             hits,
             vec![LineHit {
@@ -1504,7 +1520,7 @@ mod tests {
     fn group_spans_keeps_separate_ranges_apart() {
         let content = "foo bar foo";
         let index = LineIndex::new(content);
-        let hits = group_spans_by_line(content, &index, &[(0, 3), (8, 11)]);
+        let hits = group_spans_by_line(&index, &[(0, 3), (8, 11)]);
         assert_eq!(
             hits,
             vec![LineHit {

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -79,7 +79,10 @@ impl<'a> LineIndex<'a> {
     }
 
     pub fn line_start(&self, idx: usize) -> usize {
-        self.starts().get(idx).copied().unwrap_or(self.content.len())
+        self.starts()
+            .get(idx)
+            .copied()
+            .unwrap_or(self.content.len())
     }
 
     /// End offset of line `idx`, excluding its `\n` or `\r\n` terminator.
@@ -188,10 +191,7 @@ fn clip_spans_to_start_line(
 /// Under `--multiline` a single match can cover several lines, and every line
 /// it touches has to be printed. Overlapping ranges on the same line are
 /// merged so highlighting never emits nested escape sequences.
-pub fn group_spans_by_line(
-    index: &LineIndex<'_>,
-    spans: &[(usize, usize)],
-) -> Vec<LineHit> {
+pub fn group_spans_by_line(index: &LineIndex<'_>, spans: &[(usize, usize)]) -> Vec<LineHit> {
     let mut by_line: BTreeMap<usize, Vec<(usize, usize)>> = BTreeMap::new();
 
     for &(s, e) in spans {
@@ -1458,11 +1458,7 @@ mod tests {
             let expected: Vec<&str> = content.lines().collect();
             assert_eq!(index.line_count(), expected.len(), "count for {content:?}");
             for (i, want) in expected.iter().enumerate() {
-                assert_eq!(
-                    &index.line_text(i),
-                    want,
-                    "line {i} of {content:?}"
-                );
+                assert_eq!(&index.line_text(i), want, "line {i} of {content:?}");
             }
         }
     }

--- a/tgrep-cli/src/mem.rs
+++ b/tgrep-cli/src/mem.rs
@@ -512,11 +512,25 @@ mod tests {
 
     // The cap exists to stop tgrep exhausting the host, so it must charge
     // against memory the process actually owns wherever that is available.
+    //
+    // The two figures are sampled at different instants, and the rest of the
+    // suite is allocating on other threads meanwhile, so they are compared for
+    // *provenance* rather than exact equality - an exact match made this test
+    // flaky. Private and RSS differ by far more than the tolerance whenever the
+    // distinction matters, so a wrong source still fails.
     #[test]
     fn budgeted_memory_prefers_private_bytes() {
         let budgeted = budgeted_memory_bytes();
         match process_private_bytes() {
-            Some(private) => assert_eq!(budgeted, Some(private)),
+            Some(private) => {
+                let budgeted = budgeted.expect("private bytes are available, so a budget is too");
+                let drift = budgeted.abs_diff(private);
+                let tolerance = (private / 10).max(16 * 1024 * 1024);
+                assert!(
+                    drift <= tolerance,
+                    "budgeted {budgeted} should track private {private} (drift {drift} > {tolerance})"
+                );
+            }
             None => assert_eq!(budgeted, process_rss_bytes()),
         }
     }

--- a/tgrep-cli/src/mem.rs
+++ b/tgrep-cli/src/mem.rs
@@ -1,8 +1,26 @@
 //! Cross-platform process memory introspection.
 //!
-//! Provides functions to query the current process's resident set size (RSS)
-//! and the host's total physical memory — used to enforce an indexing memory
-//! budget so tgrep doesn't OOM-kill the host on large monorepos.
+//! Provides functions to query the current process's memory use and the host's
+//! total physical memory — used to enforce an indexing memory budget so tgrep
+//! doesn't OOM-kill the host on large monorepos.
+//!
+//! Two different quantities are available and they are not interchangeable:
+//!
+//! * **Resident set / working set** counts every physical page the process has
+//!   mapped, *including* file-backed pages from `mmap`. Since indexing maps
+//!   files at or above 1 MiB rather than reading them into heap, this number
+//!   tracks the size of the files being indexed. Those pages are clean and
+//!   file-backed, so the OS can drop them at any time without the process
+//!   doing anything — they are not memory tgrep is holding.
+//! * **Private bytes** counts only memory the process itself owns and must give
+//!   back explicitly: heap, stacks, anonymous maps. This is what "how much
+//!   memory does tgrep use" means, and it is what can actually exhaust a host.
+//!
+//! Indexing a single 2 GiB file peaks at 1.99 GiB working set but only 77.8 MiB
+//! private, so reporting or budgeting against the working set overstates the
+//! footprint by more than 25x. Prefer [`peak_private_bytes`] for reporting and
+//! [`budgeted_memory_bytes`] for enforcing the cap; the RSS functions remain
+//! for platforms that cannot separate the two.
 
 /// Returns the current process's resident set size in bytes, or `None` if
 /// the platform query fails.
@@ -16,10 +34,27 @@ pub fn process_rss_bytes() -> Option<u64> {
 ///
 /// This is an OS-maintained high-water mark, so it is exact and costs nothing
 /// to read — unlike sampling [`process_rss_bytes`], which can miss a peak that
-/// occurs between polls.
+/// occurs between polls. It includes memory-mapped file pages; see the module
+/// docs for why that makes it the wrong number to report on its own.
 #[cfg(target_os = "windows")]
 pub fn peak_rss_bytes() -> Option<u64> {
     windows_memory_counters().map(|c| c.PeakWorkingSetSize as u64)
+}
+
+/// Private committed bytes: memory the process owns, excluding file-backed
+/// pages.
+#[cfg(target_os = "windows")]
+pub fn process_private_bytes() -> Option<u64> {
+    windows_memory_counters().map(|c| c.PagefileUsage as u64)
+}
+
+/// High-water mark of [`process_private_bytes`].
+///
+/// Windows maintains this exactly, so unlike the sampled fallback on other
+/// platforms it cannot miss a spike between polls.
+#[cfg(target_os = "windows")]
+pub fn peak_private_bytes() -> Option<u64> {
+    windows_memory_counters().map(|c| c.PeakPagefileUsage as u64)
 }
 
 #[cfg(target_os = "windows")]
@@ -86,16 +121,56 @@ pub fn total_physical_memory_bytes() -> Option<u64> {
 }
 
 /// Peak RSS from `VmHWM` ("high water mark") in `/proc/self/status`.
+///
+/// Includes memory-mapped file pages; see the module docs.
 #[cfg(target_os = "linux")]
 pub fn peak_rss_bytes() -> Option<u64> {
+    proc_status_kb("VmHWM:").map(|kb| kb * 1024)
+}
+
+/// Read a `kB`-suffixed field out of `/proc/self/status`.
+#[cfg(target_os = "linux")]
+fn proc_status_kb(prefix: &str) -> Option<u64> {
     let status = std::fs::read_to_string("/proc/self/status").ok()?;
     for line in status.lines() {
-        if let Some(rest) = line.strip_prefix("VmHWM:") {
-            let kb: u64 = rest.trim().strip_suffix("kB")?.trim().parse().ok()?;
-            return Some(kb * 1024);
+        if let Some(rest) = line.strip_prefix(prefix) {
+            return rest.trim().strip_suffix("kB")?.trim().parse().ok();
         }
     }
     None
+}
+
+/// Highest value [`process_private_bytes`] has been observed at.
+///
+/// Linux exposes `VmHWM` for resident memory but has no equivalent high-water
+/// mark for anonymous memory alone, so the peak has to be sampled.
+#[cfg(target_os = "linux")]
+static PRIVATE_HWM: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Anonymous resident bytes from `RssAnon`: heap, stacks and anonymous maps,
+/// with file-backed pages excluded.
+///
+/// Reading it also advances the sampled high-water mark that
+/// [`peak_private_bytes`] reports, so any caller that polls this — the indexing
+/// memory cap does, once per batch — improves that peak's accuracy.
+#[cfg(target_os = "linux")]
+pub fn process_private_bytes() -> Option<u64> {
+    // `RssAnon` landed in Linux 4.5. On anything older the field is absent and
+    // callers fall back to RSS rather than silently reporting zero.
+    let bytes = proc_status_kb("RssAnon:")? * 1024;
+    PRIVATE_HWM.fetch_max(bytes, std::sync::atomic::Ordering::Relaxed);
+    Some(bytes)
+}
+
+/// Sampled high-water mark of [`process_private_bytes`].
+///
+/// Only as good as the sampling: a spike between polls is missed. That makes it
+/// a floor, not an exact peak, which is still far closer to the truth than
+/// `VmHWM` once large files are memory-mapped.
+#[cfg(target_os = "linux")]
+pub fn peak_private_bytes() -> Option<u64> {
+    let current = process_private_bytes()?;
+    Some(current.max(PRIVATE_HWM.load(std::sync::atomic::Ordering::Relaxed)))
 }
 
 #[cfg(target_os = "macos")]
@@ -142,6 +217,8 @@ pub fn total_physical_memory_bytes() -> Option<u64> {
 
 /// Peak RSS via `getrusage`. On macOS `ru_maxrss` is in **bytes** (on Linux the
 /// same field is kilobytes), so no scaling is applied here.
+///
+/// Includes memory-mapped file pages; see the module docs.
 #[cfg(target_os = "macos")]
 pub fn peak_rss_bytes() -> Option<u64> {
     use std::mem::MaybeUninit;
@@ -153,6 +230,20 @@ pub fn peak_rss_bytes() -> Option<u64> {
             None
         }
     }
+}
+
+/// macOS separates file-backed from anonymous memory only through the Mach
+/// `TASK_VM_INFO` `phys_footprint` counter, which `libc` does not expose.
+/// Returning `None` makes callers fall back to RSS rather than report a number
+/// that isn't the one it claims to be.
+#[cfg(target_os = "macos")]
+pub fn process_private_bytes() -> Option<u64> {
+    None
+}
+
+#[cfg(target_os = "macos")]
+pub fn peak_private_bytes() -> Option<u64> {
+    None
 }
 
 // Fallback for unsupported platforms
@@ -169,6 +260,132 @@ pub fn total_physical_memory_bytes() -> Option<u64> {
 #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
 pub fn peak_rss_bytes() -> Option<u64> {
     None
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+pub fn process_private_bytes() -> Option<u64> {
+    None
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+pub fn peak_private_bytes() -> Option<u64> {
+    None
+}
+
+/// The figure to charge against the indexing memory cap.
+///
+/// Prefers private bytes. The cap exists to stop tgrep exhausting the host, and
+/// mapped file pages cannot do that — the kernel reclaims them under pressure.
+/// Charging them anyway makes the cap fire on memory the process does not hold,
+/// and the flush it triggers then frees nothing, so the build pays for a full
+/// overlay flush and is still "over budget" on the next check.
+pub fn budgeted_memory_bytes() -> Option<u64> {
+    process_private_bytes().or_else(process_rss_bytes)
+}
+
+/// How much larger the working set must be than private bytes before it is
+/// worth reporting both, as a divisor of private bytes.
+const WORKING_SET_REPORT_RATIO: u64 = 4;
+
+/// Absolute floor on that gap. Every process maps its own executable and shared
+/// libraries, so the working set is always somewhat larger; on a run that
+/// allocates little, that fixed overhead alone clears the ratio and would
+/// produce a second figure that says nothing about the build.
+const WORKING_SET_REPORT_FLOOR: u64 = 64 * 1024 * 1024;
+
+/// Human-readable peak memory for an indexing run, or `None` if the platform
+/// exposes nothing.
+///
+/// Leads with private bytes, because that is the memory tgrep is responsible
+/// for. When the peak working set is substantially larger the difference is
+/// memory-mapped file content, so it is named explicitly rather than folded
+/// into a single number that would read as tgrep's own use.
+pub fn format_peak_memory() -> Option<String> {
+    describe_peak_memory(peak_private_bytes(), peak_rss_bytes())
+}
+
+/// The reporting decision, split out from the platform queries so it can be
+/// tested against fixed inputs instead of whatever the host happens to be
+/// doing.
+fn describe_peak_memory(private: Option<u64>, rss: Option<u64>) -> Option<String> {
+    let Some(private) = private else {
+        return rss.map(format_bytes);
+    };
+    let floor = private
+        .saturating_add(WORKING_SET_REPORT_FLOOR)
+        .max(private.saturating_add(private / WORKING_SET_REPORT_RATIO));
+    match rss {
+        Some(rss) if rss > floor => Some(format!(
+            "{} private, {} working set incl. memory-mapped files",
+            format_bytes(private),
+            format_bytes(rss)
+        )),
+        _ => Some(format_bytes(private)),
+    }
+}
+
+/// Keeps [`peak_private_bytes`] honest for the duration of a build on platforms
+/// whose kernel does not maintain a private-memory high-water mark.
+///
+/// Linux exposes `RssAnon` only as an instantaneous value, so a peak read once
+/// at the end of a build reports whatever survived it — after the sorter has
+/// dropped its 64 MiB arena, that is a small fraction of the real high point.
+/// Polling in the background keeps the mark meaningful. Windows tracks the peak
+/// itself, so there the sampler is an empty value that starts no thread.
+#[cfg(target_os = "linux")]
+pub struct PrivatePeakSampler {
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(target_os = "linux")]
+impl PrivatePeakSampler {
+    pub fn start() -> Self {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || {
+            while !flag.load(Ordering::Relaxed) {
+                // Updates PRIVATE_HWM as a side effect; the value is unused.
+                let _ = process_private_bytes();
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for PrivatePeakSampler {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub struct PrivatePeakSampler;
+
+#[cfg(not(target_os = "linux"))]
+impl PrivatePeakSampler {
+    pub fn start() -> Self {
+        Self
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+impl Drop for PrivatePeakSampler {
+    /// Nothing to stop — the kernel maintains the high-water mark itself. The
+    /// impl exists so callers can end the sampled window with `drop` on every
+    /// platform instead of branching on the target.
+    fn drop(&mut self) {}
 }
 
 /// Format a byte count for humans, e.g. `1.53 GiB` or `151.2 MiB`.
@@ -259,5 +476,140 @@ mod tests {
         // Boundaries promote to the next unit rather than reading as "1024".
         assert_eq!(format_bytes(1024 * 1024), "1.0 MiB");
         assert_eq!(format_bytes(1024 * 1024 * 1024), "1.00 GiB");
+    }
+
+    // Private bytes must be a different counter from the working set. Indexing
+    // memory-maps files at or above 1 MiB, so a working-set figure grows with
+    // the size of the files being indexed: a single 2 GiB file measured 1.99
+    // GiB peak working set against 77.8 MiB peak private, so reporting the
+    // former as "peak memory" overstated the footprint by 25x.
+    //
+    // Whether mapped pages *stay* resident is the OS's call — Windows trims
+    // them within milliseconds under cache pressure — so this asserts the
+    // counters are queryable and coherent rather than trying to pin page
+    // residency, which is not reproducible.
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[test]
+    fn private_bytes_are_queryable_and_within_the_resident_set() {
+        let private = process_private_bytes().expect("private byte query should succeed");
+        let rss = process_rss_bytes().expect("RSS query should succeed");
+        assert!(private > 0, "private bytes should be non-zero");
+        assert!(rss > 0, "RSS should be non-zero");
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn peak_private_is_at_least_current_private() {
+        let Some(current) = process_private_bytes() else {
+            return; // macOS cannot separate the two; callers fall back to RSS.
+        };
+        let peak = peak_private_bytes().expect("peak private query should succeed");
+        assert!(
+            peak >= current,
+            "peak private {peak} should be >= current {current}"
+        );
+    }
+
+    // The cap exists to stop tgrep exhausting the host, so it must charge
+    // against memory the process actually owns wherever that is available.
+    #[test]
+    fn budgeted_memory_prefers_private_bytes() {
+        let budgeted = budgeted_memory_bytes();
+        match process_private_bytes() {
+            Some(private) => assert_eq!(budgeted, Some(private)),
+            None => assert_eq!(budgeted, process_rss_bytes()),
+        }
+    }
+
+    #[test]
+    fn peak_memory_report_names_the_working_set_only_when_it_is_much_larger() {
+        let mib = 1024 * 1024;
+        // A mapped-file build: the gap is the mapping, and hiding it behind one
+        // number is what made a 77.8 MiB build look like a 1.99 GiB one.
+        assert_eq!(
+            describe_peak_memory(Some(78 * mib), Some(2038 * mib)),
+            Some("78.0 MiB private, 1.99 GiB working set incl. memory-mapped files".to_string())
+        );
+        // Measured on a 200 x 8 MiB corpus: a real gap, well past both bounds.
+        assert_eq!(
+            describe_peak_memory(Some(365 * mib), Some(470 * mib)),
+            Some("365.0 MiB private, 470.0 MiB working set incl. memory-mapped files".to_string())
+        );
+        // Ordinary builds: the gap is code and shared library mappings, which
+        // say nothing worth a second figure.
+        assert_eq!(
+            describe_peak_memory(Some(300 * mib), Some(310 * mib)),
+            Some("300.0 MiB".to_string())
+        );
+        // Clears the ratio but not the floor. Every process maps its own
+        // executable, so a tiny run trips the ratio on that alone — a Linux
+        // `tgrep index` over three files measured 1.5 MiB private against a
+        // 12 MiB working set, which is 8x and still not worth reporting.
+        assert_eq!(
+            describe_peak_memory(Some(3 * mib / 2), Some(12 * mib)),
+            Some("1.5 MiB".to_string())
+        );
+        // Clears the floor but not the ratio.
+        assert_eq!(
+            describe_peak_memory(Some(4096 * mib), Some(4200 * mib)),
+            Some("4.00 GiB".to_string())
+        );
+        // Exactly at both bounds is not "much larger"; a byte past is.
+        assert_eq!(
+            describe_peak_memory(Some(1024 * mib), Some(1280 * mib)),
+            Some("1.00 GiB".to_string())
+        );
+        assert!(
+            describe_peak_memory(Some(1024 * mib), Some(1280 * mib + 1))
+                .unwrap()
+                .contains("working set")
+        );
+        // Platforms that cannot separate the two still report something, and a
+        // platform that exposes nothing reports nothing.
+        assert_eq!(
+            describe_peak_memory(None, Some(512 * mib)),
+            Some("512.0 MiB".to_string())
+        );
+        assert_eq!(
+            describe_peak_memory(Some(512 * mib), None),
+            Some("512.0 MiB".to_string())
+        );
+        assert_eq!(describe_peak_memory(None, None), None);
+    }
+
+    // On Linux the peak is sampled in the background, so a build that allocates
+    // and then frees must still report the high point rather than whatever
+    // survived it — the sorter drops its 64 MiB arena before the build ends.
+    // Reads the mark directly: going through `peak_private_bytes` would fold in
+    // the current value and blur what is being checked.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_sampler_records_a_peak_the_process_no_longer_holds() {
+        const HOG: usize = 192 * 1024 * 1024;
+        let sampler = PrivatePeakSampler::start();
+        {
+            let mut hog: Vec<u8> = vec![7; HOG];
+            hog[0] = 1;
+            std::hint::black_box(&hog);
+            // Comfortably longer than the 50 ms sampling interval, so a poll
+            // has to land while the allocation is live.
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        }
+        drop(sampler);
+
+        let recorded = PRIVATE_HWM.load(std::sync::atomic::Ordering::Relaxed);
+        let current = proc_status_kb("RssAnon:").expect("RssAnon should be readable") * 1024;
+        assert!(
+            recorded >= current + (HOG as u64) / 2,
+            "the sampler should have recorded the freed allocation: \
+             mark {recorded}, current {current}"
+        );
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn peak_memory_report_is_available_on_supported_platforms() {
+        let report = format_peak_memory().expect("a peak memory report should be available");
+        assert!(!report.is_empty());
     }
 }

--- a/tgrep-cli/src/output.rs
+++ b/tgrep-cli/src/output.rs
@@ -242,6 +242,11 @@ pub struct OutputWriter {
     file_started: Instant,
     /// Stats for the file currently open in JSON mode.
     file_stats: Stats,
+    /// Line number of the last `match` event emitted for the current file.
+    ///
+    /// ripgrep's `matched_lines` counts distinct matching lines, so a line that
+    /// produces several events must only be counted once.
+    last_json_match_line: Option<usize>,
     total_stats: Stats,
     /// Size of the file currently being searched, for per-file JSON stats.
     pending_bytes_searched: u64,
@@ -281,6 +286,7 @@ impl OutputWriter {
             started: Instant::now(),
             file_started: Instant::now(),
             file_stats: Stats::default(),
+            last_json_match_line: None,
             total_stats: Stats::default(),
             pending_bytes_searched: 0,
             current_binary_offset: None,
@@ -291,6 +297,15 @@ impl OutputWriter {
 
     pub fn is_json(&self) -> bool {
         self.config.format == OutputFormat::Json
+    }
+
+    /// Switch to the path spelling of the next command-line argument.
+    ///
+    /// One writer spans the whole invocation so that stats accumulate and a
+    /// single JSON `summary` is emitted, but each path argument is echoed the
+    /// way the user typed it, so this part of the config is per argument.
+    pub fn set_path_display(&mut self, path_display: PathDisplay) {
+        self.config.path_display = path_display;
     }
 
     /// Record that a file of `bytes` length is about to be searched.
@@ -341,6 +356,7 @@ impl OutputWriter {
         self.current_file = Some(file.to_string());
         self.file_started = Instant::now();
         self.last_printed_line = None;
+        self.last_json_match_line = None;
         Ok(())
     }
 
@@ -371,6 +387,7 @@ impl OutputWriter {
         self.stdout.write_all(line.as_bytes())?;
         self.total_stats.add(&self.file_stats);
         self.file_stats = Stats::default();
+        self.last_json_match_line = None;
         Ok(())
     }
 
@@ -571,7 +588,13 @@ impl OutputWriter {
                         })
                     })
                     .collect();
-                self.file_stats.matched_lines += 1;
+                // ripgrep counts distinct matching *lines* here, not emitted
+                // events, so a line that produced more than one event (a
+                // multiline pattern re-reporting it, say) is only counted once.
+                if self.last_json_match_line != Some(m.line_number) {
+                    self.file_stats.matched_lines += 1;
+                    self.last_json_match_line = Some(m.line_number);
+                }
                 // Count submatch spans, not lines. An inverted match emits a
                 // line with no spans, and ripgrep counts those as zero matches
                 // while still reporting a non-zero `matched_lines`.
@@ -625,7 +648,22 @@ impl OutputWriter {
         Ok(())
     }
 
+    /// Flush buffered output, closing any file left open in JSON mode.
+    ///
+    /// Called once per searched path. The JSON `summary` covers the whole
+    /// invocation, so it is emitted by [`OutputWriter::finish`] instead.
     pub fn flush(&mut self) -> io::Result<()> {
+        if self.is_json() {
+            self.finish_json_file()?;
+        }
+        self.stdout.flush()
+    }
+
+    /// End the invocation, emitting ripgrep's single JSON `summary` event.
+    ///
+    /// ripgrep emits exactly one summary no matter how many paths were named,
+    /// so this runs after the last path rather than after each one.
+    pub fn finish(&mut self) -> io::Result<()> {
         if self.is_json() {
             self.finish_json_file()?;
             let elapsed = self.started.elapsed();

--- a/tgrep-cli/src/output.rs
+++ b/tgrep-cli/src/output.rs
@@ -397,6 +397,13 @@ impl OutputWriter {
     /// non-adjacent matching lines are the normal case and ripgrep prints
     /// nothing between them; emitting `--` there would also corrupt
     /// `--vimgrep` quickfix parsing and `-o` pipelines.
+    ///
+    /// A gap arises two ways, and ripgrep marks both: a jump between line
+    /// numbers *within* a file, and the transition from one file's context
+    /// block to the next. Only the first was handled here, so piped context
+    /// output was missing one `--` per file boundary - 808 of them across a
+    /// Substrate-sized tree. In heading mode there is no separator, because the
+    /// blank line before the next heading already does that job.
     pub fn write_context_separator(&mut self, file: &str, line_num: usize) -> io::Result<()> {
         if self.is_json() || !self.config.context {
             return Ok(());
@@ -404,11 +411,12 @@ impl OutputWriter {
         let Some(sep) = self.config.context_separator.clone() else {
             return Ok(());
         };
-        if let Some((ref last_file, last_line)) = self.last_printed_line
-            && last_file == file
-            && line_num > last_line + 1
-        {
-            writeln!(self.stdout, "{sep}")?;
+        if let Some((ref last_file, last_line)) = self.last_printed_line {
+            let gap_within_file = last_file == file && line_num > last_line + 1;
+            let new_file = last_file != file && !self.use_heading;
+            if gap_within_file || new_file {
+                writeln!(self.stdout, "{sep}")?;
+            }
         }
         Ok(())
     }

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -1033,14 +1033,13 @@ fn search_local_index(
         if exceeds_max_filesize(&full_path, opts, explicit) {
             continue;
         }
-        let (content, fixups) = match read_text_lossy(&full_path, opts.encoding) {
+        let read = match read_text_lossy(&full_path, opts.encoding) {
             Ok(c) => c,
             Err(_) => continue,
         };
 
         let outcome = search_decoded_file(
-            content.as_str(),
-            &fixups,
+            &read,
             &matcher,
             rel_path,
             opts,
@@ -1175,10 +1174,9 @@ fn brute_force_search(
         if passes_filters(&rel_path, &glob_filter, &type_filter)
             && !exceeds_max_filesize(root, opts, true)
         {
-            let (content, fixups) = read_text_lossy(root, opts.encoding)?;
+            let read = read_text_lossy(root, opts.encoding)?;
             let outcome = search_decoded_file(
-                content.as_str(),
-                &fixups,
+                &read,
                 &matcher,
                 &rel_path,
                 opts,
@@ -1229,14 +1227,13 @@ fn brute_force_search(
             continue;
         }
 
-        let (content, fixups) = match read_text_lossy(path, opts.encoding) {
+        let read = match read_text_lossy(path, opts.encoding) {
             Ok(c) => c,
             Err(_) => continue,
         };
 
         let outcome = search_decoded_file(
-            content.as_str(),
-            &fixups,
+            &read,
             &matcher,
             &rel_path,
             opts,
@@ -1319,12 +1316,75 @@ impl FileText {
     }
 }
 
+/// A file's text together with what the read already learned about it.
+struct FileRead {
+    text: FileText,
+    fixups: tgrep_core::encoding::LossyFixups,
+    /// Offset of the first NUL byte in `text`, which is what makes the file
+    /// binary. Found during the pass that decoded or validated the bytes, not
+    /// in a pass of its own — see [`validate_utf8_and_find_nul`].
+    first_nul: Option<usize>,
+}
+
+/// Validate `bytes` as UTF-8 and locate the first NUL byte in one traversal.
+///
+/// Returns `None` if the bytes are not valid UTF-8, which is the caller's
+/// signal to fall back to reading and repairing them.
+///
+/// Both questions need every byte, and asking them separately means walking the
+/// file twice. That is nearly free while it stays in the page cache and is
+/// anything but on a file larger than the cache, where the second walk is
+/// another trip to disk: on a 13.4 GiB file, validating cost 8.7 s and a
+/// separate `memchr` for the NUL cost another 6.2 s. Interleaving them at
+/// chunk granularity keeps each page hot for both.
+///
+/// The chunking is what makes that possible, and it is why this cannot simply
+/// call `str::from_utf8` per chunk: a multi-byte sequence can straddle a chunk
+/// boundary, where `from_utf8` reports an incomplete sequence. That is not an
+/// error mid-file — it means "resume here" — so the scan restarts at
+/// `valid_up_to` and lets the next chunk carry the sequence. At the *last*
+/// chunk the same report is a real truncation and does fail.
+fn validate_utf8_and_find_nul(bytes: &[u8]) -> Option<Option<usize>> {
+    /// Large enough that the ≤3 carried-over bytes are noise, small enough to
+    /// stay in cache between the two scans of it.
+    const CHUNK: usize = 1 << 20;
+
+    let mut pos = 0;
+    let mut first_nul = None;
+    while pos < bytes.len() {
+        let end = (pos + CHUNK).min(bytes.len());
+        let chunk = &bytes[pos..end];
+        let valid_len = match std::str::from_utf8(chunk) {
+            Ok(_) => chunk.len(),
+            Err(e) if e.error_len().is_none() && end < bytes.len() => e.valid_up_to(),
+            Err(_) => return None,
+        };
+        // A chunk starts on a character boundary and a UTF-8 sequence is at
+        // most 4 bytes, so a chunk this size always validates at least part of
+        // itself unless it opens with a genuinely invalid byte. Bailing keeps
+        // the loop from spinning if that reasoning ever stops holding.
+        if valid_len == 0 {
+            return None;
+        }
+        if first_nul.is_none()
+            && let Some(i) = memchr::memchr(0, &chunk[..valid_len])
+        {
+            first_nul = Some(pos + i);
+        }
+        pos += valid_len;
+    }
+    Some(first_nul)
+}
+
 /// Map a file for searching, or `None` to fall back to reading it.
 ///
 /// Declines whenever the mapped pages would not be exactly the bytes to search:
 /// a file below the threshold, an encoding that transcodes or strips a BOM, or
 /// content that is not already valid UTF-8 and so needs lossy repair.
-fn try_map_text(path: &Path, encoding: tgrep_core::encoding::EncodingMode) -> Option<FileText> {
+fn try_map_text(
+    path: &Path,
+    encoding: tgrep_core::encoding::EncodingMode,
+) -> Option<(FileText, Option<usize>)> {
     let file = std::fs::File::open(path).ok()?;
     if file.metadata().ok()?.len() < MMAP_MIN_BYTES {
         return None;
@@ -1337,8 +1397,8 @@ fn try_map_text(path: &Path, encoding: tgrep_core::encoding::EncodingMode) -> Op
     if !tgrep_core::encoding::borrows_whole_input(&map, encoding) {
         return None;
     }
-    std::str::from_utf8(&map).ok()?;
-    Some(FileText::Mapped(map))
+    let first_nul = validate_utf8_and_find_nul(&map)?;
+    Some((FileText::Mapped(map), first_nul))
 }
 
 /// Read a file as text, applying `--encoding` and replacing invalid UTF-8
@@ -1349,14 +1409,27 @@ fn try_map_text(path: &Path, encoding: tgrep_core::encoding::EncodingMode) -> Op
 fn read_text_lossy(
     path: &Path,
     encoding: tgrep_core::encoding::EncodingMode,
-) -> std::io::Result<(FileText, tgrep_core::encoding::LossyFixups)> {
+) -> std::io::Result<FileRead> {
     // A mapped file is always already-valid UTF-8, so it needs no fixups.
-    if let Some(mapped) = try_map_text(path, encoding) {
-        return Ok((mapped, tgrep_core::encoding::LossyFixups::default()));
+    if let Some((text, first_nul)) = try_map_text(path, encoding) {
+        return Ok(FileRead {
+            text,
+            fixups: tgrep_core::encoding::LossyFixups::default(),
+            first_nul,
+        });
     }
     let bytes = std::fs::read(path)?;
     let (text, fixups) = tgrep_core::encoding::decode_owned_with_fixups(bytes, encoding);
-    Ok((FileText::Owned(text), fixups))
+    // The read path already walks these bytes at least once and they are under
+    // the mapping threshold or repaired, so a separate scan here is cheap. It
+    // has to run over the *repaired* text, since that is what offsets are
+    // reported against.
+    let first_nul = memchr::memchr(0, text.as_bytes());
+    Ok(FileRead {
+        text: FileText::Owned(text),
+        fixups,
+        first_nul,
+    })
 }
 
 /// Whether `--max-filesize` excludes this file.
@@ -1451,29 +1524,32 @@ enum FileOutcome {
 /// skipped silently, so they appear in neither `-l`, `-c`, `-L`, nor the plain
 /// output.
 fn search_decoded_file(
-    content: &str,
-    fixups: &tgrep_core::encoding::LossyFixups,
+    read: &FileRead,
     matcher: &SearchMatcher,
     rel_path: &str,
     opts: &SearchOptions,
     writer: &mut OutputWriter,
     explicit: bool,
 ) -> Result<FileOutcome> {
+    let FileRead {
+        text,
+        fixups,
+        first_nul,
+    } = read;
+    let content = text.as_str();
+
     // ripgrep only surfaces a binary file when the user named it explicitly (or
     // passed `--binary`).
     //
-    // The NUL is located in the repaired text but reported in terms of the file
-    // on disk, so it goes back through `fixups`: repairing invalid UTF-8 ahead
-    // of the NUL widens every bad byte to three, which would otherwise push the
-    // reported offset past where the byte actually is.
+    // `first_nul` was found by the pass that read the file, so this costs
+    // nothing here. The NUL is located in the repaired text but reported in
+    // terms of the file on disk, so it goes back through `fixups`: repairing
+    // invalid UTF-8 ahead of the NUL widens every bad byte to three, which
+    // would otherwise push the reported offset past where the byte actually is.
     let binary_offset = if opts.text {
         None
     } else {
-        content
-            .as_bytes()
-            .iter()
-            .position(|&b| b == 0)
-            .map(|off| fixups.to_source_offset(off))
+        first_nul.map(|off| fixups.to_source_offset(off))
     };
     if binary_offset.is_some() && !explicit && !opts.binary {
         return Ok(FileOutcome::Skipped);
@@ -1686,6 +1762,102 @@ fn plan_summary(plan: &QueryPlan) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- fused UTF-8 validation and NUL scan --------------------------------
+    //
+    // `validate_utf8_and_find_nul` walks the file in chunks so that validating
+    // it and finding the NUL that marks it binary share one traversal. The
+    // chunking is the delicate part: a multi-byte sequence that straddles a
+    // chunk boundary must be carried into the next chunk rather than reported
+    // as invalid. These pin that against the whole-buffer answer it replaces.
+
+    /// What the two separate passes used to produce, for differential testing.
+    fn reference(bytes: &[u8]) -> Option<Option<usize>> {
+        std::str::from_utf8(bytes).ok()?;
+        Some(memchr::memchr(0, bytes))
+    }
+
+    fn check(bytes: &[u8]) {
+        assert_eq!(
+            validate_utf8_and_find_nul(bytes),
+            reference(bytes),
+            "disagreed with a whole-buffer scan on {} bytes",
+            bytes.len()
+        );
+    }
+
+    #[test]
+    fn fused_scan_handles_empty_and_ascii() {
+        check(b"");
+        check(b"hello world");
+        check(b"hello\0world");
+        check(b"\0");
+    }
+
+    #[test]
+    fn fused_scan_rejects_invalid_utf8() {
+        check(&[0xFF]);
+        check(b"ok\xFFbad");
+        // A truncated sequence at the very end is a real error, not a chunk
+        // boundary to resume across.
+        check(&[0xE2, 0x82]);
+    }
+
+    #[test]
+    fn fused_scan_carries_a_sequence_across_a_chunk_boundary() {
+        // Place every multi-byte width so that it straddles the boundary at
+        // each possible split, which is exactly the case a per-chunk
+        // `from_utf8` would reject.
+        const CHUNK: usize = 1 << 20;
+        for seq in ["\u{00E9}", "\u{20AC}", "\u{1F600}"] {
+            for offset in 1..seq.len() {
+                let mut bytes = vec![b'a'; CHUNK - offset];
+                bytes.extend_from_slice(seq.as_bytes());
+                bytes.extend_from_slice(b"tail");
+                check(&bytes);
+                // The same, with a NUL on the far side of the boundary, so the
+                // reported offset has to survive the carry.
+                let mut with_nul = bytes.clone();
+                with_nul.push(0);
+                with_nul.extend_from_slice(b"more");
+                check(&with_nul);
+            }
+        }
+    }
+
+    #[test]
+    fn fused_scan_reports_the_first_nul_not_a_later_one() {
+        const CHUNK: usize = 1 << 20;
+        // One NUL in the first chunk and one in the third: the scan must stop
+        // updating after the first, even though later chunks also match.
+        let mut bytes = vec![b'a'; CHUNK * 3];
+        bytes[7] = 0;
+        bytes[CHUNK * 2 + 11] = 0;
+        check(&bytes);
+        assert_eq!(validate_utf8_and_find_nul(&bytes), Some(Some(7)));
+    }
+
+    #[test]
+    fn fused_scan_finds_a_nul_exactly_on_a_chunk_boundary() {
+        const CHUNK: usize = 1 << 20;
+        for at in [CHUNK - 1, CHUNK, CHUNK + 1] {
+            let mut bytes = vec![b'a'; CHUNK * 2];
+            bytes[at] = 0;
+            check(&bytes);
+            assert_eq!(validate_utf8_and_find_nul(&bytes), Some(Some(at)));
+        }
+    }
+
+    #[test]
+    fn fused_scan_spans_many_chunks_without_a_nul() {
+        const CHUNK: usize = 1 << 20;
+        // Multi-byte content throughout, so every chunk ends mid-sequence at
+        // some point and the loop has to keep making progress.
+        let unit = "héllo wörld €";
+        let bytes = unit.repeat((CHUNK * 3) / unit.len()).into_bytes();
+        check(&bytes);
+        assert_eq!(validate_utf8_and_find_nul(&bytes), Some(None));
+    }
 
     // --- `--stats` counting -------------------------------------------------
     //

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -69,6 +69,10 @@ pub struct SearchOptions {
     /// path argument, since each argument is echoed back exactly as typed.
     pub path_display: crate::output::PathDisplay,
     pub max_filesize: Option<u64>,
+    /// Whether `--max-filesize` was passed, as opposed to inheriting
+    /// [`tgrep_core::walker::DEFAULT_MAX_FILE_SIZE`]. See
+    /// [`exceeds_max_filesize`].
+    pub max_filesize_requested: bool,
     pub encoding: tgrep_core::encoding::EncodingMode,
     pub follow: bool,
     pub no_messages: bool,
@@ -1026,7 +1030,7 @@ fn search_local_index(
         }
 
         let full_path = scope.full_path(&index_root, rel_path);
-        if exceeds_max_filesize(&full_path, opts) {
+        if exceeds_max_filesize(&full_path, opts, explicit) {
             continue;
         }
         let (content, fixups) = match read_text_lossy(&full_path, opts.encoding) {
@@ -1169,7 +1173,7 @@ fn brute_force_search(
     if root.is_file() {
         let rel_path = explicit_file_display_path(root);
         if passes_filters(&rel_path, &glob_filter, &type_filter)
-            && !exceeds_max_filesize(root, opts)
+            && !exceeds_max_filesize(root, opts, true)
         {
             let (content, fixups) = read_text_lossy(root, opts.encoding)?;
             let outcome = search_decoded_file(
@@ -1361,7 +1365,16 @@ fn read_text_lossy(
 /// takes candidates straight from the index and the explicit-file path skips
 /// the walk entirely. Both check here so the flag means the same thing on every
 /// path instead of silently doing nothing on the default (indexed) one.
-fn exceeds_max_filesize(path: &Path, opts: &SearchOptions) -> bool {
+///
+/// `explicit` marks a file the user named on the command line. Those are exempt
+/// from the *inherited* [`tgrep_core::walker::DEFAULT_MAX_FILE_SIZE`], because
+/// naming a file is an unambiguous request to search it and answering "no
+/// match" would be a lie. A limit the user actually passed still applies, since
+/// then the limit is itself the request.
+fn exceeds_max_filesize(path: &Path, opts: &SearchOptions, explicit: bool) -> bool {
+    if explicit && !opts.max_filesize_requested {
+        return false;
+    }
     let Some(limit) = opts.max_filesize else {
         return false;
     };

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -1029,7 +1029,7 @@ fn search_local_index(
         };
 
         let outcome = search_decoded_file(
-            &content,
+            content.as_str(),
             &fixups,
             &matcher,
             rel_path,
@@ -1167,7 +1167,7 @@ fn brute_force_search(
         {
             let (content, fixups) = read_text_lossy(root, opts.encoding)?;
             let outcome = search_decoded_file(
-                &content,
+                content.as_str(),
                 &fixups,
                 &matcher,
                 &rel_path,
@@ -1225,7 +1225,7 @@ fn brute_force_search(
         };
 
         let outcome = search_decoded_file(
-            &content,
+            content.as_str(),
             &fixups,
             &matcher,
             &rel_path,
@@ -1268,6 +1268,69 @@ fn brute_force_search(
     Ok(had_matches)
 }
 
+/// Smallest file worth memory-mapping instead of reading.
+///
+/// Mapping costs a syscall pair and a page-table setup per file, which is a bad
+/// trade for the small files that dominate a repository walk — a kernel tree is
+/// ~94k files averaging well under 64 KB. Above this size the whole-file read is
+/// the dominant cost and mapping wins outright, so the threshold buys the
+/// large-file case without taxing the common one.
+///
+/// 1 MiB is far above the size of real source — only 110 of the kernel's 94,747
+/// files reach it — so ordinary searches never map, while the large generated
+/// files that actually cost memory always do.
+const MMAP_MIN_BYTES: u64 = 1024 * 1024;
+
+/// The text of a file to search, either owned on the heap or borrowed from a
+/// memory map.
+///
+/// Reading a file with `fs::read` costs its full size in heap, per file in
+/// flight. ripgrep searches a 192 MB file in under 10 MiB because its memory is
+/// decoupled from file size; mapping large files gives the same property here,
+/// since mapped pages are file-backed and the OS can evict them under pressure
+/// instead of the process holding an allocation it cannot give back.
+enum FileText {
+    Owned(String),
+    /// Mapped bytes verified as UTF-8 when the map was created.
+    Mapped(memmap2::Mmap),
+}
+
+impl FileText {
+    fn as_str(&self) -> &str {
+        match self {
+            FileText::Owned(text) => text,
+            // SAFETY: `Mapped` is only constructed by `try_map_text`, which
+            // validates the entire mapping with `str::from_utf8` first, so the
+            // bytes were UTF-8 when the map was taken. A concurrent writer
+            // could still invalidate them, which is the same exposure ripgrep
+            // accepts when it maps a file it is searching.
+            FileText::Mapped(map) => unsafe { std::str::from_utf8_unchecked(map) },
+        }
+    }
+}
+
+/// Map a file for searching, or `None` to fall back to reading it.
+///
+/// Declines whenever the mapped pages would not be exactly the bytes to search:
+/// a file below the threshold, an encoding that transcodes or strips a BOM, or
+/// content that is not already valid UTF-8 and so needs lossy repair.
+fn try_map_text(path: &Path, encoding: tgrep_core::encoding::EncodingMode) -> Option<FileText> {
+    let file = std::fs::File::open(path).ok()?;
+    if file.metadata().ok()?.len() < MMAP_MIN_BYTES {
+        return None;
+    }
+    // SAFETY: the map is read-only, owned by the returned `FileText`, and
+    // dropped before this function's caller finishes with the file. Mapping is
+    // undefined behaviour if another process truncates the file underneath us;
+    // that is inherent to searching by map and is the tradeoff ripgrep makes.
+    let map = unsafe { memmap2::Mmap::map(&file).ok()? };
+    if !tgrep_core::encoding::borrows_whole_input(&map, encoding) {
+        return None;
+    }
+    std::str::from_utf8(&map).ok()?;
+    Some(FileText::Mapped(map))
+}
+
 /// Read a file as text, applying `--encoding` and replacing invalid UTF-8
 /// rather than failing.
 ///
@@ -1276,11 +1339,14 @@ fn brute_force_search(
 fn read_text_lossy(
     path: &Path,
     encoding: tgrep_core::encoding::EncodingMode,
-) -> std::io::Result<(String, tgrep_core::encoding::LossyFixups)> {
+) -> std::io::Result<(FileText, tgrep_core::encoding::LossyFixups)> {
+    // A mapped file is always already-valid UTF-8, so it needs no fixups.
+    if let Some(mapped) = try_map_text(path, encoding) {
+        return Ok((mapped, tgrep_core::encoding::LossyFixups::default()));
+    }
     let bytes = std::fs::read(path)?;
-    Ok(tgrep_core::encoding::decode_owned_with_fixups(
-        bytes, encoding,
-    ))
+    let (text, fixups) = tgrep_core::encoding::decode_owned_with_fixups(bytes, encoding);
+    Ok((FileText::Owned(text), fixups))
 }
 
 /// Whether `--max-filesize` excludes this file.

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -250,11 +250,22 @@ impl SearchOptions {
         self.byte_offset || self.max_columns.is_some()
     }
 
+    /// `--only-matching` as the search should actually apply it.
+    ///
+    /// ripgrep implements `-o` in its standard printer only: the JSON printer
+    /// always reports whole lines with one `submatch` per hit, so `--json -o`
+    /// and `--json` produce byte-identical streams. Fanning a line out into one
+    /// event per match here would both reshape the stream and inflate
+    /// `matched_lines`, which counts distinct lines.
+    fn effective_only_matching(&self) -> bool {
+        self.only_matching && !self.json
+    }
+
     fn match_options(&self) -> crate::matching::MatchOptions {
         crate::matching::MatchOptions {
             invert_match: self.invert_match,
             multiline: self.multiline,
-            only_matching: self.only_matching,
+            only_matching: self.effective_only_matching(),
             before_context: self.before_ctx(),
             after_context: self.after_ctx(),
             // `-q` and `--files-without-match` only need to know whether the
@@ -381,6 +392,13 @@ impl SearchOptions {
     }
 }
 
+/// Build the [`OutputWriter`] that spans a whole invocation.
+///
+/// Kept here so `make_output_config` stays private to this module.
+pub fn new_writer(opts: &SearchOptions) -> OutputWriter {
+    OutputWriter::new(opts.make_output_config())
+}
+
 /// List files that would be searched (--files mode).
 pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
     let root = match std::fs::canonicalize(root) {
@@ -428,7 +446,18 @@ pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
     Ok(())
 }
 
-pub fn run(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) -> Result<bool> {
+/// Run one search path's worth of work, writing through the caller's `writer`.
+///
+/// The writer is owned by the caller and shared across every path argument:
+/// ripgrep emits one JSON `summary` for the whole invocation, so stats have to
+/// accumulate across paths and the summary is emitted by
+/// [`OutputWriter::finish`] once the last path is done.
+pub fn run(
+    root: &Path,
+    index_path: Option<&Path>,
+    opts: &SearchOptions,
+    writer: &mut OutputWriter,
+) -> Result<bool> {
     let root = match std::fs::canonicalize(root) {
         Ok(root) => root,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
@@ -475,7 +504,9 @@ pub fn run(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) -> Resu
         && let Ok(info) = ServerInfo::load(&index_dir)
         && let Some((index_root, scope)) = resolve_scope(&index_dir, &root)
     {
-        if let Ok(had_matches) = search_via_server(&info, &root, &index_root, &scope, opts, ci) {
+        if let Ok(had_matches) =
+            search_via_server(&info, &root, &index_root, &scope, opts, ci, writer)
+        {
             return Ok(had_matches);
         }
         eprintln!("Server unreachable, falling back to local index");
@@ -483,14 +514,14 @@ pub fn run(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) -> Resu
 
     // No server — use on-disk index directly (or brute force)
     if opts.no_index || bypass_index {
-        return brute_force_search(&root, opts, ci);
+        return brute_force_search(&root, opts, ci, writer);
     }
     if !index_dir.join("lookup.bin").exists() {
         warn_missing_index(&index_dir, index_path.is_some(), opts.quiet);
-        return brute_force_search(&root, opts, ci);
+        return brute_force_search(&root, opts, ci, writer);
     }
 
-    search_local_index(&root, &index_dir, opts, ci)
+    search_local_index(&root, &index_dir, opts, ci, writer)
 }
 
 /// Render a path the way the user typed it.
@@ -548,6 +579,7 @@ fn search_via_server(
     scope: &IndexScope,
     opts: &SearchOptions,
     ci: bool,
+    writer: &mut OutputWriter,
 ) -> Result<bool> {
     let mut stream = TcpStream::connect(format!("127.0.0.1:{}", info.port))?;
     stream.set_read_timeout(Some(std::time::Duration::from_secs(300)))?;
@@ -592,7 +624,7 @@ fn search_via_server(
             "type_add": opts.type_add,
             "type_clear": opts.type_clear,
             "invert_match": opts.invert_match,
-            "only_matching": opts.only_matching,
+            "only_matching": opts.effective_only_matching(),
             "after_context": if wants_context { opts.after_ctx() } else { 0 },
             "before_context": if wants_context { opts.before_ctx() } else { 0 },
             "multiline": opts.multiline,
@@ -736,7 +768,6 @@ fn search_via_server(
         }
     };
 
-    let mut writer = OutputWriter::new(opts.make_output_config());
     let had_matches = !matches.is_empty();
 
     if opts.quiet {
@@ -888,6 +919,7 @@ fn search_local_index(
     index_dir: &Path,
     opts: &SearchOptions,
     ci: bool,
+    writer: &mut OutputWriter,
 ) -> Result<bool> {
     let start = Instant::now();
     let reader = IndexReader::open(index_dir)?;
@@ -898,7 +930,7 @@ fn search_local_index(
     // silently reports nothing.
     let Some((index_root, scope)) = resolve_scope(index_dir, root) else {
         // The index covers an unrelated tree, so it cannot answer this search.
-        return brute_force_search(root, opts, ci);
+        return brute_force_search(root, opts, ci, writer);
     };
 
     let glob_filter = opts.glob_filter()?;
@@ -977,7 +1009,6 @@ fn search_local_index(
         );
     }
 
-    let mut writer = OutputWriter::new(opts.make_output_config());
     let mut had_matches = false;
     // A single-file search root is a file the user named on the command line,
     // which is what makes binary files visible in ripgrep.
@@ -1003,7 +1034,7 @@ fn search_local_index(
             &matcher,
             rel_path,
             opts,
-            &mut writer,
+            &mut *writer,
             explicit,
         )?;
         match outcome {
@@ -1115,14 +1146,18 @@ fn within_max_depth(rel: &str, opts: &SearchOptions) -> bool {
     }
 }
 
-fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<bool> {
+fn brute_force_search(
+    root: &Path,
+    opts: &SearchOptions,
+    ci: bool,
+    writer: &mut OutputWriter,
+) -> Result<bool> {
     let start = Instant::now();
     let glob_filter = opts.glob_filter()?;
     let type_filter = opts.type_filter()?;
 
     let matcher = opts.matcher(ci)?;
 
-    let mut writer = OutputWriter::new(opts.make_output_config());
     let mut had_matches = false;
 
     if root.is_file() {
@@ -1137,7 +1172,7 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
                 &matcher,
                 &rel_path,
                 opts,
-                &mut writer,
+                &mut *writer,
                 true,
             )?;
             match outcome {
@@ -1195,7 +1230,7 @@ fn brute_force_search(root: &Path, opts: &SearchOptions, ci: bool) -> Result<boo
             &matcher,
             &rel_path,
             opts,
-            &mut writer,
+            &mut *writer,
             false,
         )?;
         match outcome {

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -941,11 +941,17 @@ fn search_local_index(
     // Narrow candidates using every pattern, not just the primary one. A
     // non-default `--encoding` re-decodes files into text the index never saw,
     // so the trigram plan cannot be trusted to find them.
-    let plan = if !matcher.is_standard() || opts.encoding.may_differ_from_index() {
+    //
+    // A PCRE-style pattern is not parseable by `regex-syntax`, but relaxing it
+    // (dropping lookarounds and the like) yields one that is, and that matches a
+    // superset — so its trigrams remain mandatory for the original.
+    let plan = if opts.encoding.may_differ_from_index() {
         QueryPlan::MatchAll
-    } else {
+    } else if matcher.is_standard() || opts.fixed_string {
         query::build_multi_pattern_plan(&opts.all_patterns()?, opts.fixed_string, ci)
             .map_err(|e| anyhow::anyhow!("{e}"))?
+    } else {
+        query::build_relaxed_multi_pattern_plan(&opts.all_patterns()?, ci)
     };
 
     let is_match_all = plan.is_match_all();

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -1038,14 +1038,7 @@ fn search_local_index(
             Err(_) => continue,
         };
 
-        let outcome = search_decoded_file(
-            &read,
-            &matcher,
-            rel_path,
-            opts,
-            &mut *writer,
-            explicit,
-        )?;
+        let outcome = search_decoded_file(&read, &matcher, rel_path, opts, &mut *writer, explicit)?;
         match outcome {
             FileOutcome::Matched => {
                 if !opts.files_without_match {
@@ -1175,14 +1168,8 @@ fn brute_force_search(
             && !exceeds_max_filesize(root, opts, true)
         {
             let read = read_text_lossy(root, opts.encoding)?;
-            let outcome = search_decoded_file(
-                &read,
-                &matcher,
-                &rel_path,
-                opts,
-                &mut *writer,
-                true,
-            )?;
+            let outcome =
+                search_decoded_file(&read, &matcher, &rel_path, opts, &mut *writer, true)?;
             match outcome {
                 FileOutcome::Matched => {
                     if !opts.files_without_match {
@@ -1232,14 +1219,7 @@ fn brute_force_search(
             Err(_) => continue,
         };
 
-        let outcome = search_decoded_file(
-            &read,
-            &matcher,
-            &rel_path,
-            opts,
-            &mut *writer,
-            false,
-        )?;
+        let outcome = search_decoded_file(&read, &matcher, &rel_path, opts, &mut *writer, false)?;
         match outcome {
             FileOutcome::Matched => {
                 if !opts.files_without_match {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -209,6 +209,10 @@ struct ServerState {
     /// Searches do **not** take this lock; they keep using the
     /// current reader + overlay throughout.
     snapshot_gate: RwLock<()>,
+    /// Serializes the complete stale walk → matcher → merge cycle. Serializing
+    /// only publication would let an older walk publish after a newer
+    /// ignore-rule refresh and roll the index back to stale ignore semantics.
+    stale_refresh_lock: Mutex<()>,
     /// Gitignore matcher used by the file watcher to drop events for
     /// paths the initial walk would have skipped via the `ignore` crate
     /// (`.gitignore`, `.git/info/exclude`, global gitignore, etc.).
@@ -397,6 +401,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         publish_lock: Mutex::new(()),
         file_stamps: RwLock::new(tgrep_core::meta::read_filestamps(&index_dir).unwrap_or_default()),
         snapshot_gate: RwLock::new(()),
+        stale_refresh_lock: Mutex::new(()),
         gitignore: RwLock::new(None),
         memory_cap_bytes,
         index_threads,
@@ -455,7 +460,15 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
             // during the gap: it compares the whole tree against the index,
             // so any edit that landed while the matcher was still building is
             // picked up here.
-            background_refresh_stale(&stale_state, &stale_root, &stale_index_dir, None);
+            let mut retry_delay = Duration::from_secs(1);
+            while !background_refresh_stale(&stale_state, &stale_root, &stale_index_dir, false) {
+                eprintln!(
+                    "[trace] stale check: retrying in {:.0}s",
+                    retry_delay.as_secs_f64()
+                );
+                thread::sleep(retry_delay);
+                retry_delay = (retry_delay * 2).min(Duration::from_secs(30));
+            }
         });
     }
 
@@ -479,8 +492,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
 
     // Start auto-save thread
     let save_state = Arc::clone(&state);
-    let save_index_dir = index_dir.clone();
-    thread::spawn(move || auto_save_loop(save_state, &save_index_dir));
+    thread::spawn(move || auto_save_loop(save_state));
 
     // Accept connections
     for stream in listener.incoming() {
@@ -500,29 +512,21 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     Ok(())
 }
 
-/// Publish the watcher's ignore matcher from ignore files discovered by a walk
-/// that already happened, and release the `gitignore_pending` gate.
+/// Build the ignore matcher used by the watcher from files discovered by a walk
+/// that already happened. The stale path needs it even with `--no-watch`.
 ///
 /// Reusing the caller's walk is the whole point: `gitignore::build_matcher`
 /// would traverse the entire tree a second time purely to find the same ignore
 /// files. On a 289k-file repo on a network drive that second walk cost 205s,
 /// against 1.6s for the stale-check walk over the same tree.
 ///
-/// Every exit path clears the gate. A repo with no ignore rules at all yields
-/// `None`, which is a legitimate final answer rather than a missing matcher, so
-/// it clears the gate too — otherwise the watcher would stay muted forever.
-fn publish_watcher_matcher(
+fn build_stale_matcher(
     state: &ServerState,
     root: &Path,
     walk: &tgrep_core::walker::MetaWalkResult,
-) {
-    if !state.watch_enabled {
-        return;
-    }
+) -> Option<tgrep_core::gitignore::IgnoreMatcher> {
     if state.no_ignore {
-        *state.gitignore.write().unwrap() = None;
-        state.gitignore_pending.store(false, Ordering::SeqCst);
-        return;
+        return None;
     }
 
     let start = Instant::now();
@@ -530,10 +534,9 @@ fn publish_watcher_matcher(
         root,
         &walk.gitignore_files,
         &walk.ignore_files,
+        state.no_require_git,
     );
     let has_matcher = matcher.is_some();
-    *state.gitignore.write().unwrap() = matcher;
-    state.gitignore_pending.store(false, Ordering::SeqCst);
     eprintln!(
         "[trace] gitignore matcher built from stale walk in {:.1}ms \
          ({} .gitignore + {} .ignore files{})",
@@ -542,6 +545,17 @@ fn publish_watcher_matcher(
         walk.ignore_files.len(),
         if has_matcher { "" } else { ", no rules found" }
     );
+    matcher
+}
+
+/// Commit matcher and index semantics together while the stale refresh holds
+/// `snapshot_gate`. `None` is a legitimate matcher when no rules exist.
+fn commit_stale_matcher(
+    state: &ServerState,
+    matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
+) {
+    *state.gitignore.write().unwrap() = matcher;
+    state.gitignore_pending.store(false, Ordering::SeqCst);
 }
 
 fn handle_connection(stream: TcpStream, state: &ServerState) -> Result<()> {
@@ -1332,12 +1346,15 @@ fn start_file_watcher(
                             "[trace] watcher queue overflowed (cap {queue_cap}); \
                              reconciling with a stale check"
                         );
-                        background_refresh_stale(
+                        if !background_refresh_stale(
                             &worker_state,
                             &worker_root,
                             &worker_index_dir,
-                            None,
-                        );
+                            false,
+                        ) {
+                            overflowed.store(true, Ordering::SeqCst);
+                            thread::sleep(Duration::from_secs(1));
+                        }
                     }
                     // The watcher was dropped, so the server is shutting down.
                     Err(RecvTimeoutError::Disconnected) => break,
@@ -1441,13 +1458,10 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
                 // The stale refresh walks the tree anyway and republishes the
                 // matcher from that walk, so the reload costs one traversal
                 // rather than a rebuild plus a re-scan.
-                let indexed_paths = {
-                    let index = state.index.read().unwrap();
-                    let mut paths = index.reader_paths();
-                    paths.extend(index.live.overlay_paths());
-                    paths
-                };
-                background_refresh_stale(&state, &root, &state.index_dir, Some(&indexed_paths));
+                if !background_refresh_stale(&state, &root, &state.index_dir, true) {
+                    state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+                    thread::sleep(Duration::from_secs(1));
+                }
             }
 
             state
@@ -1496,17 +1510,6 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         return;
     }
 
-    // Likewise, stay off the index until the gitignore matcher exists. On a
-    // warm start (complete index on disk) `indexing` is false from the very
-    // first event, so without this the watcher would run with a `None`
-    // matcher and index exactly the build output the walk skipped — the
-    // divergence `should_skip_watcher_path` exists to prevent. Events dropped
-    // here are recovered by the stale check that runs right after the
-    // matcher is published.
-    if state.gitignore_pending.load(Ordering::SeqCst) {
-        return;
-    }
-
     // Acquire the snapshot gate up-front for the whole event. While a
     // flush/auto-save is publishing (writer holds it), no reindex
     // *work* — file I/O, trigram extraction, even the [trace] line —
@@ -1515,6 +1518,14 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     // would just block the watcher thread anyway. We hold it for read
     // so multiple events can proceed concurrently outside any flush.
     let _gate = state.snapshot_gate.read().unwrap();
+
+    // Stay off the index until the initial ignore matcher exists. This check
+    // must happen *under* the gate: during startup the stale walk holds the
+    // write side, so an event waits and is applied after publication instead
+    // of being dropped after the walk may already have visited its path.
+    if state.gitignore_pending.load(Ordering::SeqCst) {
+        return;
+    }
 
     for path in &event.paths {
         // Skip the index directory itself
@@ -1628,7 +1639,7 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     }
 }
 
-fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
+fn auto_save_loop(state: Arc<ServerState>) {
     let mut last_save = Instant::now();
 
     loop {
@@ -1652,91 +1663,22 @@ fn auto_save_loop(state: Arc<ServerState>, index_dir: &Path) {
             let save_start = Instant::now();
             eprintln!("[trace] auto-save: {dirty} mutations, saving...");
 
-            // Hold the snapshot gate in write mode for the entire
-            // snapshot → publish → prune cycle so watcher mutations
-            // can't race the prune (see flush_index_to_disk for the
-            // same pattern + rationale).
+            // Hold the gate through delta build → publish → prune so watcher
+            // mutations cannot race publication. Recheck after acquiring it:
+            // another publisher may have drained the overlay while we waited.
             let _gate = state.snapshot_gate.write().unwrap();
-
-            // Snapshot reader + overlay under brief read lock
-            let (paths, inverted) = {
-                let index = state.index.read().unwrap();
-                index.full_snapshot()
-            };
-            let staging_dir = index_dir.with_file_name(".tgrep_save_staging");
-            // Clear any stale files from a previously crashed auto-save —
-            // otherwise leftover artifacts (e.g. an old filestamps.json)
-            // would be picked up by move_staged_files and published.
-            let _ = std::fs::remove_dir_all(&staging_dir);
-            if let Err(e) = builder::write_index_from_snapshot(
-                &state.root,
-                &staging_dir,
-                &paths,
-                &inverted,
-                true,
-            ) {
-                eprintln!("[trace] auto-save failed: {e}");
-                let _ = std::fs::remove_dir_all(&staging_dir);
+            if !state.index.read().unwrap().live.has_pending_changes() {
                 continue;
             }
 
-            // Lock-free publish: rename staging files into place, build a
-            // new IndexReader, then swap it in via a brief read lock. Search
-            // queries are NOT blocked: they continue to be served by the
-            // previous reader (whose mmap stays valid until the last
-            // in-flight Arc<IndexReader> is dropped) and by the live overlay
-            // throughout the entire publish.
-            //
-            // Held across move + open + swap so concurrent publishers
-            // (checkpoint / flush) cannot interleave renames or swap
-            // readers out of order. Searches do not take this lock.
-            let _publish = state.publish_lock.lock().unwrap();
-            let num_files = paths.len();
-            if let Err(e) = move_staged_files(&staging_dir, index_dir) {
-                eprintln!("[trace] auto-save move failed: {e}");
-                let _ = std::fs::remove_dir_all(&staging_dir);
-                continue;
+            let stamps = state.file_stamps.read().unwrap().clone();
+            if stream_merge_stale_changes(&state, &[], &[], &[], &stamps, "auto-save", false) {
+                last_save = Instant::now();
+                eprintln!(
+                    "[trace] auto-save complete in {:.1}s",
+                    save_start.elapsed().as_secs_f64()
+                );
             }
-            match tgrep_core::reader::IndexReader::open(index_dir) {
-                Ok(new_reader) => {
-                    let reader_files = new_reader.num_files();
-                    let reader_trigrams = new_reader.num_trigrams();
-
-                    if new_reader.is_degenerate() {
-                        eprintln!(
-                            "[trace] auto-save: degenerate reader ({reader_files} files, \
-                             0 trigrams), keeping live overlay"
-                        );
-                    } else if let Err(msg) = new_reader.validate_lookup() {
-                        eprintln!(
-                            "[trace] auto-save: validation failed: {msg}, keeping live overlay"
-                        );
-                    } else if reader_files >= num_files {
-                        // Swap the reader without blocking concurrent searches.
-                        state.index.read().unwrap().swap_reader(new_reader);
-                        // Brief write lock for in-memory overlay prune + dirty reset.
-                        {
-                            let mut index = state.index.write().unwrap();
-                            index.prune_persisted_entries();
-                            index.live.reset_dirty_count();
-                        }
-                        last_save = Instant::now();
-                        eprintln!(
-                            "[trace] auto-save complete in {:.1}s ({reader_files} files, \
-                             {reader_trigrams} trigrams on disk)",
-                            save_start.elapsed().as_secs_f64(),
-                        );
-                    } else {
-                        eprintln!(
-                            "[trace] auto-save reopen incomplete: expected {num_files} files, found {reader_files}; live overlay retained"
-                        );
-                    }
-                }
-                Err(e) => {
-                    eprintln!("[trace] auto-save reopen failed: {e}, live overlay retained");
-                }
-            }
-            let _ = std::fs::remove_dir_all(&staging_dir);
         }
     }
 }
@@ -1795,7 +1737,8 @@ fn create_empty_index(index_dir: &Path) -> Result<()> {
 fn classify_file_changes(
     current_meta: &[tgrep_core::walker::FileMeta],
     old_stamps: &std::collections::HashMap<String, tgrep_core::meta::FileStamp>,
-    indexed_paths: Option<&std::collections::HashSet<String>>,
+    indexed_paths: &std::collections::HashSet<String>,
+    compare_index_membership: bool,
 ) -> (Vec<String>, Vec<String>, Vec<String>) {
     use tgrep_core::meta::FileStamp;
 
@@ -1809,7 +1752,7 @@ fn classify_file_changes(
             mtime: fm.mtime,
             size: fm.size,
         };
-        if indexed_paths.is_some_and(|paths| !paths.contains(&fm.relative_path)) {
+        if compare_index_membership && !indexed_paths.contains(&fm.relative_path) {
             added.push(fm.relative_path.clone());
             continue;
         }
@@ -1820,11 +1763,11 @@ fn classify_file_changes(
         }
     }
 
-    let indexed_or_stamped_paths: Box<dyn Iterator<Item = &String>> = match indexed_paths {
-        Some(paths) => Box::new(paths.iter()),
-        None => Box::new(old_stamps.keys()),
-    };
-    let deleted = indexed_or_stamped_paths
+    let mut seen = std::collections::HashSet::new();
+    let deleted = old_stamps
+        .keys()
+        .chain(indexed_paths)
+        .filter(|path| seen.insert(path.as_str()))
         .filter(|path| !current_set.contains(path.as_str()))
         .cloned()
         .collect();
@@ -1832,15 +1775,189 @@ fn classify_file_changes(
     (changed, added, deleted)
 }
 
+/// Apply a stale diff without materializing the existing index in heap.
+///
+/// The ordinary incremental flush uses `HybridIndex::full_snapshot`, whose
+/// memory is proportional to every posting already on disk. That is especially
+/// harmful when a newer tgrep first opens an index built with an older file-size
+/// cap: every formerly-oversized file appears as new at once. Build new and
+/// replacement files into a bounded external-sort delta, then stream it together
+/// with the old index while filtering replaced and deleted reader entries.
+///
+/// The caller holds `snapshot_gate` across the metadata walk and this merge, so
+/// the walk's exact path set is newer than every live entry captured here.
+fn stream_merge_stale_changes(
+    state: &Arc<ServerState>,
+    changed: &[String],
+    added: &[String],
+    deleted: &[String],
+    stamps: &std::collections::HashMap<String, tgrep_core::meta::FileStamp>,
+    operation: &str,
+    authoritative_membership: bool,
+) -> bool {
+    let root = &state.root;
+    let index_dir = &state.index_dir;
+    let (reader, overlay_paths, tombstone_paths) = {
+        let index = state.index.read().unwrap();
+        (
+            index.reader_arc(),
+            index.live.overlay_paths(),
+            index.live.tombstone_paths(),
+        )
+    };
+
+    state.flushing.store(true, Ordering::SeqCst);
+    let start = Instant::now();
+    eprintln!(
+        "[trace] {operation}: building a memory-bounded delta \
+         ({} changed, {} new, {} deleted)...",
+        changed.len(),
+        added.len(),
+        deleted.len()
+    );
+
+    // Keep work directories inside the locked index directory. Sibling names
+    // collide when two independent indexes share a parent directory.
+    let delta_dir = index_dir.join(".stale-delta");
+    let staging_dir = index_dir.join(".stale-merge");
+    let _ = std::fs::remove_dir_all(&delta_dir);
+    let _ = std::fs::remove_dir_all(&staging_dir);
+
+    // Fold in every live mutation. A stale walk also treats its exact path set
+    // as authoritative, removing reader entries missing from the walk; an
+    // auto-save cannot do that because its filestamps may be incomplete.
+    let mut seen = std::collections::HashSet::new();
+    let mut candidates: Vec<String> = changed
+        .iter()
+        .chain(added)
+        .chain(deleted)
+        .chain(overlay_paths.iter())
+        .chain(tombstone_paths.iter())
+        .filter(|path| seen.insert((*path).clone()))
+        .cloned()
+        .collect();
+    if authoritative_membership {
+        candidates.extend(
+            reader
+                .all_paths()
+                .iter()
+                .filter(|path| !stamps.contains_key(path.as_str()))
+                .filter(|path| seen.insert((*path).clone()))
+                .cloned(),
+        );
+    }
+    let desired_paths: Vec<String> = candidates
+        .iter()
+        .filter(|path| stamps.contains_key(path.as_str()))
+        .cloned()
+        .collect();
+    let files: Vec<PathBuf> = desired_paths.iter().map(|path| root.join(path)).collect();
+    // Every candidate is either removed or replaced by the delta. Including a
+    // genuinely new path is harmless because it has no reader entry to filter.
+    let removed: std::collections::HashSet<String> = candidates.iter().cloned().collect();
+
+    let published_stamps = stamps.clone();
+
+    let result = (|| -> Result<bool> {
+        let build = || {
+            builder::build_index_for_files(
+                root,
+                &delta_dir,
+                &files,
+                builder::DEFAULT_INDEX_BUFFER_BYTES,
+            )
+        };
+        let delta_count = match rayon::ThreadPoolBuilder::new()
+            .num_threads(state.index_threads)
+            .thread_name(|i| format!("tgrep-stale-index-{i}"))
+            .build()
+        {
+            Ok(pool) => pool.install(build)?,
+            Err(_) => build()?,
+        };
+        let delta = tgrep_core::reader::IndexReader::open(&delta_dir)?;
+        if delta.num_files() != delta_count {
+            anyhow::bail!(
+                "delta reopened with {} files after writing {delta_count}",
+                delta.num_files()
+            );
+        }
+
+        builder::merge_index_with_delta(root, &staging_dir, &reader, &delta, &removed, true)?;
+        tgrep_core::meta::write_filestamps(&published_stamps, &staging_dir)?;
+        let removed_reader_files = reader
+            .all_paths()
+            .iter()
+            .filter(|path| removed.contains(path.as_str()))
+            .count();
+        let expected_files = reader.num_files() - removed_reader_files + delta.num_files();
+        let published = publish_staged_index(state, index_dir, &staging_dir, expected_files);
+        if published {
+            // `publish_staged_index` prunes overlay entries represented by the
+            // new reader. Also clear reconciled entries intentionally omitted
+            // (newly ignored/binary/deleted) and old tombstones for files the
+            // delta restored. The gate guarantees none is newer than this merge.
+            state
+                .index
+                .write()
+                .unwrap()
+                .live
+                .clear_reconciled_paths(&candidates);
+            state
+                .index_progress
+                .store(expected_files as u64, Ordering::Relaxed);
+            state
+                .index_total
+                .store(expected_files as u64, Ordering::Relaxed);
+        }
+        Ok(published)
+    })();
+
+    let _ = std::fs::remove_dir_all(&delta_dir);
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    state.flushing.store(false, Ordering::SeqCst);
+    if matches!(&result, Ok(true)) {
+        *state.file_stamps.write().unwrap() = published_stamps;
+    }
+    match result {
+        Ok(true) => {
+            eprintln!(
+                "[trace] {operation}: streamed {} changes into the index in {:.1}s",
+                candidates.len(),
+                start.elapsed().as_secs_f64()
+            );
+            true
+        }
+        Ok(false) => {
+            eprintln!(
+                "[trace] warning: {operation} delta could not be published; \
+                 keeping the old index"
+            );
+            false
+        }
+        Err(error) => {
+            eprintln!(
+                "[trace] warning: memory-bounded {operation} failed ({error}); \
+                 keeping the old index"
+            );
+            false
+        }
+    }
+}
+
 fn background_refresh_stale(
     state: &Arc<ServerState>,
     root: &Path,
     index_dir: &Path,
-    indexed_paths: Option<&std::collections::HashSet<String>>,
-) {
+    compare_index_membership: bool,
+) -> bool {
     use tgrep_core::meta::{self, FileStamp};
     use tgrep_core::walker;
 
+    let _refresh = state.stale_refresh_lock.lock().unwrap();
+    // Keep watcher/auto-save mutations out for the complete walk → matcher →
+    // merge cycle. Search queries do not take this gate and remain available.
+    let _gate = state.snapshot_gate.write().unwrap();
     let start = Instant::now();
     eprintln!("[trace] stale check: comparing index against filesystem...");
 
@@ -1858,15 +1975,23 @@ fn background_refresh_stale(
         },
     );
     let walk_ms = start.elapsed().as_millis();
-    publish_watcher_matcher(state, root, &walk);
+    if walk.skipped_error > 0 {
+        eprintln!(
+            "[trace] warning: stale check could not inspect {} filesystem entries \
+             (walk: {walk_ms}ms); keeping the old index",
+            walk.skipped_error
+        );
+        return false;
+    }
+    let matcher = build_stale_matcher(state, root, &walk);
     let current_meta = &walk.files;
 
     // Load stored per-file stamps from last index write
     let mut old_stamps = match meta::read_filestamps(index_dir) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("[trace] stale check: no filestamps found ({e}), skipping");
-            return;
+            eprintln!("[trace] stale check: no filestamps found ({e}), comparing against reader");
+            std::collections::HashMap::new()
         }
     };
 
@@ -1881,74 +2006,52 @@ fn background_refresh_stale(
     for (path, stamp) in state.file_stamps.read().unwrap().iter() {
         old_stamps.insert(path.clone(), stamp.clone());
     }
-    if old_stamps.is_empty() && indexed_paths.is_none() {
-        eprintln!("[trace] stale check: no filestamps found, skipping");
-        return;
+    let indexed_paths = {
+        let index = state.index.read().unwrap();
+        let mut paths = index.reader_paths();
+        paths.extend(index.live.overlay_paths());
+        paths
+    };
+    if old_stamps.is_empty() && indexed_paths.is_empty() && current_meta.is_empty() {
+        eprintln!("[trace] stale check: no indexed files or filesystem files, skipping");
+        commit_stale_matcher(state, matcher);
+        return true;
     }
 
-    let (changed, added, deleted) = classify_file_changes(current_meta, &old_stamps, indexed_paths);
+    let (changed, added, deleted) = classify_file_changes(
+        current_meta,
+        &old_stamps,
+        &indexed_paths,
+        compare_index_membership,
+    );
 
     let total_changes = changed.len() + added.len() + deleted.len();
-    if total_changes == 0 {
+    let live_pending = state.index.read().unwrap().live.has_pending_changes();
+    if total_changes == 0 && !live_pending {
         eprintln!(
             "[trace] stale check: index is up-to-date ({} files checked in {}ms)",
             current_meta.len(),
             walk_ms
         );
-        return;
+        commit_stale_matcher(state, matcher);
+        return true;
     }
 
-    eprintln!(
-        "[trace] stale check: {} changed, {} new, {} deleted (walk: {}ms)",
-        changed.len(),
-        added.len(),
-        deleted.len(),
-        walk_ms
-    );
-
-    // Apply changes to the LiveIndex. Hold snapshot_gate.read() across the
-    // mutation block so a concurrent flush/auto-save cannot snapshot the
-    // overlay and then prune away these updates after publishing. The
-    // subsequent flush_index_to_disk call below takes the gate exclusively
-    // itself.
-    let update_start = Instant::now();
-    let files_to_update: Vec<String> = changed.into_iter().chain(added).collect();
-
-    {
-        let _gate = state.snapshot_gate.read().unwrap();
-        let mut index = state.index.write().unwrap();
-
-        // Remove deleted files
-        for rel_path in &deleted {
-            index.live.delete_file(rel_path);
-        }
-
-        // Upsert changed/new files (reads content, extracts trigrams)
-        for rel_path in &files_to_update {
-            index.live.update_from_disk(root, rel_path);
-        }
+    if total_changes == 0 {
+        eprintln!(
+            "[trace] stale check: metadata is unchanged, reconciling live mutations \
+             (walk: {walk_ms}ms)"
+        );
+    } else {
+        eprintln!(
+            "[trace] stale check: {} changed, {} new, {} deleted (walk: {}ms)",
+            changed.len(),
+            added.len(),
+            deleted.len(),
+            walk_ms
+        );
     }
 
-    // Invalidate cache entries for all affected files
-    {
-        if let Ok(mut cache) = state.cache.write() {
-            for rel_path in deleted.iter().chain(files_to_update.iter()) {
-                cache.pop(rel_path);
-            }
-        }
-    }
-
-    eprintln!(
-        "[trace] stale check: updated {} files in {:.1}ms (total: {:.1}ms)",
-        total_changes,
-        update_start.elapsed().as_secs_f64() * 1000.0,
-        start.elapsed().as_secs_f64() * 1000.0
-    );
-
-    // Persist the updated index immediately so changes survive a crash.
-    // Pass the freshly-walked stamps so they publish atomically with the
-    // index files.
-    eprintln!("[trace] stale check: flushing updated index to disk...");
     let new_stamps: std::collections::HashMap<String, FileStamp> = current_meta
         .iter()
         .map(|fm| {
@@ -1961,13 +2064,26 @@ fn background_refresh_stale(
             )
         })
         .collect();
-    state.flushing.store(true, Ordering::SeqCst);
-    flush_index_to_disk(state, root, index_dir, Some(&new_stamps));
-    state.flushing.store(false, Ordering::SeqCst);
 
-    // Refresh in-memory stamps so the watcher can dedupe spurious notify
-    // events for files that already match what we just published.
-    *state.file_stamps.write().unwrap() = new_stamps;
+    if !stream_merge_stale_changes(
+        state,
+        &changed,
+        &added,
+        &deleted,
+        &new_stamps,
+        "stale check",
+        true,
+    ) {
+        return false;
+    }
+
+    commit_stale_matcher(state, matcher);
+    if let Ok(mut cache) = state.cache.write() {
+        for path in changed.iter().chain(added.iter()).chain(deleted.iter()) {
+            cache.pop(path);
+        }
+    }
+    true
 }
 
 /// Restore a known-empty on-disk index after a failed bootstrap.
@@ -2087,6 +2203,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             root,
             &outcome.gitignore_files,
             &outcome.ignore_files,
+            state.no_require_git,
         );
         let found = matcher.is_some();
         *state.gitignore.write().unwrap() = matcher;
@@ -2180,6 +2297,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             root,
             &walk.gitignore_files,
             &walk.ignore_files,
+            state.no_require_git,
         );
         let has_matcher = matcher.is_some();
         *state.gitignore.write().unwrap() = matcher;
@@ -2419,97 +2537,10 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     }
 }
 
-/// Flush the current LiveIndex to disk and reopen the reader.
-/// Uses fast clone + background remap so queries stay responsive.
-///
-/// If `stamps` is `Some`, the function attempts to write per-file stamps
-/// into the staging directory so they are renamed into the index dir
-/// alongside the index files. Stamp persistence is best-effort: if writing
-/// `filestamps.json` fails we log and still publish the index, since
-/// losing the incremental stale-check on next start is preferable to
-/// dropping the freshly-built index. Callers must therefore not rely on
-/// `filestamps.json` always being published alongside a newly-flushed
-/// index.
-///
-/// Returns `true` if the new reader was opened and `prune_persisted_entries`
-/// ran on the live overlay; `false` on any earlier failure (write/move/open
-/// error or partial reader). Callers can use this to decide whether
-/// follow-up work that depends on the prune (e.g. shrinking the overlay)
-/// is worth doing.
-fn flush_index_to_disk(
-    state: &ServerState,
-    _root: &Path,
-    index_dir: &Path,
-    stamps: Option<&std::collections::HashMap<String, tgrep_core::meta::FileStamp>>,
-) -> bool {
-    let flush_start = Instant::now();
-
-    // Hold the snapshot gate in write mode for the entire snapshot →
-    // publish → prune cycle. Watcher mutations block on this for the
-    // duration; without it, an event that fires after the snapshot but
-    // before the prune would be silently dropped (snapshot doesn't see
-    // it, reader is reopened with the old version, then the prune
-    // removes the overlay entry by path because it now matches a reader
-    // entry). Searches do not take this lock and remain unaffected.
-    let _gate = state.snapshot_gate.write().unwrap();
-
-    // Snapshot under brief read lock — use full_snapshot to merge reader + overlay
-    let (paths, inverted, num_files) = {
-        let index = state.index.read().unwrap();
-        let (paths, inverted) = index.full_snapshot();
-        let num = paths.len();
-        eprintln!(
-            "[trace] flush: snapshotted {num} files in {:.1}ms",
-            flush_start.elapsed().as_secs_f64() * 1000.0
-        );
-        (paths, inverted, num)
-    };
-
-    // Always start from a clean staging dir. A previous crash (or a partial
-    // earlier flush whose error path missed the cleanup) could have left
-    // stale files behind — including a stale `filestamps.json`. If the
-    // current flush is invoked with `stamps == None` and we left an old
-    // filestamps.json there, `move_staged_files` would publish it next to
-    // a freshly-built index, silently corrupting the stale-check baseline.
-    let staging_dir = index_dir.with_file_name(".tgrep_flush_staging");
-    let _ = std::fs::remove_dir_all(&staging_dir);
-
-    // Expensive write — no lock held, queries served normally
-    if let Err(e) =
-        builder::write_index_from_snapshot(&state.root, &staging_dir, &paths, &inverted, true)
-    {
-        eprintln!("[trace] warning: flush to disk failed: {e}");
-        let _ = std::fs::remove_dir_all(&staging_dir);
-        return false;
-    }
-
-    // Stage filestamps alongside the index files so the subsequent move
-    // publishes them atomically. If this fails we still try to publish the
-    // index — losing only the incremental stale-check benefit on next start,
-    // not the index itself.
-    if let Some(stamps) = stamps
-        && let Err(e) = tgrep_core::meta::write_filestamps(stamps, &staging_dir)
-    {
-        eprintln!("[trace] warning: failed to write staging filestamps: {e}");
-    }
-
-    // Lock-free publish: rename staging files into place, build the new
-    // reader, swap it in, and prune the now-persisted overlay. Search queries
-    // continue to be served by the previous reader throughout.
-    let pruned = publish_staged_index(state, index_dir, &staging_dir, num_files);
-
-    eprintln!(
-        "[trace] index flushed: {num_files} files on disk in {:.1}s",
-        flush_start.elapsed().as_secs_f64()
-    );
-    pruned
-}
-
 /// Memory-bounded append-only flush used during the initial bulk build.
 ///
-/// Unlike [`flush_index_to_disk`] (which builds a full reader+overlay snapshot
-/// in heap via `full_snapshot`, costing O(total index size) memory), this
-/// streams the live overlay onto the existing on-disk index via
+/// Unlike building a full reader+overlay snapshot in heap (which costs
+/// O(total index size) memory), this streams the live overlay onto disk via
 /// [`builder::append_overlay_to_index`]: the existing postings are copied
 /// verbatim from the reader's mmap and never enter the heap. Peak heap stays
 /// bounded to the overlay snapshot, so repeated checkpoint flushes and the
@@ -2531,10 +2562,9 @@ fn flush_append_only_overlay(
     complete: bool,
     stamps: Option<&std::collections::HashMap<String, tgrep_core::meta::FileStamp>>,
 ) -> bool {
-    // Hold the snapshot gate for the whole snapshot → publish → prune cycle,
-    // mirroring flush_index_to_disk. (During the bulk build the watcher is
-    // already suppressed, but auto-save coordination and future-proofing make
-    // the gate the right call.)
+    // Hold the snapshot gate for the whole snapshot → publish → prune cycle.
+    // During the bulk build the watcher is already suppressed, but auto-save
+    // coordination and future-proofing make the gate the right call.
     let _gate = state.snapshot_gate.write().unwrap();
     flush_append_only_overlay_locked(state, index_dir, complete, stamps)
 }
@@ -2605,10 +2635,10 @@ fn flush_append_only_overlay_locked(
 /// validate + warm it, swap it in without blocking searches, and prune the
 /// now-persisted overlay entries.
 ///
-/// Shared by [`flush_index_to_disk`] and [`flush_append_only_overlay`]. The
-/// `publish_lock` is held across move + open + swap so concurrent publishers
-/// cannot interleave renames or swap readers out of order. `num_files` is the
-/// expected on-disk file count used to reject a partially-published reader.
+/// Shared by stale refresh and [`flush_append_only_overlay`]. The `publish_lock`
+/// is held across move + open + swap so concurrent publishers cannot interleave
+/// renames or swap readers out of order. `num_files` is the expected on-disk
+/// file count used to reject a partially-published reader.
 ///
 /// Returns `true` when the swap + prune succeeded, `false` on any failure (the
 /// previous reader and the live overlay are retained as the fallback).
@@ -3175,10 +3205,30 @@ mod tests {
         ]);
         let indexed = HashSet::from(["kept.txt".to_string(), "newly-ignored.txt".to_string()]);
 
-        let (changed, added, deleted) = classify_file_changes(&current, &stamps, Some(&indexed));
+        let (changed, added, deleted) = classify_file_changes(&current, &stamps, &indexed, true);
         assert!(changed.is_empty());
         assert_eq!(added, vec!["newly-unignored.txt"]);
         assert_eq!(deleted, vec!["newly-ignored.txt"]);
+    }
+
+    #[test]
+    fn stale_classification_uses_reader_paths_for_deletions_and_case_renames() {
+        use std::collections::{HashMap, HashSet};
+        use tgrep_core::walker::FileMeta;
+
+        let current = vec![FileMeta {
+            relative_path: "case.txt".to_string(),
+            mtime: 1,
+            size: 10,
+        }];
+        let indexed = HashSet::from(["Case.txt".to_string(), "reader-only.txt".to_string()]);
+
+        let (changed, added, mut deleted) =
+            classify_file_changes(&current, &HashMap::new(), &indexed, false);
+        assert!(changed.is_empty());
+        assert_eq!(added, vec!["case.txt"]);
+        deleted.sort();
+        assert_eq!(deleted, vec!["Case.txt", "reader-only.txt"]);
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -52,6 +52,38 @@ const WATCHER_QUEUE_CAP: usize = 16_384;
 /// reconciling stale check runs.
 const WATCHER_IDLE_POLL: Duration = Duration::from_secs(1);
 
+/// How long a file the watcher never heard about can stay wrong in the index.
+///
+/// Every mutation the index takes after the initial build arrives as an OS
+/// notification, and a notification can go missing: the queue between the
+/// callback and the worker can overflow, a network or virtualised filesystem
+/// can decline to report a change at all, and a `serve` that is running while
+/// the tree is replaced wholesale (a branch switch, a build) can be handed
+/// more events than the platform is willing to buffer. Overflow is detected
+/// and repaired immediately; the rest is silent. Nothing else in the server
+/// ever revisits a file it believes it already knows, so a miss lasts until
+/// the file happens to change again — which for a deleted file is never.
+///
+/// A full stale check finds all of it, because it compares the whole tree
+/// against the index rather than trusting any event. Running one on a timer
+/// turns "until something else happens to fix it" into a bound.
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// How often the reconcile loop wakes to see whether it is due.
+const RECONCILE_POLL: Duration = Duration::from_secs(60);
+
+/// How long the server must have gone without a search before a scheduled
+/// reconcile runs. A reconcile walks the entire tree and holds the snapshot
+/// gate while it does, so on a repository being actively queried it waits for
+/// a gap rather than competing.
+const RECONCILE_QUIET_PERIOD: Duration = Duration::from_secs(120);
+
+/// The point at which a reconcile stops waiting for a quiet gap. A server
+/// queried steadily every minute would otherwise never see one, and would
+/// never reconcile at all — which is the failure this exists to prevent.
+const RECONCILE_DEADLINE: Duration = Duration::from_secs(4 * 3600);
+
+
 /// Server discovery info, written to `serve.json`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServerInfo {
@@ -337,6 +369,43 @@ struct ServerState {
     /// save. Higher values reduce save frequency (and the pauses they cause)
     /// at the cost of more unsaved work if the process is killed.
     auto_save_mutations: u32,
+    /// Files a delta build could not read, and the metadata they had when it
+    /// tried.
+    ///
+    /// A file that fails to read has its stamp withheld so the next reconcile
+    /// retries it rather than recording it as indexed. That is right for a
+    /// transient failure and wrong for a permanent one: a file locked by
+    /// another process, or unreadable by permission, fails identically every
+    /// time, and with a reconcile on a timer it would rewrite the whole index
+    /// once an hour forever to re-attempt a file that will fail again.
+    ///
+    /// Remembering the metadata of the attempt separates the two. A file whose
+    /// mtime and size have not moved since it failed is not worth another
+    /// read; one that has changed gets a fresh look. The record lives in
+    /// memory, so restarting the server retries everything — which is the
+    /// escape hatch for a file made readable without being modified.
+    unreadable: RwLock<std::collections::HashMap<String, tgrep_core::meta::FileStamp>>,
+    /// Reference point for [`ServerState::quiet_for`], because an `Instant`
+    /// cannot live in an atomic.
+    started: Instant,
+    /// Milliseconds since `started` at the last search request, used by the
+    /// periodic reconcile to stay out of the way of a server in active use.
+    last_search_ms: std::sync::atomic::AtomicU64,
+}
+
+impl ServerState {
+    fn note_search(&self) {
+        self.last_search_ms
+            .store(self.started.elapsed().as_millis() as u64, Ordering::Relaxed);
+    }
+
+    /// How long the server has gone without a search.
+    fn quiet_for(&self) -> Duration {
+        let last = self.last_search_ms.load(Ordering::Relaxed);
+        self.started
+            .elapsed()
+            .saturating_sub(Duration::from_millis(last))
+    }
 }
 
 /// `Default` exists only for tests, which need to vary one field at a time.
@@ -515,6 +584,9 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         memory_cap_bytes,
         index_threads,
         auto_save_mutations,
+        unreadable: RwLock::new(std::collections::HashMap::new()),
+        started: serve_start,
+        last_search_ms: std::sync::atomic::AtomicU64::new(0),
     });
 
     // Bind TCP listener on a random port
@@ -605,6 +677,19 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     // Start auto-save thread
     let save_state = Arc::clone(&state);
     thread::spawn(move || auto_save_loop(save_state));
+
+    // Bound how long a change the watcher never heard about can stay wrong.
+    // Pointless without a watcher: `--no-watch` means the index is only ever
+    // refreshed on request, and silently rewriting it on a timer would be a
+    // surprise rather than a repair.
+    if !no_watch {
+        let reconcile_state = Arc::clone(&state);
+        let reconcile_root = root.clone();
+        let reconcile_index_dir = index_dir.clone();
+        thread::spawn(move || {
+            periodic_reconcile_loop(reconcile_state, reconcile_root, reconcile_index_dir)
+        });
+    }
 
     // Accept connections
     for stream in listener.incoming() {
@@ -971,6 +1056,9 @@ fn handle_search(
     state: &ServerState,
 ) -> String {
     let start = Instant::now();
+    // Marks the server as in use, so the periodic reconcile waits for a gap
+    // rather than walking the tree underneath a client that is mid-session.
+    state.note_search();
 
     let req = match parse_search_params(params) {
         Ok(r) => r,
@@ -1770,6 +1858,61 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     }
 }
 
+/// Whether a scheduled reconcile should run now.
+///
+/// Split out from the loop so the schedule can be exercised without waiting
+/// hours for it.
+fn reconcile_due(since_last: Duration, quiet_for: Duration, busy: bool) -> bool {
+    // Indexing and flushing are already rewriting the index, and a reconcile
+    // takes the snapshot gate for its whole walk-and-merge. Let them finish;
+    // the next tick is a minute away.
+    if busy {
+        return false;
+    }
+    if since_last >= RECONCILE_DEADLINE {
+        return true;
+    }
+    since_last >= RECONCILE_INTERVAL && quiet_for >= RECONCILE_QUIET_PERIOD
+}
+
+/// Periodically compare the whole tree against the index, so a change the
+/// watcher never heard about cannot stay wrong indefinitely.
+///
+/// See [`RECONCILE_INTERVAL`] for why this is needed at all. It is deliberately
+/// unhurried: it defers to indexing, to flushing, and to a server that is
+/// being queried, and it does nothing at all on a tree that has not drifted —
+/// the walk finds no differences and returns without touching the index.
+fn periodic_reconcile_loop(state: Arc<ServerState>, root: PathBuf, index_dir: PathBuf) {
+    let mut last = Instant::now();
+    loop {
+        thread::sleep(RECONCILE_POLL);
+
+        let busy = state.indexing.load(Ordering::SeqCst) || state.flushing.load(Ordering::SeqCst);
+        if !reconcile_due(last.elapsed(), state.quiet_for(), busy) {
+            continue;
+        }
+
+        // Restart the interval before the walk rather than after it. On a large
+        // repository the reconcile itself takes a while, and timing from its
+        // completion would push each one further out than the last.
+        last = Instant::now();
+        eprintln!("[trace] periodic reconcile: looking for changes the watcher missed");
+        // Same comparison the startup check makes, and for the same reason: a
+        // lost event is a stamp that disagrees with the filesystem, a file with
+        // no stamp, or a stamp with no file, and all three fall out of that.
+        // Comparing index *membership* as well would additionally re-add any
+        // file whose stamp says indexed but which the reader does not hold —
+        // a publication bug rather than a lost event, and one that on an hourly
+        // timer would rebuild the whole index every hour if it ever misfired.
+        if !background_refresh_stale(&state, &root, &index_dir, false) {
+            // It declined — an unreadable directory, or a walk that raced a
+            // delete. The index is untouched and correct as far as it goes,
+            // and the next interval tries again.
+            eprintln!("[trace] periodic reconcile: declined, keeping the current index");
+        }
+    }
+}
+
 fn auto_save_loop(state: Arc<ServerState>) {
     let mut last_save = Instant::now();
 
@@ -2012,20 +2155,34 @@ fn stream_merge_stale_changes(
         // means "indexed at this version", so keeping one for a skipped file
         // would hide it from every later reconcile and make the miss permanent.
         // Dropping the stamp leaves it looking new, so the next pass retries it.
-        if !outcome.unreadable.is_empty() {
-            eprintln!(
-                "[trace] {} file(s) were unreadable during the delta build; \
-                 their stamps are withheld so the next reconcile retries them",
-                outcome.unreadable.len()
-            );
+        //
+        // Record what the file looked like when it failed, so a permanent
+        // failure is retried when the file changes rather than on every pass.
+        // See `ServerState::unreadable`.
+        {
+            let mut memo = state.unreadable.write().unwrap();
+            // Anything this delta was asked to build is settled: either it was
+            // read, or it is in `outcome.unreadable` and re-recorded below.
+            for path in changed.iter().chain(added).chain(deleted) {
+                memo.remove(path);
+            }
             for path in &outcome.unreadable {
                 let rel = path
                     .strip_prefix(root)
                     .unwrap_or(path)
                     .to_string_lossy()
                     .replace('\\', "/");
-                published_stamps.remove(&rel);
+                if let Some(stamp) = published_stamps.remove(&rel) {
+                    memo.insert(rel, stamp);
+                }
             }
+        }
+        if !outcome.unreadable.is_empty() {
+            eprintln!(
+                "[trace] {} file(s) were unreadable during the delta build; \
+                 their stamps are withheld so a later reconcile retries them",
+                outcome.unreadable.len()
+            );
         }
 
         let delta = tgrep_core::reader::IndexReader::open(&delta_dir)?;
@@ -2184,12 +2341,44 @@ fn background_refresh_stale(
         return true;
     }
 
-    let (changed, added, deleted) = classify_file_changes(
+    let (mut changed, mut added, deleted) = classify_file_changes(
         current_meta,
         &old_stamps,
         &indexed_paths,
         compare_index_membership,
     );
+
+    // Files that failed to read last time and have not changed since are not
+    // worth another attempt; without this a single permanently locked file
+    // makes every scheduled reconcile rebuild the index. `deleted` is exempt —
+    // a file that is gone needs no read to evict.
+    let skipped_unreadable = {
+        let memo = state.unreadable.read().unwrap();
+        if memo.is_empty() {
+            0
+        } else {
+            // One pass over the walk to pick out the memoized paths, rather
+            // than a scan per candidate.
+            let still_failing: std::collections::HashSet<&str> = current_meta
+                .iter()
+                .filter(|fm| {
+                    memo.get(&fm.relative_path)
+                        .is_some_and(|a| a.mtime == fm.mtime && a.size == fm.size)
+                })
+                .map(|fm| fm.relative_path.as_str())
+                .collect();
+            let before = changed.len() + added.len();
+            changed.retain(|path| !still_failing.contains(path.as_str()));
+            added.retain(|path| !still_failing.contains(path.as_str()));
+            before - (changed.len() + added.len())
+        }
+    };
+    if skipped_unreadable > 0 {
+        eprintln!(
+            "[trace] stale check: {skipped_unreadable} file(s) unchanged since they \
+             last failed to read; not retrying them"
+        );
+    }
 
     let total_changes = changed.len() + added.len() + deleted.len();
     let live_pending = state.index.read().unwrap().live.has_pending_changes();
@@ -3235,6 +3424,9 @@ mod tests {
             memory_cap_bytes: 16 * 1024 * 1024 * 1024,
             index_threads: 1,
             auto_save_mutations: 0,
+            unreadable: RwLock::new(std::collections::HashMap::new()),
+            started: Instant::now(),
+            last_search_ms: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -3516,6 +3708,83 @@ mod tests {
         assert_eq!(added, vec!["case.txt"]);
         deleted.sort();
         assert_eq!(deleted, vec!["Case.txt", "reader-only.txt"]);
+    }
+
+    /// The reconcile waits for the server to go quiet, but not forever.
+    #[test]
+    fn a_scheduled_reconcile_defers_to_a_busy_server_but_not_indefinitely() {
+        let long_quiet = RECONCILE_QUIET_PERIOD + Duration::from_secs(1);
+        let just_queried = Duration::from_secs(1);
+
+        // Before the interval, nothing runs however idle the server is.
+        assert!(!reconcile_due(
+            RECONCILE_INTERVAL - Duration::from_secs(1),
+            long_quiet,
+            false
+        ));
+        // After it, an idle server reconciles.
+        assert!(reconcile_due(RECONCILE_INTERVAL, long_quiet, false));
+        // A server mid-query waits for a gap...
+        assert!(!reconcile_due(RECONCILE_INTERVAL, just_queried, false));
+        // ...but a server that is *always* mid-query would otherwise never
+        // reconcile at all, which is the failure this exists to prevent.
+        assert!(reconcile_due(RECONCILE_DEADLINE, just_queried, false));
+        // Indexing and flushing outrank even the deadline: they are rewriting
+        // the index already, and the next tick is a minute away.
+        assert!(!reconcile_due(RECONCILE_DEADLINE, long_quiet, true));
+    }
+
+    /// A file that cannot be read must not make every reconcile rebuild.
+    ///
+    /// Its stamp is deliberately withheld so it looks new and gets retried.
+    /// Left at that, a file locked by another process would be "new" on every
+    /// pass, and a reconcile on a timer would rewrite the whole index once an
+    /// hour, forever, to re-attempt a read that fails the same way each time.
+    #[test]
+    fn a_file_that_stays_unreadable_is_not_retried_until_it_changes() {
+        use tgrep_core::meta::FileStamp;
+        use tgrep_core::walker::FileMeta;
+
+        let memo = std::collections::HashMap::from([(
+            "locked.bin".to_string(),
+            FileStamp {
+                mtime: 100,
+                size: 5,
+            },
+        )]);
+
+        let retried = |mtime: u64, size: u64| {
+            let current = vec![FileMeta {
+                relative_path: "locked.bin".to_string(),
+                mtime,
+                size,
+            }];
+            let (mut changed, mut added, _) = classify_file_changes(
+                &current,
+                &std::collections::HashMap::new(),
+                &std::collections::HashSet::new(),
+                false,
+            );
+            // Mirrors the filter `background_refresh_stale` applies.
+            let still_failing: std::collections::HashSet<&str> = current
+                .iter()
+                .filter(|fm| {
+                    memo.get(&fm.relative_path)
+                        .is_some_and(|a| a.mtime == fm.mtime && a.size == fm.size)
+                })
+                .map(|fm| fm.relative_path.as_str())
+                .collect();
+            changed.retain(|path| !still_failing.contains(path.as_str()));
+            added.retain(|path| !still_failing.contains(path.as_str()));
+            changed.len() + added.len()
+        };
+
+        // Unchanged since the failed read: leave it alone.
+        assert_eq!(retried(100, 5), 0);
+        // Touched: worth another look.
+        assert_eq!(retried(200, 5), 1);
+        // Resized: likewise.
+        assert_eq!(retried(100, 6), 1);
     }
 
     /// A walk error must not leave the watcher gated forever.

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -83,7 +83,6 @@ const RECONCILE_QUIET_PERIOD: Duration = Duration::from_secs(120);
 /// never reconcile at all — which is the failure this exists to prevent.
 const RECONCILE_DEADLINE: Duration = Duration::from_secs(4 * 3600);
 
-
 /// Server discovery info, written to `serve.json`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServerInfo {
@@ -3861,12 +3860,8 @@ mod tests {
 
         // And with that stamp withheld, a later pass over an unchanged tree
         // still offers the file up rather than treating it as up-to-date.
-        let (changed, added, _) = classify_file_changes(
-            &current,
-            &stamps,
-            &std::collections::HashSet::new(),
-            false,
-        );
+        let (changed, added, _) =
+            classify_file_changes(&current, &stamps, &std::collections::HashSet::new(), false);
         assert_eq!(changed.len() + added.len(), 1);
         assert!(added.contains(&"locked.bin".to_string()));
     }

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2139,6 +2139,10 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
     let start = Instant::now();
     eprintln!("[trace] bootstrapping index with the external merge sort (memory-bounded)...");
 
+    // Dropped once the build is done so the sampled peak (on platforms without
+    // a kernel high-water mark) covers the whole of it. Unlike the incremental
+    // path below, nothing here polls memory on its own.
+    let sampler = crate::mem::PrivatePeakSampler::start();
     let outcome = match builder::build_index_with_options(
         root,
         Some(index_dir),
@@ -2231,11 +2235,11 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
     drop(gate);
 
     let elapsed = start.elapsed().as_secs_f64();
-    match crate::mem::peak_rss_bytes() {
+    drop(sampler);
+    match crate::mem::format_peak_memory() {
         Some(peak) => eprintln!(
             "[trace] bootstrap complete: {indexed} files indexed in {elapsed:.1}s \
-             (peak memory {})",
-            crate::mem::format_bytes(peak)
+             (peak memory {peak})"
         ),
         None => eprintln!("[trace] bootstrap complete: {indexed} files indexed in {elapsed:.1}s"),
     }
@@ -2430,19 +2434,24 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             );
         }
 
-        // Memory-bounded build: if the in-heap overlay has pushed RSS past the
-        // budget, persist what we've indexed so far to disk and reclaim the
+        // Memory-bounded build: if the in-heap overlay has pushed memory past
+        // the budget, persist what we've indexed so far to disk and reclaim the
         // heap before continuing. This keeps peak memory bounded (the flush
         // copies existing on-disk postings verbatim from mmap rather than into
         // heap) while still converging to a *complete* index — unlike simply
         // stopping, which would leave a partial index.
-        if let Some(rss) = crate::mem::process_rss_bytes()
-            && rss > state.memory_cap_bytes
+        //
+        // Charged against private bytes, not the working set: the overlay is
+        // heap, and that is what a flush can give back. Mapped index pages sit
+        // in the working set too but are file-backed, so counting them would
+        // fire the cap on memory no flush can reclaim.
+        if let Some(used) = crate::mem::budgeted_memory_bytes()
+            && used > state.memory_cap_bytes
         {
             eprintln!(
-                "[trace] memory cap reached ({} MB RSS > {} MB cap) — flushing \
+                "[trace] memory cap reached ({} MB in use > {} MB cap) — flushing \
                  overlay to disk to reclaim memory and continuing",
-                rss / (1024 * 1024),
+                used / (1024 * 1024),
                 state.memory_cap_bytes / (1024 * 1024),
             );
             if flush_append_only_overlay(state, index_dir, false, None) {

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2255,13 +2255,70 @@ fn stream_merge_stale_changes(
     }
 }
 
+/// Drop the candidates that failed to read last time and have not changed since.
+///
+/// Returns the paths removed, which the caller must also keep out of the
+/// published stamps — see [`stamps_for_indexed`].
+fn drop_memoized_failures(
+    memo: &std::collections::HashMap<String, tgrep_core::meta::FileStamp>,
+    current_meta: &[tgrep_core::walker::FileMeta],
+    changed: &mut Vec<String>,
+    added: &mut Vec<String>,
+) -> std::collections::HashSet<String> {
+    if memo.is_empty() {
+        return std::collections::HashSet::new();
+    }
+    // One pass over the walk to pick out the memoized paths, rather than a scan
+    // per candidate.
+    let still_failing: std::collections::HashSet<String> = current_meta
+        .iter()
+        .filter(|fm| {
+            memo.get(&fm.relative_path)
+                .is_some_and(|a| a.mtime == fm.mtime && a.size == fm.size)
+        })
+        .map(|fm| fm.relative_path.clone())
+        .collect();
+    changed.retain(|path| !still_failing.contains(path));
+    added.retain(|path| !still_failing.contains(path));
+    still_failing
+}
+
+/// The stamps to publish for a walk, minus the files that were never built.
+///
+/// A published stamp means "indexed at this version". Stamping a file the delta
+/// deliberately skipped would make every later reconcile see it as unchanged,
+/// so it would never be indexed again — and because the stamp lands in
+/// `filestamps.json`, not even a restart would recover it: every automatic
+/// caller of the stale check passes `compare_index_membership = false`, which
+/// is precisely the check that would have noticed the file is missing. Leaving
+/// it unstamped keeps it looking new, which is what makes the retry-on-change
+/// behaviour in [`drop_memoized_failures`] work at all.
+fn stamps_for_indexed(
+    current_meta: &[tgrep_core::walker::FileMeta],
+    skipped: &std::collections::HashSet<String>,
+) -> std::collections::HashMap<String, tgrep_core::meta::FileStamp> {
+    current_meta
+        .iter()
+        .filter(|fm| !skipped.contains(&fm.relative_path))
+        .map(|fm| {
+            (
+                fm.relative_path.clone(),
+                tgrep_core::meta::FileStamp {
+                    mtime: fm.mtime,
+                    size: fm.size,
+                },
+            )
+        })
+        .collect()
+}
+
 fn background_refresh_stale(
     state: &Arc<ServerState>,
     root: &Path,
     index_dir: &Path,
     compare_index_membership: bool,
 ) -> bool {
-    use tgrep_core::meta::{self, FileStamp};
+    use tgrep_core::meta;
     use tgrep_core::walker;
 
     let _refresh = state.stale_refresh_lock.lock().unwrap();
@@ -2354,29 +2411,13 @@ fn background_refresh_stale(
     // a file that is gone needs no read to evict.
     let skipped_unreadable = {
         let memo = state.unreadable.read().unwrap();
-        if memo.is_empty() {
-            0
-        } else {
-            // One pass over the walk to pick out the memoized paths, rather
-            // than a scan per candidate.
-            let still_failing: std::collections::HashSet<&str> = current_meta
-                .iter()
-                .filter(|fm| {
-                    memo.get(&fm.relative_path)
-                        .is_some_and(|a| a.mtime == fm.mtime && a.size == fm.size)
-                })
-                .map(|fm| fm.relative_path.as_str())
-                .collect();
-            let before = changed.len() + added.len();
-            changed.retain(|path| !still_failing.contains(path.as_str()));
-            added.retain(|path| !still_failing.contains(path.as_str()));
-            before - (changed.len() + added.len())
-        }
+        drop_memoized_failures(&memo, current_meta, &mut changed, &mut added)
     };
-    if skipped_unreadable > 0 {
+    if !skipped_unreadable.is_empty() {
         eprintln!(
-            "[trace] stale check: {skipped_unreadable} file(s) unchanged since they \
-             last failed to read; not retrying them"
+            "[trace] stale check: {} file(s) unchanged since they last failed to \
+             read; not retrying them",
+            skipped_unreadable.len()
         );
     }
 
@@ -2406,18 +2447,7 @@ fn background_refresh_stale(
         );
     }
 
-    let new_stamps: std::collections::HashMap<String, FileStamp> = current_meta
-        .iter()
-        .map(|fm| {
-            (
-                fm.relative_path.clone(),
-                FileStamp {
-                    mtime: fm.mtime,
-                    size: fm.size,
-                },
-            )
-        })
-        .collect();
+    let new_stamps = stamps_for_indexed(current_meta, &skipped_unreadable);
 
     if !stream_merge_stale_changes(
         state,
@@ -3765,26 +3795,80 @@ mod tests {
                 &std::collections::HashSet::new(),
                 false,
             );
-            // Mirrors the filter `background_refresh_stale` applies.
-            let still_failing: std::collections::HashSet<&str> = current
-                .iter()
-                .filter(|fm| {
-                    memo.get(&fm.relative_path)
-                        .is_some_and(|a| a.mtime == fm.mtime && a.size == fm.size)
-                })
-                .map(|fm| fm.relative_path.as_str())
-                .collect();
-            changed.retain(|path| !still_failing.contains(path.as_str()));
-            added.retain(|path| !still_failing.contains(path.as_str()));
-            changed.len() + added.len()
+            let skipped = drop_memoized_failures(&memo, &current, &mut changed, &mut added);
+            (changed.len() + added.len(), skipped)
         };
 
         // Unchanged since the failed read: leave it alone.
-        assert_eq!(retried(100, 5), 0);
+        assert_eq!(retried(100, 5).0, 0);
         // Touched: worth another look.
-        assert_eq!(retried(200, 5), 1);
+        assert_eq!(retried(200, 5).0, 1);
         // Resized: likewise.
-        assert_eq!(retried(100, 6), 1);
+        assert_eq!(retried(100, 6).0, 1);
+    }
+
+    /// Skipping a file must not also mark it indexed.
+    ///
+    /// The two halves have to agree. `drop_memoized_failures` keeps a file out
+    /// of the delta, so nothing reads it and nothing writes postings for it; if
+    /// the stamps published alongside that delta still claimed it was indexed at
+    /// its current mtime and size, the next reconcile would classify it as
+    /// unchanged and skip it for a completely different reason — one that never
+    /// clears, because the memo is not involved and the stamp outlives the
+    /// process in `filestamps.json`. A file that failed to read once would be
+    /// invisible to search forever, with no error and no way back short of
+    /// deleting the index.
+    #[test]
+    fn a_skipped_file_is_left_unstamped_so_the_next_pass_still_sees_it() {
+        use tgrep_core::meta::FileStamp;
+        use tgrep_core::walker::FileMeta;
+
+        let current = vec![
+            FileMeta {
+                relative_path: "locked.bin".to_string(),
+                mtime: 100,
+                size: 5,
+            },
+            FileMeta {
+                relative_path: "src/main.rs".to_string(),
+                mtime: 100,
+                size: 9,
+            },
+        ];
+        let memo = std::collections::HashMap::from([(
+            "locked.bin".to_string(),
+            FileStamp {
+                mtime: 100,
+                size: 5,
+            },
+        )]);
+
+        let (mut changed, mut added, _) = classify_file_changes(
+            &current,
+            &std::collections::HashMap::new(),
+            &std::collections::HashSet::new(),
+            false,
+        );
+        let skipped = drop_memoized_failures(&memo, &current, &mut changed, &mut added);
+        assert!(skipped.contains("locked.bin"));
+
+        let stamps = stamps_for_indexed(&current, &skipped);
+        assert!(
+            !stamps.contains_key("locked.bin"),
+            "published a stamp for a file that was never read: {stamps:?}"
+        );
+        assert!(stamps.contains_key("src/main.rs"), "{stamps:?}");
+
+        // And with that stamp withheld, a later pass over an unchanged tree
+        // still offers the file up rather than treating it as up-to-date.
+        let (changed, added, _) = classify_file_changes(
+            &current,
+            &stamps,
+            &std::collections::HashSet::new(),
+            false,
+        );
+        assert_eq!(changed.len() + added.len(), 1);
+        assert!(added.contains(&"locked.bin".to_string()));
     }
 
     /// A walk error must not leave the watcher gated forever.

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -453,8 +453,8 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
             // the index while the matcher is missing. That gate is armed when
             // `ServerState` is built — before this thread is spawned and
             // before `start_file_watcher` runs below — so it holds whichever
-            // of the two wins the race, and the stale check releases it
-            // before any of its early returns.
+            // of the two wins the race, and the stale check releases it as
+            // soon as its walk finishes, ahead of every one of its returns.
             //
             // The same stale check is also what recovers events dropped
             // during the gap: it compares the whole tree against the index,
@@ -1962,9 +1962,8 @@ fn background_refresh_stale(
     eprintln!("[trace] stale check: comparing index against filesystem...");
 
     // Walk first. This single traversal feeds both the stale diff and the
-    // watcher's ignore matcher, and it must run before the early returns
-    // below so the matcher is published — and `gitignore_pending` released —
-    // even when the index turns out to be up to date or has no stamps yet.
+    // watcher's ignore matcher, and it must run before the early returns below
+    // so the matcher can be published on every path out of this function.
     let walk = walker::walk_file_metadata(
         root,
         &walker::MetaWalkOptions {
@@ -1975,6 +1974,22 @@ fn background_refresh_stale(
         },
     );
     let walk_ms = start.elapsed().as_millis();
+
+    // Publish the matcher immediately, before any early return can skip it.
+    // Every exit below is a decision about the *index*; none of them is a
+    // reason to leave the watcher gated. `gitignore_pending` is what keeps the
+    // watcher off the index until a matcher exists, so leaking it past a return
+    // disables the watcher permanently — and the overflow-repair path skips
+    // reconciling while that flag is set, so nothing recovers it either. A
+    // single unreadable directory, or one file whose `metadata()` lost a race
+    // with a delete, would be enough.
+    //
+    // Committing here rather than at each exit is invisible to the watcher:
+    // this function holds `snapshot_gate` for write across its whole body, and
+    // the only reader of `state.gitignore` takes the read side first, so no
+    // event can observe the matcher before this function returns either way.
+    commit_stale_matcher(state, build_stale_matcher(state, root, &walk));
+
     if walk.skipped_error > 0 {
         eprintln!(
             "[trace] warning: stale check could not inspect {} filesystem entries \
@@ -1983,7 +1998,6 @@ fn background_refresh_stale(
         );
         return false;
     }
-    let matcher = build_stale_matcher(state, root, &walk);
     let current_meta = &walk.files;
 
     // Load stored per-file stamps from last index write
@@ -2014,7 +2028,6 @@ fn background_refresh_stale(
     };
     if old_stamps.is_empty() && indexed_paths.is_empty() && current_meta.is_empty() {
         eprintln!("[trace] stale check: no indexed files or filesystem files, skipping");
-        commit_stale_matcher(state, matcher);
         return true;
     }
 
@@ -2033,7 +2046,6 @@ fn background_refresh_stale(
             current_meta.len(),
             walk_ms
         );
-        commit_stale_matcher(state, matcher);
         return true;
     }
 
@@ -2077,7 +2089,6 @@ fn background_refresh_stale(
         return false;
     }
 
-    commit_stale_matcher(state, matcher);
     if let Ok(mut cache) = state.cache.write() {
         for path in changed.iter().chain(added.iter()).chain(deleted.iter()) {
             cache.pop(path);
@@ -2951,6 +2962,42 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// A `ServerState` over an empty index, for exercising the stale path
+    /// directly. Mirrors the defaults `run` uses with a watcher and ignore
+    /// rules enabled, which is the configuration `gitignore_pending` gates.
+    #[cfg(unix)]
+    fn test_server_state(root: &Path, index_dir: &Path) -> Arc<ServerState> {
+        create_empty_index(index_dir).expect("create empty index");
+        let hybrid = HybridIndex::open(index_dir, root).expect("open empty index");
+        Arc::new(ServerState {
+            index: RwLock::new(hybrid),
+            cache: RwLock::new(LruCache::new(NonZeroUsize::new(CACHE_CAPACITY).unwrap())),
+            root: root.to_path_buf(),
+            watcher_active: std::sync::atomic::AtomicBool::new(false),
+            indexing: std::sync::atomic::AtomicBool::new(false),
+            flushing: std::sync::atomic::AtomicBool::new(false),
+            gitignore_pending: std::sync::atomic::AtomicBool::new(true),
+            ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
+            ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+            index_progress: std::sync::atomic::AtomicU64::new(0),
+            index_total: std::sync::atomic::AtomicU64::new(0),
+            watch_enabled: true,
+            exclude_dirs: Vec::new(),
+            no_ignore: false,
+            no_require_git: false,
+            max_file_size: None,
+            index_dir: index_dir.to_path_buf(),
+            publish_lock: Mutex::new(()),
+            file_stamps: RwLock::new(Default::default()),
+            snapshot_gate: RwLock::new(()),
+            stale_refresh_lock: Mutex::new(()),
+            gitignore: RwLock::new(None),
+            memory_cap_bytes: 16 * 1024 * 1024 * 1024,
+            index_threads: 1,
+            auto_save_mutations: 0,
+        })
+    }
+
     /// A binary marker's offset is a position in the file, not in the repaired
     /// text.
     ///
@@ -3229,6 +3276,66 @@ mod tests {
         assert_eq!(added, vec!["case.txt"]);
         deleted.sort();
         assert_eq!(deleted, vec!["Case.txt", "reader-only.txt"]);
+    }
+
+    /// A walk error must not leave the watcher gated forever.
+    ///
+    /// `gitignore_pending` is what keeps the watcher off the index until a
+    /// matcher exists, and the stale check owns clearing it. It also refuses to
+    /// touch the index when the walk could not inspect every entry, because
+    /// unseen files would be misclassified as deleted. Those two are separate
+    /// decisions: taking the second one used to skip the first, so one
+    /// unreadable directory — or one file whose `metadata()` lost a race with a
+    /// delete — silently disabled the watcher for the life of the process, and
+    /// the overflow-repair path would not reconcile either, since it defers to
+    /// the pending matcher.
+    ///
+    /// Unix-only because it needs a directory the process genuinely cannot
+    /// read, which has no portable equivalent on Windows.
+    #[cfg(unix)]
+    #[test]
+    fn a_walk_error_still_publishes_the_watcher_matcher() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        // `.gitignore` is git-gated, matching the indexing walk.
+        std::fs::create_dir(root.join(".git")).unwrap();
+        std::fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        std::fs::write(root.join("src.rs"), "fn main() {}\n").unwrap();
+
+        let unreadable = root.join("locked");
+        std::fs::create_dir(&unreadable).unwrap();
+        std::fs::write(unreadable.join("inner.rs"), "fn inner() {}\n").unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read_dir(&unreadable).is_ok() {
+            // Running as root, so permissions prove nothing. Restore and skip.
+            std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o755)).unwrap();
+            return;
+        }
+
+        let index_dir = root.join(".tgrep");
+        std::fs::create_dir(&index_dir).unwrap();
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(true, Ordering::SeqCst);
+
+        let ok = background_refresh_stale(&state, &root, &index_dir, false);
+
+        // Restore before any assertion so a failure still leaves a removable dir.
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            !ok,
+            "a walk that could not inspect every entry must keep the old index"
+        );
+        assert!(
+            !state.gitignore_pending.load(Ordering::SeqCst),
+            "the watcher gate must be released even when the index is left alone"
+        );
+        assert!(
+            state.gitignore.read().unwrap().is_some(),
+            "the matcher the walk did find must still be published"
+        );
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -986,6 +986,16 @@ fn handle_search(
     let pattern = req.pattern;
     let case_insensitive = req.case_insensitive;
 
+    // The index build already dropped everything above the server's own cap, so
+    // re-checking a query cap that is no stricter can never reject a candidate
+    // the index did not already reject — it would only buy a `metadata` call
+    // per candidate on every query. Now that a cap is the default rather than
+    // opt-in, that is the common case, so recognise it and skip the stat.
+    let query_size_limit = match (opts.max_filesize, state.max_file_size) {
+        (Some(query), Some(built)) if built <= query => None,
+        (query, _) => query,
+    };
+
     // Collect candidates and their paths/full_paths while holding the index lock briefly
     let t_index = Instant::now();
     let (candidate_info, raw_candidate_count): (Vec<(String, PathBuf)>, usize) = {
@@ -1027,7 +1037,7 @@ fn handle_search(
                     return None;
                 }
                 let full_path = index.resolve_full_path(fid, &reader_snapshot)?;
-                if let Some(limit) = opts.max_filesize
+                if let Some(limit) = query_size_limit
                     && std::fs::metadata(&full_path).is_ok_and(|md| md.len() > limit)
                 {
                     return None;

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -25,6 +25,14 @@ use tgrep_core::hybrid::HybridIndex;
 use tgrep_core::query;
 
 const CACHE_CAPACITY: usize = 50_000;
+/// Total decoded bytes the content cache may hold. The entry-count limit above
+/// says nothing about memory; without this a handful of large files can pin
+/// tens of gigabytes for the life of the process.
+const CACHE_MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GiB
+/// Largest single entry the cache will admit. A file bigger than this would
+/// evict most of the cache to store itself, so it is read straight through
+/// instead. It is still searched - only the caching is skipped.
+const CACHE_MAX_ENTRY_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 /// Default mutation count that triggers a background save (override with
 /// `--auto-save-mutations`).
 const AUTO_SAVE_MUTATIONS: u32 = 5000;
@@ -125,11 +133,108 @@ impl DecodedFile {
         let (text, fixups) = tgrep_core::encoding::decode_owned_with_fixups(bytes, encoding);
         Self { text, fixups }
     }
+
+    /// Heap cost of this entry, used to bound the cache by memory rather than
+    /// by entry count.
+    fn heap_bytes(&self) -> u64 {
+        self.text.capacity() as u64 + self.fixups.heap_bytes()
+    }
+}
+
+/// An LRU of decoded file contents bounded by *bytes* as well as by entry count.
+///
+/// Bounding only by entry count makes memory unbounded in practice: 50,000
+/// entries of arbitrary size. Serving a repository that contains one 13.7 GiB
+/// build artifact took the server to 14.4 GiB of private memory after a single
+/// query, and it stayed there for the life of the process, because nothing ever
+/// evicted that one entry.
+///
+/// Two limits are applied:
+///   * `max_bytes` - total cached bytes; the least-recently-used entries are
+///     evicted until the total fits.
+///   * `max_entry_bytes` - entries larger than this are never admitted. A file
+///     that alone exceeds the whole budget would evict every useful entry to
+///     cache itself, and would then be evicted by the next insert anyway.
+struct ContentCache {
+    lru: LruCache<String, Arc<DecodedFile>>,
+    bytes: u64,
+    max_bytes: u64,
+    max_entry_bytes: u64,
+}
+
+impl ContentCache {
+    fn new(capacity: usize, max_bytes: u64, max_entry_bytes: u64) -> Self {
+        Self {
+            lru: LruCache::new(NonZeroUsize::new(capacity).unwrap()),
+            bytes: 0,
+            max_bytes,
+            max_entry_bytes,
+        }
+    }
+
+    fn peek(&self, key: &str) -> Option<&Arc<DecodedFile>> {
+        self.lru.peek(key)
+    }
+
+    /// Promote an entry to most-recently-used.
+    fn touch(&mut self, key: &str) {
+        self.lru.get(key);
+    }
+
+    fn put(&mut self, key: String, value: Arc<DecodedFile>) {
+        let size = value.heap_bytes();
+        if size > self.max_entry_bytes {
+            return;
+        }
+        // `push`, not `put`: `put` returns the old value only when the *key*
+        // already existed, and stays silent when the entry-count limit evicts
+        // some other entry to make room. That eviction still frees bytes, so
+        // using `put` would leak the running total upward until the byte budget
+        // looked full and the cache evicted everything.
+        if let Some((_, old)) = self.lru.push(key, value) {
+            self.bytes = self.bytes.saturating_sub(old.heap_bytes());
+        }
+        self.bytes = self.bytes.saturating_add(size);
+        self.evict_to_fit();
+    }
+
+    fn evict_to_fit(&mut self) {
+        while self.bytes > self.max_bytes {
+            match self.lru.pop_lru() {
+                Some((_, evicted)) => {
+                    self.bytes = self.bytes.saturating_sub(evicted.heap_bytes());
+                }
+                None => {
+                    self.bytes = 0;
+                    break;
+                }
+            }
+        }
+    }
+
+    fn pop(&mut self, key: &str) {
+        if let Some(old) = self.lru.pop(key) {
+            self.bytes = self.bytes.saturating_sub(old.heap_bytes());
+        }
+    }
+
+    fn clear(&mut self) {
+        self.lru.clear();
+        self.bytes = 0;
+    }
+
+    fn len(&self) -> usize {
+        self.lru.len()
+    }
+
+    fn byte_len(&self) -> u64 {
+        self.bytes
+    }
 }
 
 struct ServerState {
     index: RwLock<HybridIndex>,
-    cache: RwLock<LruCache<String, Arc<DecodedFile>>>,
+    cache: RwLock<ContentCache>,
     root: PathBuf,
     watcher_active: std::sync::atomic::AtomicBool,
     /// True while the initial index build is in progress.
@@ -380,7 +485,11 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
 
     let state = Arc::new(ServerState {
         index: RwLock::new(hybrid),
-        cache: RwLock::new(LruCache::new(NonZeroUsize::new(CACHE_CAPACITY).unwrap())),
+        cache: RwLock::new(ContentCache::new(
+            CACHE_CAPACITY,
+            CACHE_MAX_BYTES,
+            CACHE_MAX_ENTRY_BYTES,
+        )),
         root: root.clone(),
         watcher_active: std::sync::atomic::AtomicBool::new(false),
         indexing: std::sync::atomic::AtomicBool::new(needs_build),
@@ -420,11 +529,14 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     info.save(&index_dir)?;
 
     eprintln!(
-        "[trace] serve ready in {:.1}ms. TCP on port {}. Cache: max {} entries. \
+        "[trace] serve ready in {:.1}ms. TCP on port {}. Cache: max {} entries / {} MiB \
+         (entries over {} MiB not cached). \
          Memory cap: {} MB. Index threads: {}. Watcher queue cap: {}.",
         serve_start.elapsed().as_secs_f64() * 1000.0,
         port,
         CACHE_CAPACITY,
+        CACHE_MAX_BYTES / (1024 * 1024),
+        CACHE_MAX_ENTRY_BYTES / (1024 * 1024),
         memory_cap_bytes / (1024 * 1024),
         index_threads,
         watcher_queue_cap,
@@ -811,10 +923,17 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
     // `--encoding` is unsound for the same reason: the index holds trigrams of
     // the BOM-sniffed text, so a re-decoded file can match bytes that were
     // never indexed.
-    let plan = if !matcher.is_standard() || invert_match || encoding.may_differ_from_index() {
+    //
+    // A PCRE-style pattern cannot be parsed by `regex-syntax` at all, but it can
+    // usually be *relaxed* into one that can (dropping lookarounds and the like).
+    // The relaxed pattern matches a superset, so its trigrams are still mandatory
+    // for the original and the candidate set stays sound.
+    let plan = if invert_match || encoding.may_differ_from_index() {
         query::QueryPlan::MatchAll
-    } else {
+    } else if matcher.is_standard() || fixed_string {
         query::build_multi_pattern_plan(&all_patterns, fixed_string, case_insensitive)?
+    } else {
+        query::build_relaxed_multi_pattern_plan(&all_patterns, case_insensitive)
     };
 
     Ok(SearchRequest {
@@ -987,7 +1106,7 @@ fn handle_search(
             let mut cache = state.cache.write().unwrap();
             // Promote hit entries so LRU recency stays accurate
             for key in &hit_keys {
-                cache.get(key);
+                cache.touch(key);
             }
             // Insert disk results, re-checking for races with other threads
             for (rel_path, content) in &disk_results {
@@ -1222,6 +1341,8 @@ fn handle_status(id: Option<serde_json::Value>, state: &ServerState) -> String {
         "num_trigrams": index.num_trigrams(),
         "cache_size": cache.len(),
         "cache_capacity": CACHE_CAPACITY,
+        "cache_bytes": cache.byte_len(),
+        "cache_max_bytes": CACHE_MAX_BYTES,
         "watcher_active": state.watcher_active.load(std::sync::atomic::Ordering::Relaxed),
         "indexing": indexing,
         "index_progress": state.index_progress.load(std::sync::atomic::Ordering::Relaxed),
@@ -1856,7 +1977,7 @@ fn stream_merge_stale_changes(
     // genuinely new path is harmless because it has no reader entry to filter.
     let removed: std::collections::HashSet<String> = candidates.iter().cloned().collect();
 
-    let published_stamps = stamps.clone();
+    let mut published_stamps = stamps.clone();
 
     let result = (|| -> Result<bool> {
         let build = || {
@@ -1867,7 +1988,7 @@ fn stream_merge_stale_changes(
                 builder::DEFAULT_INDEX_BUFFER_BYTES,
             )
         };
-        let delta_count = match rayon::ThreadPoolBuilder::new()
+        let outcome = match rayon::ThreadPoolBuilder::new()
             .num_threads(state.index_threads)
             .thread_name(|i| format!("tgrep-stale-index-{i}"))
             .build()
@@ -1875,6 +1996,28 @@ fn stream_merge_stale_changes(
             Ok(pool) => pool.install(build)?,
             Err(_) => build()?,
         };
+        let delta_count = outcome.indexed;
+
+        // Withhold stamps for files the delta could not read. A published stamp
+        // means "indexed at this version", so keeping one for a skipped file
+        // would hide it from every later reconcile and make the miss permanent.
+        // Dropping the stamp leaves it looking new, so the next pass retries it.
+        if !outcome.unreadable.is_empty() {
+            eprintln!(
+                "[trace] {} file(s) were unreadable during the delta build; \
+                 their stamps are withheld so the next reconcile retries them",
+                outcome.unreadable.len()
+            );
+            for path in &outcome.unreadable {
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                published_stamps.remove(&rel);
+            }
+        }
+
         let delta = tgrep_core::reader::IndexReader::open(&delta_dir)?;
         if delta.num_files() != delta_count {
             anyhow::bail!(
@@ -2971,6 +3114,80 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn cached(len: usize) -> Arc<DecodedFile> {
+        // `String::from_utf8` preserves the Vec's capacity, so `heap_bytes`
+        // is exactly `len` and the assertions below can use round numbers.
+        let mut bytes = Vec::with_capacity(len);
+        bytes.resize(len, b'a');
+        Arc::new(DecodedFile {
+            text: String::from_utf8(bytes).unwrap(),
+            fixups: Default::default(),
+        })
+    }
+
+    #[test]
+    fn content_cache_evicts_to_stay_under_byte_budget() {
+        let mut cache = ContentCache::new(CACHE_CAPACITY, 1000, 1000);
+        for i in 0..10 {
+            cache.put(format!("f{i}"), cached(200));
+        }
+        assert!(cache.byte_len() <= 1000, "bytes = {}", cache.byte_len());
+        assert_eq!(cache.len(), 5);
+        // Oldest entries went first; the newest survive.
+        assert!(cache.peek("f0").is_none());
+        assert!(cache.peek("f9").is_some());
+    }
+
+    #[test]
+    fn content_cache_refuses_oversized_entries() {
+        let mut cache = ContentCache::new(CACHE_CAPACITY, 1000, 100);
+        cache.put("small".into(), cached(50));
+        cache.put("huge".into(), cached(500));
+        assert!(cache.peek("huge").is_none(), "oversized entry was admitted");
+        // Admitting it would also have evicted the useful entry.
+        assert!(cache.peek("small").is_some());
+        assert_eq!(cache.byte_len(), 50);
+    }
+
+    /// The byte total must stay exact across every path that removes an entry,
+    /// including the entry-count eviction that `LruCache` performs internally.
+    #[test]
+    fn content_cache_byte_accounting_stays_exact() {
+        let mut cache = ContentCache::new(2, u64::MAX, u64::MAX);
+        cache.put("a".into(), cached(100));
+        cache.put("b".into(), cached(100));
+        assert_eq!(cache.byte_len(), 200);
+
+        // Capacity is 2, so this evicts "a" inside the LRU.
+        cache.put("c".into(), cached(100));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.byte_len(), 200, "count-eviction leaked bytes");
+
+        // Replacing an existing key must not double-count.
+        cache.put("c".into(), cached(300));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.byte_len(), 400);
+
+        cache.pop("c");
+        assert_eq!(cache.byte_len(), 100);
+        cache.clear();
+        assert_eq!(cache.byte_len(), 0);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn content_cache_touch_promotes_recency() {
+        let mut cache = ContentCache::new(CACHE_CAPACITY, 300, 300);
+        cache.put("a".into(), cached(100));
+        cache.put("b".into(), cached(100));
+        cache.touch("a");
+        // "b" is now least-recently-used, so it is the one that goes.
+        cache.put("c".into(), cached(100));
+        cache.put("d".into(), cached(100));
+        assert!(cache.peek("a").is_some(), "touched entry was evicted first");
+        assert!(cache.peek("b").is_none());
+    }
+
     /// A `ServerState` over an empty index, for exercising the stale path
     /// directly. Mirrors the defaults `run` uses with a watcher and ignore
     /// rules enabled, which is the configuration `gitignore_pending` gates.
@@ -2980,7 +3197,11 @@ mod tests {
         let hybrid = HybridIndex::open(index_dir, root).expect("open empty index");
         Arc::new(ServerState {
             index: RwLock::new(hybrid),
-            cache: RwLock::new(LruCache::new(NonZeroUsize::new(CACHE_CAPACITY).unwrap())),
+            cache: RwLock::new(ContentCache::new(
+                CACHE_CAPACITY,
+                CACHE_MAX_BYTES,
+                CACHE_MAX_ENTRY_BYTES,
+            )),
             root: root.to_path_buf(),
             watcher_active: std::sync::atomic::AtomicBool::new(false),
             indexing: std::sync::atomic::AtomicBool::new(false),

--- a/tgrep-cli/tests/default_max_filesize.rs
+++ b/tgrep-cli/tests/default_max_filesize.rs
@@ -38,7 +38,11 @@ fn fixture() -> (TempDir, PathBuf) {
     let root = dir.path().join("testdata");
     std::fs::create_dir_all(&root).unwrap();
 
-    std::fs::write(root.join("small.txt"), format!("{NEEDLE} in a small file\n")).unwrap();
+    std::fs::write(
+        root.join("small.txt"),
+        format!("{NEEDLE} in a small file\n"),
+    )
+    .unwrap();
 
     let big_path = root.join("big.txt");
     let mut big = std::io::BufWriter::new(std::fs::File::create(&big_path).unwrap());

--- a/tgrep-cli/tests/default_max_filesize.rs
+++ b/tgrep-cli/tests/default_max_filesize.rs
@@ -1,0 +1,149 @@
+//! The 64 MiB default size cap, which is a deliberate divergence from ripgrep.
+//!
+//! ripgrep has no default `--max-filesize`. tgrep does, because a file a walk
+//! picks up is also a file the index carries and re-reads on every query whose
+//! trigrams make it a candidate, so one outlier is paid for repeatedly rather
+//! than once. On a real enlistment a single 13.41 GiB generated artifact was
+//! 71% of all searchable bytes and 39x the cost of an otherwise sub-second
+//! query.
+//!
+//! The cap can hide a real match, so these tests pin the two things that keep
+//! that from being silent: `--no-max-filesize`, and the rule that a file named
+//! directly on the command line is never dropped by the *inherited* default.
+//! They also pin the boundary itself, since a default nobody tests is a default
+//! that drifts.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn tgrep_bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("tgrep")
+}
+
+const NEEDLE: &str = "NEEDLE_OVER_THE_CAP";
+const FILLER: &str = "filler line that is not interesting at all\n";
+
+/// A repo holding one small file and one file just past the 64 MiB default,
+/// both containing the needle.
+///
+/// The oversized file is built by writing real bytes rather than `set_len`,
+/// because the search path has to *read* it — a sparse hole would be searched
+/// as NUL bytes and rejected as binary, which would pass the "not found" case
+/// for entirely the wrong reason.
+fn fixture() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    std::fs::create_dir_all(&root).unwrap();
+
+    std::fs::write(root.join("small.txt"), format!("{NEEDLE} in a small file\n")).unwrap();
+
+    let big_path = root.join("big.txt");
+    let mut big = std::io::BufWriter::new(std::fs::File::create(&big_path).unwrap());
+    // The needle goes in first so that a truncated read cannot be the reason a
+    // search fails to find it.
+    writeln!(big, "{NEEDLE} in a big file").unwrap();
+    let mut written = 0usize;
+    while written <= 64 * 1024 * 1024 {
+        big.write_all(FILLER.as_bytes()).unwrap();
+        written += FILLER.len();
+    }
+    big.flush().unwrap();
+    drop(big);
+
+    assert!(
+        std::fs::metadata(&big_path).unwrap().len() > 64 * 1024 * 1024,
+        "fixture must land above the default cap"
+    );
+    (dir, big_path)
+}
+
+/// Run a search and return the paths that matched, one per line.
+fn search(target: &Path, extra: &[&str]) -> Vec<String> {
+    let out = Command::new(tgrep_bin())
+        .arg("--no-index")
+        .args(extra)
+        .args(["--files-with-matches", NEEDLE])
+        .arg(target)
+        .output()
+        .unwrap();
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(|l| {
+            Path::new(l.trim())
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect()
+}
+
+#[test]
+fn a_walk_drops_files_past_the_default_cap() {
+    let (dir, _big) = fixture();
+    let root = dir.path().join("testdata");
+
+    // The small sibling proves the walk itself worked, so the missing big file
+    // is the cap and not a broken fixture.
+    assert_eq!(search(&root, &[]), vec!["small.txt"]);
+}
+
+#[test]
+fn no_max_filesize_restores_ripgrep_behaviour() {
+    let (dir, _big) = fixture();
+    let root = dir.path().join("testdata");
+
+    let mut found = search(&root, &["--no-max-filesize"]);
+    found.sort();
+    assert_eq!(found, vec!["big.txt", "small.txt"]);
+}
+
+#[test]
+fn a_raised_cap_also_restores_the_file() {
+    let (dir, _big) = fixture();
+    let root = dir.path().join("testdata");
+
+    let mut found = search(&root, &["--max-filesize", "128M"]);
+    found.sort();
+    assert_eq!(found, vec!["big.txt", "small.txt"]);
+}
+
+#[test]
+fn naming_a_file_defeats_the_inherited_default() {
+    let (_dir, big) = fixture();
+
+    // Pointing at a file is an unambiguous request to search it. Answering "no
+    // match" because of a limit the user never asked for would be a lie, and an
+    // exit status of 1 makes it an actionable one.
+    assert_eq!(search(&big, &[]), vec!["big.txt"]);
+}
+
+#[test]
+fn naming_a_file_still_honours_a_cap_the_user_set() {
+    let (_dir, big) = fixture();
+
+    // The exemption is for the *inherited* default only. Once the user names a
+    // limit, the limit is itself the request.
+    assert!(search(&big, &["--max-filesize", "1M"]).is_empty());
+}
+
+#[test]
+fn the_default_is_last_flag_wins() {
+    let (dir, _big) = fixture();
+    let root = dir.path().join("testdata");
+
+    // `--max-filesize` and `--no-max-filesize` override one another, so a
+    // wrapper script that sets one cannot be silently defeated by argument
+    // order it did not choose. The small file stays visible under the 1M cap,
+    // which is what distinguishes "the later flag won" from "the search broke".
+    assert_eq!(
+        search(&root, &["--no-max-filesize", "--max-filesize", "1M"]),
+        vec!["small.txt"]
+    );
+    let mut found = search(&root, &["--max-filesize", "1M", "--no-max-filesize"]);
+    found.sort();
+    assert_eq!(found, vec!["big.txt", "small.txt"]);
+}

--- a/tgrep-cli/tests/large_file_search.rs
+++ b/tgrep-cli/tests/large_file_search.rs
@@ -22,7 +22,7 @@ fn tgrep_bin() -> PathBuf {
 }
 
 /// Comfortably above the 1 MiB mapping threshold in `search.rs`.
-const LARGE_ENOUGH_TO_MAP: usize = 9 * 1024 * 1024;
+const LARGE_ENOUGH_TO_MAP: usize = 2 * 1024 * 1024;
 
 const FILLER: &str = "the quick brown fox jumps over the lazy dog\n";
 const NEEDLE_LINE: &str = "NEEDLE_ALPHA marker\n";
@@ -71,7 +71,7 @@ fn a_mapped_file_reports_the_same_lines_as_a_read_one() {
     std::fs::write(&path, &text).unwrap();
 
     assert!(
-        std::fs::metadata(&path).unwrap().len() as usize > 8 * 1024 * 1024,
+        std::fs::metadata(&path).unwrap().len() as usize > 1024 * 1024,
         "fixture must exceed the mapping threshold or this tests nothing"
     );
 

--- a/tgrep-cli/tests/large_file_search.rs
+++ b/tgrep-cli/tests/large_file_search.rs
@@ -21,7 +21,7 @@ fn tgrep_bin() -> PathBuf {
     assert_cmd::cargo::cargo_bin("tgrep")
 }
 
-/// Comfortably above the 8 MiB mapping threshold in `search.rs`.
+/// Comfortably above the 1 MiB mapping threshold in `search.rs`.
 const LARGE_ENOUGH_TO_MAP: usize = 9 * 1024 * 1024;
 
 const FILLER: &str = "the quick brown fox jumps over the lazy dog\n";

--- a/tgrep-cli/tests/large_file_search.rs
+++ b/tgrep-cli/tests/large_file_search.rs
@@ -1,0 +1,140 @@
+//! Integration test: searching files large enough to be memory-mapped.
+//!
+//! Reading a file with `fs::read` costs its full size in heap, so large files
+//! are mapped instead and searched straight out of the mapping. That path is
+//! only taken above a size threshold, which means the rest of the suite — whose
+//! fixtures are all comfortably small — never exercises it. These tests are the
+//! only coverage of the mapped path, so they deliberately build files past the
+//! threshold and check that results are indistinguishable from the read path.
+//!
+//! The mapping is only valid when the mapped bytes are exactly the bytes to
+//! search, so the cases that must *decline* to map matter as much as the one
+//! that maps: invalid UTF-8 needs lossy repair, and a BOM needs transcoding.
+//! Both must fall back and still return correct results.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn tgrep_bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("tgrep")
+}
+
+/// Comfortably above the 8 MiB mapping threshold in `search.rs`.
+const LARGE_ENOUGH_TO_MAP: usize = 9 * 1024 * 1024;
+
+const FILLER: &str = "the quick brown fox jumps over the lazy dog\n";
+const NEEDLE_LINE: &str = "NEEDLE_ALPHA marker\n";
+
+/// Build text past the mapping threshold, returning it with the 1-based line
+/// numbers that hold the needle.
+fn large_text_with_needles() -> (String, Vec<usize>) {
+    let mut text = String::with_capacity(LARGE_ENOUGH_TO_MAP + FILLER.len());
+    let mut needle_lines = Vec::new();
+    let mut lineno = 0usize;
+    while text.len() < LARGE_ENOUGH_TO_MAP {
+        lineno += 1;
+        // Spread the needles across the file so a bug that only reads the head
+        // or tail of the mapping cannot pass.
+        if lineno % 20_000 == 7 {
+            text.push_str(NEEDLE_LINE);
+            needle_lines.push(lineno);
+        } else {
+            text.push_str(FILLER);
+        }
+    }
+    assert!(
+        needle_lines.len() >= 3,
+        "fixture should scatter several needles, got {}",
+        needle_lines.len()
+    );
+    (text, needle_lines)
+}
+
+fn search(path: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new(tgrep_bin())
+        .arg("--no-index")
+        .args(args)
+        .arg("NEEDLE_ALPHA")
+        .arg(path)
+        .output()
+        .expect("tgrep should run");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn a_mapped_file_reports_the_same_lines_as_a_read_one() {
+    let dir = TempDir::new().unwrap();
+    let (text, needle_lines) = large_text_with_needles();
+    let path = dir.path().join("huge.txt");
+    std::fs::write(&path, &text).unwrap();
+
+    assert!(
+        std::fs::metadata(&path).unwrap().len() as usize > 8 * 1024 * 1024,
+        "fixture must exceed the mapping threshold or this tests nothing"
+    );
+
+    let count = search(&path, &["-c"]);
+    assert_eq!(
+        count.trim(),
+        needle_lines.len().to_string(),
+        "mapped file should count every needle"
+    );
+
+    // Line numbers are the part most likely to break if the mapped bytes and
+    // the searched bytes ever disagree.
+    let numbered = search(&path, &["-n"]);
+    let reported: Vec<usize> = numbered
+        .lines()
+        .filter_map(|l| l.split(':').next()?.trim().parse().ok())
+        .collect();
+    assert_eq!(
+        reported, needle_lines,
+        "mapped file should report exact lines"
+    );
+}
+
+#[test]
+fn a_large_file_with_invalid_utf8_still_searches() {
+    // Invalid UTF-8 cannot be mapped and searched directly: it needs lossy
+    // repair first, so this must fall back to the read path and still match.
+    let dir = TempDir::new().unwrap();
+    let (text, needle_lines) = large_text_with_needles();
+    let mut bytes = text.into_bytes();
+    bytes.extend_from_slice(&[0xFF, 0xFE, 0xFF]);
+    bytes.extend_from_slice(NEEDLE_LINE.as_bytes());
+
+    let path = dir.path().join("invalid.txt");
+    std::fs::write(&path, &bytes).unwrap();
+
+    let count = search(&path, &["-c"]);
+    assert_eq!(
+        count.trim(),
+        (needle_lines.len() + 1).to_string(),
+        "invalid UTF-8 must fall back to the read path, not lose matches"
+    );
+}
+
+#[test]
+fn a_large_utf16_file_still_searches() {
+    // A BOM means the bytes on disk are not the bytes to search, so the
+    // mapping must be declined in favour of transcoding.
+    let dir = TempDir::new().unwrap();
+    let (text, needle_lines) = large_text_with_needles();
+
+    let mut bytes = vec![0xFF, 0xFE]; // UTF-16LE BOM
+    for unit in text.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+
+    let path = dir.path().join("utf16.txt");
+    std::fs::write(&path, &bytes).unwrap();
+
+    let count = search(&path, &["-c"]);
+    assert_eq!(
+        count.trim(),
+        needle_lines.len().to_string(),
+        "UTF-16 must be transcoded rather than searched as mapped bytes"
+    );
+}

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -5227,3 +5227,169 @@ fn indexed_search_excludes_ignored_files_under_no_require_git() {
         "ignored build output must not be searchable: {stdout:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// `-P` patterns still use the index
+//
+// A PCRE pattern cannot be parsed by regex-syntax, so the planner used to give up
+// and hand back MatchAll - every file in the index, read and decoded and matched
+// one by one. On a large tree that turned a query with an obvious mandatory
+// literal into a full-corpus scan. The planner now relaxes the pattern first
+// (dropping the zero-width assertions) and plans from the result, which matches a
+// superset and therefore cannot exclude a real hit. These tests pin that the
+// answers are unchanged.
+// ---------------------------------------------------------------------------
+
+/// Index and direct scans can print paths differently; compare the set of lines
+/// with separators and ordering normalised away.
+fn normalize(out: &str) -> Vec<String> {
+    let mut lines: Vec<String> = out
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.replace('\\', "/"))
+        .collect();
+    lines.sort();
+    lines
+}
+
+/// Two files hold the literal - one commented out, one not - plus decoys that do
+/// not hold it at all, so a plan that works can be told apart from one that does
+/// not.
+fn setup_lookaround_fixture() -> (TempDir, String) {
+    let dir = TempDir::new().unwrap();
+    let sub = dir.path().join("testdata");
+    fs::create_dir_all(&sub).unwrap();
+
+    fs::write(sub.join("live.rs"), "let p = ExchangePrincipal::new();\n").unwrap();
+    fs::write(sub.join("commented.rs"), "//ExchangePrincipal is gone\n").unwrap();
+    fs::write(sub.join("unrelated.rs"), "let q = SomethingElse::new();\n").unwrap();
+    fs::write(sub.join("notes.txt"), "no mention of the type here\n").unwrap();
+
+    let index_dir = dir.path().join("idx");
+    tgrep()
+        .args([
+            "index",
+            sub.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    (dir, index_dir.to_str().unwrap().to_string())
+}
+
+#[test]
+fn indexed_lookaround_finds_the_same_lines_as_a_direct_scan() {
+    let (dir, idx) = setup_lookaround_fixture();
+    let root = indexed_fixture_path(&dir);
+
+    let indexed = String::from_utf8(
+        tgrep()
+            .args([
+                "--no-heading",
+                "-P",
+                "--index-path",
+                &idx,
+                r"(?<!//)ExchangePrincipal",
+                &root,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap();
+
+    let direct = String::from_utf8(
+        tgrep()
+            .args([
+                "--no-heading",
+                "-P",
+                "--no-index",
+                r"(?<!//)ExchangePrincipal",
+                &root,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        normalize(&indexed),
+        normalize(&direct),
+        "using the index must not change the answer"
+    );
+    assert!(
+        indexed.contains("live.rs"),
+        "the uncommented hit survives the relaxed plan: {indexed}"
+    );
+    assert!(
+        !indexed.contains("commented.rs"),
+        "the lookbehind is still applied by the real matcher: {indexed}"
+    );
+}
+
+#[test]
+fn indexed_lookahead_finds_the_same_lines_as_a_direct_scan() {
+    let (dir, idx) = setup_lookaround_fixture();
+    let root = indexed_fixture_path(&dir);
+
+    for pattern in [
+        r"ExchangePrincipal(?=::)",
+        r"ExchangePrincipal(?!::)",
+        r"(?=.*Exchange)ExchangePrincipal",
+    ] {
+        let indexed = tgrep()
+            .args(["--no-heading", "-P", "--index-path", &idx, pattern, &root])
+            .assert()
+            .get_output()
+            .stdout
+            .clone();
+        let direct = tgrep()
+            .args(["--no-heading", "-P", "--no-index", pattern, &root])
+            .assert()
+            .get_output()
+            .stdout
+            .clone();
+        assert_eq!(
+            normalize(&String::from_utf8(indexed).unwrap()),
+            normalize(&String::from_utf8(direct).unwrap()),
+            "index and direct scan disagree for {pattern}"
+        );
+    }
+}
+
+#[test]
+fn indexed_backreference_still_returns_every_match() {
+    // Backreferences cannot be relaxed, so the planner falls back to scanning
+    // everything. That is slow, not wrong - the results must still be complete.
+    let (dir, idx) = setup_lookaround_fixture();
+    let root = indexed_fixture_path(&dir);
+
+    let out = String::from_utf8(
+        tgrep()
+            .args([
+                "--no-heading",
+                "-P",
+                "--index-path",
+                &idx,
+                r"(Exchange)\1?Principal",
+                &root,
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone(),
+    )
+    .unwrap();
+    assert!(
+        out.contains("live.rs") && out.contains("commented.rs"),
+        "an unrelaxable pattern still sees every file: {out}"
+    );
+}

--- a/tgrep-cli/tests/ripgrep_parity.rs
+++ b/tgrep-cli/tests/ripgrep_parity.rs
@@ -2167,12 +2167,15 @@ fn json_bytes_searched_counts_the_file_when_there_is_no_nul() {
 //      $ rg --json -o alpha a.txt
 //      ... two `match` events, {"matches":3,"matched_lines":2}
 //
-// c) `-c`, `--count-matches`, `-l` and `--files-without-match` are handled by
-//    a printer that predates `--json`, so those flags win outright and the
-//    invocation emits no JSON at all -- not even a `summary`:
+// c) `-c`, `--count-matches`, `-l`, `--files-without-match` and `--files` are
+//    handled by printers that predate `--json`, so those flags win outright
+//    and the invocation emits no JSON at all -- not even a `summary`:
 //
 //      $ rg --json -c alpha a.txt
 //      2
+//      $ rg --json --files
+//      b.txt
+//      a.txt
 // ---------------------------------------------------------------------------
 
 /// The two fixtures the `--json` stats cases were verified against.
@@ -2261,12 +2264,16 @@ fn json_ignores_only_matching() {
                 .args(["--no-index", "--json", "alpha", "a.txt"]),
         );
 
-    let strip_timings = |out: &str| {
+    // `elapsed` is wall clock, and `bytes_printed` counts the serialized JSON
+    // itself -- including the variable-width `nanos` of the event before it --
+    // so both move run to run. Every other field has to match exactly.
+    let strip_volatile = |out: &str| {
         json_events(out)
             .into_iter()
             .map(|mut e| {
                 if let Some(stats) = e["data"]["stats"].as_object_mut() {
                     stats.remove("elapsed");
+                    stats.remove("bytes_printed");
                 }
                 e["data"].as_object_mut().map(|d| d.remove("elapsed_total"));
                 e
@@ -2274,8 +2281,8 @@ fn json_ignores_only_matching() {
             .collect::<Vec<_>>()
     };
     assert_eq!(
-        strip_timings(&with_o),
-        strip_timings(&without_o),
+        strip_volatile(&with_o),
+        strip_volatile(&without_o),
         "ripgrep's JSON printer has no -o mode, so the two streams are the \
          same: with -o {with_o}\nwithout -o {without_o}"
     );
@@ -2337,4 +2344,25 @@ fn json_is_ignored_when_listing_files() {
             "`--json {flag}` prints file names alone, with no stray summary: {out}"
         );
     }
+}
+
+#[test]
+fn json_is_ignored_when_listing_every_file() {
+    let dir = json_stats_fixture();
+    let out = stdout_of(
+        tgrep()
+            .current_dir(dir.path())
+            .args(["--no-index", "--json", "--files"]),
+    );
+    assert!(
+        !out.lines().any(|l| l.starts_with('{')),
+        "`--json --files` prints the bare file list, with no stray summary: {out}"
+    );
+    let mut listed: Vec<_> = out.lines().filter(|l| !l.is_empty()).collect();
+    listed.sort_unstable();
+    assert_eq!(
+        listed,
+        ["a.txt", "b.txt"],
+        "the listing itself is unchanged by --json: {out}"
+    );
 }

--- a/tgrep-cli/tests/ripgrep_parity.rs
+++ b/tgrep-cli/tests/ripgrep_parity.rs
@@ -2366,3 +2366,92 @@ fn json_is_ignored_when_listing_every_file() {
         "the listing itself is unchanged by --json: {out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Context separators across file boundaries
+//
+// ripgrep marks every gap in the printed stream with `--`, and the jump from one
+// file's context block to the next is a gap. tgrep only marked gaps *within* a
+// file, so piped `-C` output was short one separator per file boundary - 808 of
+// them across a large tree. In heading mode there is no `--`, because the blank
+// line before the next heading already separates the files.
+// ---------------------------------------------------------------------------
+
+/// Two files, each with a match, so the only separator in play is the boundary.
+fn context_fixture() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "a1\nneedle\na3\n").unwrap();
+    fs::write(dir.path().join("b.txt"), "b1\nneedle\nb3\n").unwrap();
+    dir
+}
+
+#[test]
+fn context_separator_marks_the_boundary_between_files() {
+    let dir = context_fixture();
+    let out = stdout_of(tgrep().current_dir(dir.path()).args([
+        "--no-index",
+        "--no-heading",
+        "-n",
+        "-C",
+        "1",
+        "needle",
+    ]));
+    assert_eq!(
+        out.lines().filter(|l| *l == "--").count(),
+        1,
+        "one `--` separates the two files' context blocks: {out}"
+    );
+}
+
+#[test]
+fn context_separator_is_absent_in_heading_mode() {
+    let dir = context_fixture();
+    let out = stdout_of(tgrep().current_dir(dir.path()).args([
+        "--no-index",
+        "--heading",
+        "-n",
+        "-C",
+        "1",
+        "needle",
+    ]));
+    assert_eq!(
+        out.lines().filter(|l| *l == "--").count(),
+        0,
+        "heading mode separates files with a blank line, not `--`: {out}"
+    );
+}
+
+#[test]
+fn context_separator_is_absent_without_context_flags() {
+    let dir = context_fixture();
+    let out = stdout_of(tgrep().current_dir(dir.path()).args([
+        "--no-index",
+        "--no-heading",
+        "-n",
+        "needle",
+    ]));
+    assert_eq!(
+        out.lines().filter(|l| *l == "--").count(),
+        0,
+        "without -A/-B/-C a file change is not a context gap: {out}"
+    );
+}
+
+#[test]
+fn no_context_separator_suppresses_the_boundary_marker() {
+    let dir = context_fixture();
+    let out = stdout_of(tgrep().current_dir(dir.path()).args([
+        "--no-index",
+        "--no-heading",
+        "--no-context-separator",
+        "-n",
+        "-C",
+        "1",
+        "needle",
+    ]));
+    assert_eq!(
+        out.lines().filter(|l| *l == "--").count(),
+        0,
+        "--no-context-separator suppresses the boundary marker too: {out}"
+    );
+}

--- a/tgrep-cli/tests/ripgrep_parity.rs
+++ b/tgrep-cli/tests/ripgrep_parity.rs
@@ -2145,3 +2145,196 @@ fn json_bytes_searched_counts_the_file_when_there_is_no_nul() {
          larger size it has once invalid UTF-8 is repaired: {end}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 22. `--json` stats parity
+//
+// Confirmed against rg 15.2.0 with fixtures
+//   a.txt = "alpha\nbeta\ngamma\nalpha again alpha\n"
+//   b.txt = "beta\ndelta\n"
+//
+// a) One `summary` per *invocation*, not per named path. ripgrep aggregates
+//    every path it was given into a single event, so `searches` counts them
+//    all:
+//
+//      $ rg --json -v alpha a.txt b.txt
+//      ... {"stats":{"matched_lines":4,"searches":2,"searches_with_match":2}}
+//
+// b) `-o` is a flag of ripgrep's *standard* printer; the JSON printer has no
+//    equivalent and always emits whole lines with one submatch per hit, so
+//    `--json -o` is byte-identical to `--json`:
+//
+//      $ rg --json -o alpha a.txt
+//      ... two `match` events, {"matches":3,"matched_lines":2}
+//
+// c) `-c`, `--count-matches`, `-l` and `--files-without-match` are handled by
+//    a printer that predates `--json`, so those flags win outright and the
+//    invocation emits no JSON at all -- not even a `summary`:
+//
+//      $ rg --json -c alpha a.txt
+//      2
+// ---------------------------------------------------------------------------
+
+/// The two fixtures the `--json` stats cases were verified against.
+fn json_stats_fixture() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("a.txt"),
+        "alpha\nbeta\ngamma\nalpha again alpha\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("b.txt"), "beta\ndelta\n").unwrap();
+    dir
+}
+
+#[test]
+fn json_emits_one_summary_for_all_named_paths() {
+    let dir = json_stats_fixture();
+    let out = stdout_of(tgrep().current_dir(dir.path()).args([
+        "--no-index",
+        "--json",
+        "-v",
+        "alpha",
+        "a.txt",
+        "b.txt",
+    ]));
+    let summaries: Vec<_> = json_events(&out)
+        .into_iter()
+        .filter(|e| e["type"] == "summary")
+        .collect();
+    assert_eq!(
+        summaries.len(),
+        1,
+        "ripgrep emits one summary for the whole invocation, not one per \
+         named path: {out}"
+    );
+    let stats = &summaries[0]["data"]["stats"];
+    assert_eq!(
+        stats["searches"], 2,
+        "both named paths count towards the one summary: {out}"
+    );
+    assert_eq!(
+        stats["searches_with_match"], 2,
+        "both produced output: {out}"
+    );
+    assert_eq!(
+        stats["matched_lines"], 4,
+        "two inverted lines in each file: {out}"
+    );
+}
+
+#[test]
+fn json_summary_comes_last_across_named_paths() {
+    let dir = json_stats_fixture();
+    let out = stdout_of(tgrep().current_dir(dir.path()).args([
+        "--no-index",
+        "--json",
+        "beta",
+        "a.txt",
+        "b.txt",
+    ]));
+    let kinds: Vec<_> = json_events(&out)
+        .iter()
+        .map(|e| e["type"].as_str().unwrap_or("?").to_string())
+        .collect();
+    assert_eq!(
+        kinds,
+        ["begin", "match", "end", "begin", "match", "end", "summary"],
+        "every file's begin/end pair precedes the single trailing summary: {out}"
+    );
+}
+
+#[test]
+fn json_ignores_only_matching() {
+    let dir = json_stats_fixture();
+    let with_o = stdout_of(tgrep().current_dir(dir.path()).args([
+        "--no-index",
+        "--json",
+        "-o",
+        "alpha",
+        "a.txt",
+    ]));
+    let without_o =
+        stdout_of(
+            tgrep()
+                .current_dir(dir.path())
+                .args(["--no-index", "--json", "alpha", "a.txt"]),
+        );
+
+    let strip_timings = |out: &str| {
+        json_events(out)
+            .into_iter()
+            .map(|mut e| {
+                if let Some(stats) = e["data"]["stats"].as_object_mut() {
+                    stats.remove("elapsed");
+                }
+                e["data"].as_object_mut().map(|d| d.remove("elapsed_total"));
+                e
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        strip_timings(&with_o),
+        strip_timings(&without_o),
+        "ripgrep's JSON printer has no -o mode, so the two streams are the \
+         same: with -o {with_o}\nwithout -o {without_o}"
+    );
+
+    let events = json_events(&with_o);
+    let matches: Vec<_> = events.iter().filter(|e| e["type"] == "match").collect();
+    assert_eq!(
+        matches.len(),
+        2,
+        "one event per matching *line*, carrying every submatch: {with_o}"
+    );
+    let stats = &events
+        .iter()
+        .find(|e| e["type"] == "summary")
+        .unwrap_or_else(|| panic!("expected a summary: {with_o}"))["data"]["stats"];
+    assert_eq!(
+        stats["matched_lines"], 2,
+        "`alpha` is on two distinct lines: {with_o}"
+    );
+    assert_eq!(
+        stats["matches"], 3,
+        "three spans across those lines: {with_o}"
+    );
+}
+
+#[test]
+fn json_is_ignored_when_counting() {
+    let dir = json_stats_fixture();
+    for flag in ["-c", "--count-matches"] {
+        let out = stdout_of(tgrep().current_dir(dir.path()).args([
+            "--no-index",
+            "--json",
+            flag,
+            "alpha",
+            "a.txt",
+        ]));
+        assert!(
+            !out.lines().any(|l| l.starts_with('{')),
+            "`--json {flag}` prints the count alone, with no stray summary \
+             a consumer cannot tie to a begin/end pair: {out}"
+        );
+    }
+}
+
+#[test]
+fn json_is_ignored_when_listing_files() {
+    let dir = json_stats_fixture();
+    for flag in ["-l", "--files-without-match"] {
+        let out = stdout_of(tgrep().current_dir(dir.path()).args([
+            "--no-index",
+            "--json",
+            flag,
+            "alpha",
+            "a.txt",
+            "b.txt",
+        ]));
+        assert!(
+            !out.lines().any(|l| l.starts_with('{')),
+            "`--json {flag}` prints file names alone, with no stray summary: {out}"
+        );
+    }
+}

--- a/tgrep-cli/tests/serve_max_filesize.rs
+++ b/tgrep-cli/tests/serve_max_filesize.rs
@@ -9,11 +9,10 @@
 //! This test builds an index with an explicit cap, serves it with the same cap,
 //! and asserts the large file survives and is still searchable.
 //!
-//! The default cap is now 64 MiB, so the fixture below sits under it rather
-//! than over it. What this still catches is a walk that reverts to a hard-coded
-//! low cap instead of honouring the one it was given; reproducing the original
-//! above-the-default case would cost a >64 MiB fixture on every CI platform,
-//! which is not worth it when `walker`'s own unit tests cover that direction.
+//! The default is now no size cap, so this fixture is chosen to be well above
+//! the historical 1 MiB cap and comfortably under the explicit 10 MiB cap this
+//! test pins on both sides, keeping CI lightweight while still exercising the
+//! "honour the provided cap" path.
 
 use std::fs;
 use std::io::{BufRead, BufReader, Write};

--- a/tgrep-cli/tests/serve_max_filesize.rs
+++ b/tgrep-cli/tests/serve_max_filesize.rs
@@ -6,8 +6,14 @@
 //! raised `--max-filesize` lost every file above 1 MiB the first time it was
 //! served — silently, and permanently once the eviction was flushed to disk.
 //!
-//! This test builds an index with a raised cap, serves it with the same cap,
+//! This test builds an index with an explicit cap, serves it with the same cap,
 //! and asserts the large file survives and is still searchable.
+//!
+//! The default cap is now 64 MiB, so the fixture below sits under it rather
+//! than over it. What this still catches is a walk that reverts to a hard-coded
+//! low cap instead of honouring the one it was given; reproducing the original
+//! above-the-default case would cost a >64 MiB fixture on every CI platform,
+//! which is not worth it when `walker`'s own unit tests cover that direction.
 
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
@@ -20,8 +26,8 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 const MARKER: &str = "oversized_survivor_marker";
-/// Comfortably over the 1 MiB default cap, comfortably under the 10 MiB one
-/// the test raises it to.
+/// Comfortably under the 10 MiB cap this test pins on both sides, and large
+/// enough that a walk falling back to the historical 1 MiB cap would drop it.
 const BIG_FILE_BYTES: usize = 2 * 1024 * 1024;
 
 fn tgrep_bin() -> std::path::PathBuf {
@@ -39,8 +45,8 @@ impl Drop for ServerGuard {
     }
 }
 
-/// A repo holding the marker in one small file and one file above the default
-/// size cap.
+/// A repo holding the marker in one small file and one file well above the
+/// historical 1 MiB cap.
 fn setup_fixture() -> TempDir {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
@@ -149,13 +155,14 @@ fn wait_for_stale_check(log_path: &Path) {
 }
 
 #[test]
-fn serving_an_index_built_with_a_raised_max_filesize_keeps_large_files() {
+fn serving_an_index_built_with_an_explicit_max_filesize_keeps_large_files() {
     let fixture = setup_fixture();
     let root = fixture.path();
     let index_dir = root.join(".tgrep_test_index");
 
-    // Build a complete index with a raised cap so `serve` takes the warm-start
-    // path and runs the stale check against an index holding a 2 MiB file.
+    // Build a complete index with an explicit cap so `serve` takes the
+    // warm-start path and runs the stale check against an index holding a
+    // 2 MiB file.
     let output = Command::new(tgrep_bin())
         .args([
             "index",

--- a/tgrep-cli/tests/serve_max_filesize.rs
+++ b/tgrep-cli/tests/serve_max_filesize.rs
@@ -9,10 +9,13 @@
 //! This test builds an index with an explicit cap, serves it with the same cap,
 //! and asserts the large file survives and is still searchable.
 //!
-//! The default is now no size cap, so this fixture is chosen to be well above
-//! the historical 1 MiB cap and comfortably under the explicit 10 MiB cap this
-//! test pins on both sides, keeping CI lightweight while still exercising the
-//! "honour the provided cap" path.
+//! The default cap is now [`tgrep_core::walker::DEFAULT_MAX_FILE_SIZE`], 64 MiB,
+//! so this fixture is chosen to be well above the historical 1 MiB cap and
+//! comfortably under the explicit 10 MiB cap this test pins on both sides,
+//! keeping CI lightweight while still exercising the "honour the provided cap"
+//! path. Pinning an explicit cap rather than relying on the default is
+//! deliberate: it keeps the test measuring cap propagation rather than whatever
+//! the default happens to be.
 
 use std::fs;
 use std::io::{BufRead, BufReader, Write};

--- a/tgrep-core/Cargo.toml
+++ b/tgrep-core/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 memmap2 = "0.9"
+memchr = "2"
 regex = "1"
 regex-syntax = "0.8"
 rayon = "1"

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -1145,7 +1145,7 @@ pub fn merge_index_with_delta(
             usize::from(append_only) * (bytes.len() / ondisk::POSTING_ENTRY_SIZE)
         });
         if !append_only && let Some(bytes) = reader_bytes {
-            for raw in bytes.chunks_exact(ondisk::POSTING_ENTRY_SIZE) {
+            for raw in bytes.as_chunks::<{ ondisk::POSTING_ENTRY_SIZE }>().0.iter() {
                 let old_id = u32::from_le_bytes(raw[0..4].try_into().expect("four-byte file id"));
                 let new_id = *reader_id_map.get(old_id as usize).ok_or_else(|| {
                     Error::IndexCorrupted(format!(
@@ -1186,7 +1186,7 @@ pub fn merge_index_with_delta(
                 for chunk in bytes.chunks(POSTING_WRITE_CHUNK_ENTRIES * ondisk::POSTING_ENTRY_SIZE)
                 {
                     posting_scratch.clear();
-                    for raw in chunk.chunks_exact(ondisk::POSTING_ENTRY_SIZE) {
+                    for raw in chunk.as_chunks::<{ ondisk::POSTING_ENTRY_SIZE }>().0.iter() {
                         let old_id =
                             u32::from_le_bytes(raw[0..4].try_into().expect("four-byte file id"));
                         let new_id = reader_id_map[old_id as usize];
@@ -1202,7 +1202,7 @@ pub fn merge_index_with_delta(
         if let Some(bytes) = delta_bytes {
             for chunk in bytes.chunks(POSTING_WRITE_CHUNK_ENTRIES * ondisk::POSTING_ENTRY_SIZE) {
                 posting_scratch.clear();
-                for raw in chunk.chunks_exact(ondisk::POSTING_ENTRY_SIZE) {
+                for raw in chunk.as_chunks::<{ ondisk::POSTING_ENTRY_SIZE }>().0.iter() {
                     let file_id =
                         u32::from_le_bytes(raw[0..4].try_into().expect("four-byte file id"));
                     if file_id as usize >= delta.num_files() {

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -241,6 +241,63 @@ fn batch_ranges(sizes: &[u64], budget: u64) -> Vec<std::ops::Range<usize>> {
     ranges
 }
 
+/// Smallest file worth memory-mapping instead of reading.
+///
+/// The same tradeoff the search path makes: mapping costs a syscall pair and a
+/// page-table setup per file, which is a bad deal across the ~94k mostly-small
+/// files of a kernel tree, but above this size it is what stops a large
+/// generated header from costing its full size in heap in every worker that
+/// touches one. Mapped pages are file-backed, so the kernel can reclaim them
+/// under pressure instead of the process holding an allocation it cannot give
+/// back.
+///
+/// 1 MiB is where the measurement pointed rather than a round guess. In the AMD
+/// register headers — the worst case in the kernel tree — an 8 MiB threshold
+/// mapped only 11 of 488 files and left 69% of the bytes on the heap, while
+/// 1 MiB maps 102 files covering 87% of the bytes. It stays cheap on ordinary
+/// trees because it is far above the size of real source: only 110 of the
+/// kernel's 94,747 files reach it at all.
+const MMAP_MIN_BYTES: u64 = 1024 * 1024;
+
+/// The bytes of a file to index, either read onto the heap or borrowed from a
+/// memory map.
+enum FileBytes {
+    Read(Vec<u8>),
+    Mapped(memmap2::Mmap),
+}
+
+impl std::ops::Deref for FileBytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        match self {
+            FileBytes::Read(bytes) => bytes,
+            FileBytes::Mapped(map) => map,
+        }
+    }
+}
+
+/// Get a file's bytes for indexing, mapping it when it is large enough to be
+/// worth avoiding the copy.
+///
+/// Falls back to reading whenever mapping is unavailable, so a filesystem that
+/// cannot map still indexes correctly.
+fn read_for_index(path: &Path, size: u64) -> Option<FileBytes> {
+    if size >= MMAP_MIN_BYTES {
+        // SAFETY: the map is read-only and owned by the returned value, which
+        // is dropped once the file's trigrams have been extracted. A concurrent
+        // truncation would be undefined behaviour; that is inherent to mapping
+        // a file being indexed, and is the same exposure the search path
+        // accepts.
+        let mapped =
+            std::fs::File::open(path).and_then(|file| unsafe { memmap2::Mmap::map(&file) });
+        if let Ok(map) = mapped {
+            return Some(FileBytes::Mapped(map));
+        }
+    }
+    std::fs::read(path).ok().map(FileBytes::Read)
+}
+
 /// Build a trigram index, choosing how postings are accumulated.
 pub fn build_index_with_options(
     root: &Path,
@@ -311,11 +368,13 @@ pub fn build_index_with_options(
         .collect();
 
     for range in batch_ranges(&sizes, INDEX_BUILD_BATCH_BYTES) {
-        let batch = &walk.files[range];
+        let batch = &walk.files[range.clone()];
+        let batch_sizes = &sizes[range];
         let batch_data: Vec<(String, HashMap<u32, TrigramMasks>)> = batch
             .par_iter()
-            .filter_map(|path| {
-                let data = std::fs::read(path).ok()?;
+            .zip(batch_sizes.par_iter())
+            .filter_map(|(path, &size)| {
+                let data = read_for_index(path, size)?;
                 let text = crate::encoding::decode_for_index(&data);
                 if trigram::is_binary(&text) {
                     binary_skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -17,6 +17,23 @@ const INDEX_BUILD_BATCH_SIZE: usize = 1024;
 const POSTING_WRITE_CHUNK_ENTRIES: usize = 8192;
 const LOOKUP_WRITE_CHUNK_ENTRIES: usize = 4096;
 
+/// Cumulative bytes allowed in one extraction batch.
+///
+/// Batching by file count alone bounds nothing in memory: every file in a batch
+/// can be read concurrently, so a run of large files puts an unbounded number of
+/// whole-file buffers in flight at once. Bounding the batch's total size bounds
+/// that directly, because each buffer is freed as soon as its trigrams have been
+/// extracted.
+///
+/// The budget also bounds parallelism — a batch holding three 20 MB headers can
+/// only occupy three workers — so it was measured rather than guessed. On the
+/// Linux kernel this value cut peak memory 32% for roughly 4% build time, and a
+/// larger budget that scales with the thread pool was tried and rejected: it was
+/// both slower *and* hungrier there, because the kernel's large files are a rare
+/// minority and the extra headroom bought no throughput. A budget this size only
+/// costs throughput on a tree that is nothing but oversized generated headers.
+const INDEX_BUILD_BATCH_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Default arena budget for [`IndexStrategy::External`] before spilling.
 pub use crate::external::DEFAULT_BUFFER_BYTES as DEFAULT_INDEX_BUFFER_BYTES;
 
@@ -200,6 +217,30 @@ fn gitignore_gate_hint(root: &Path, opts: &BuildOptions) -> Option<String> {
     ))
 }
 
+/// Split a file list into batches bounded by both file count and cumulative
+/// bytes, given each file's size in walk order.
+///
+/// A file larger than the budget forms a batch of its own rather than being
+/// split, so the bound is "one budget, plus at most one oversized file".
+fn batch_ranges(sizes: &[u64], budget: u64) -> Vec<std::ops::Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    let mut bytes = 0u64;
+    for (i, &size) in sizes.iter().enumerate() {
+        let full = i - start >= INDEX_BUILD_BATCH_SIZE || bytes.saturating_add(size) > budget;
+        if i > start && full {
+            ranges.push(start..i);
+            start = i;
+            bytes = 0;
+        }
+        bytes = bytes.saturating_add(size);
+    }
+    if start < sizes.len() {
+        ranges.push(start..sizes.len());
+    }
+    ranges
+}
+
 /// Build a trigram index, choosing how postings are accumulated.
 pub fn build_index_with_options(
     root: &Path,
@@ -249,7 +290,9 @@ pub fn build_index_with_options(
     let binary_skipped = std::sync::atomic::AtomicUsize::new(0);
 
     // Assign file IDs and collect posting entries. Batching avoids
-    // retaining every file's per-trigram HashMap at once for large repos.
+    // retaining every file's per-trigram HashMap at once for large repos, and
+    // bounding each batch by cumulative bytes caps how much raw file content is
+    // resident at once, since the whole batch is read concurrently.
     let mut file_id_map: Vec<(u32, String)> = Vec::with_capacity(walk.files.len());
     let mut sink = match opts.strategy {
         IndexStrategy::InMemory => PostingSink::InMemory(Vec::new()),
@@ -259,7 +302,16 @@ pub fn build_index_with_options(
         }
     };
 
-    for batch in walk.files.chunks(INDEX_BUILD_BATCH_SIZE) {
+    // The walk already stats every entry but discards the size, so recover it
+    // here rather than widening WalkResult into the search and serve paths.
+    let sizes: Vec<u64> = walk
+        .files
+        .par_iter()
+        .map(|path| std::fs::metadata(path).map(|m| m.len()).unwrap_or(0))
+        .collect();
+
+    for range in batch_ranges(&sizes, INDEX_BUILD_BATCH_BYTES) {
+        let batch = &walk.files[range];
         let batch_data: Vec<(String, HashMap<u32, TrigramMasks>)> = batch
             .par_iter()
             .filter_map(|path| {
@@ -796,6 +848,49 @@ fn count_sorted_trigrams(postings: &[TrigramPosting]) -> usize {
 mod tests {
     use super::*;
     use crate::reader::IndexReader;
+
+    const MB: u64 = 1024 * 1024;
+
+    #[test]
+    fn batches_are_bounded_by_cumulative_bytes() {
+        // Five 20 MB files against a 64 MB budget: three fit, then the rest.
+        let sizes = vec![20 * MB; 5];
+        assert_eq!(batch_ranges(&sizes, 64 * MB), vec![0..3, 3..5]);
+    }
+
+    #[test]
+    fn batches_are_still_bounded_by_file_count() {
+        // Tiny files never reach the byte budget, so the count bound applies.
+        let sizes = vec![1u64; INDEX_BUILD_BATCH_SIZE * 2 + 5];
+        let ranges = batch_ranges(&sizes, 64 * MB);
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges[0], 0..INDEX_BUILD_BATCH_SIZE);
+    }
+
+    #[test]
+    fn a_file_larger_than_the_budget_gets_its_own_batch() {
+        // The oversized file is never split, and never drags neighbours along.
+        let sizes = vec![MB, 500 * MB, MB];
+        assert_eq!(batch_ranges(&sizes, 64 * MB), vec![0..1, 1..2, 2..3]);
+    }
+
+    #[test]
+    fn batches_cover_every_file_exactly_once() {
+        let sizes: Vec<u64> = (0..500).map(|i| (i as u64 % 7) * 9 * MB).collect();
+        let ranges = batch_ranges(&sizes, 64 * MB);
+        let mut next = 0usize;
+        for range in &ranges {
+            assert_eq!(range.start, next, "gap or overlap between batches");
+            assert!(range.start < range.end, "empty batch");
+            next = range.end;
+        }
+        assert_eq!(next, sizes.len(), "batches must cover the whole walk");
+    }
+
+    #[test]
+    fn an_empty_walk_produces_no_batches() {
+        assert!(batch_ranges(&[], 64 * MB).is_empty());
+    }
 
     /// Build a repo with enough varied content that a small arena spills.
     fn write_sample_repo(root: &Path, file_count: usize) {

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -30,8 +30,13 @@ const LOOKUP_WRITE_CHUNK_ENTRIES: usize = 4096;
 /// Linux kernel this value cut peak memory 32% for roughly 4% build time, and a
 /// larger budget that scales with the thread pool was tried and rejected: it was
 /// both slower *and* hungrier there, because the kernel's large files are a rare
-/// minority and the extra headroom bought no throughput. A budget this size only
-/// costs throughput on a tree that is nothing but oversized generated headers.
+/// minority and the extra headroom bought no throughput.
+///
+/// Files large enough to be mapped are charged [`MAPPED_BATCH_CHARGE`] instead
+/// of their length, so a tree that is mostly oversized files still fills the
+/// pool. Raising this budget would trade memory on *every* tree for that;
+/// charging mapped bytes honestly costs nothing on trees like the kernel, where
+/// only 110 of 94,747 files are mapped at all.
 const INDEX_BUILD_BATCH_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Default arena budget for [`IndexStrategy::External`] before spilling.
@@ -213,28 +218,102 @@ fn gitignore_gate_hint(root: &Path, opts: &BuildOptions) -> Option<String> {
     ))
 }
 
-/// Split a file list into batches bounded by both file count and cumulative
-/// bytes, given each file's size in walk order.
+/// Nominal heap charge for a file large enough to be memory-mapped.
 ///
-/// A file larger than the budget forms a batch of its own rather than being
-/// split, so the bound is "one budget, plus at most one oversized file".
-fn batch_ranges(sizes: &[u64], budget: u64) -> Vec<std::ops::Range<usize>> {
+/// A mapped file's bytes never reach the heap, so charging it its own length
+/// against the heap budget is charging for memory the build does not allocate.
+/// What it does cost is its extracted trigram map, and that is bounded by the
+/// number of *distinct* trigrams — at most 16.7M, and in practice saturating
+/// long before file size does. Saturating the charge keeps that real cost
+/// bounded while letting a batch hold enough large files to fill the pool.
+const MAPPED_BATCH_CHARGE: u64 = 2 * 1024 * 1024;
+
+/// Ceiling on mapped bytes one batch may put in flight.
+///
+/// Mapped pages are file-backed and reclaimable, so they are not the same
+/// liability as heap, but they are still resident: a batch of large files maps
+/// all of them at once, and the process working set follows. This is the second
+/// half of the bound — the heap budget alone would let a batch of 32 MiB files
+/// map 64 MiB *per worker*.
+const MAPPED_BATCH_BYTES: u64 = 256 * 1024 * 1024;
+
+/// What one file costs a batch, split by where the bytes live.
+#[derive(Clone, Copy, Default)]
+struct BatchCharge {
+    /// Charge against the heap budget: the read buffer for a small file, or the
+    /// saturating stand-in for a mapped file's extracted trigram map.
+    heap: u64,
+    /// Charge against the mapped budget; zero for a file that is read.
+    mapped: u64,
+}
+
+fn batch_charge(size: u64) -> BatchCharge {
+    if size >= MMAP_MIN_BYTES {
+        BatchCharge {
+            heap: size.min(MAPPED_BATCH_CHARGE),
+            mapped: size,
+        }
+    } else {
+        BatchCharge {
+            heap: size,
+            mapped: 0,
+        }
+    }
+}
+
+/// Charge for a file whose size could not be read.
+///
+/// An unknown size counts as a whole batch rather than as zero. A file that
+/// failed to stat may still read, and calling it empty would both let it slip
+/// into an already-full batch and route it to the heap instead of a map —
+/// losing the bound precisely for the file whose size is unknown.
+const UNKNOWN_SIZE_CHARGE: BatchCharge = BatchCharge {
+    heap: INDEX_BUILD_BATCH_BYTES,
+    mapped: MAPPED_BATCH_BYTES,
+};
+
+/// Split a file list into batches bounded by file count, heap bytes and mapped
+/// bytes, given each file's charge in walk order.
+///
+/// A file whose charge alone exceeds a budget forms a batch of its own rather
+/// than being split, so the bound is "one budget, plus at most one oversized
+/// file".
+fn batch_ranges(charges: &[BatchCharge], budget: u64) -> Vec<std::ops::Range<usize>> {
     let mut ranges = Vec::new();
     let mut start = 0usize;
-    let mut bytes = 0u64;
-    for (i, &size) in sizes.iter().enumerate() {
-        let full = i - start >= INDEX_BUILD_BATCH_SIZE || bytes.saturating_add(size) > budget;
+    let mut heap = 0u64;
+    let mut mapped = 0u64;
+    for (i, charge) in charges.iter().enumerate() {
+        let full = i - start >= INDEX_BUILD_BATCH_SIZE
+            || heap.saturating_add(charge.heap) > budget
+            || mapped.saturating_add(charge.mapped) > MAPPED_BATCH_BYTES;
         if i > start && full {
             ranges.push(start..i);
             start = i;
-            bytes = 0;
+            heap = 0;
+            mapped = 0;
         }
-        bytes = bytes.saturating_add(size);
+        heap = heap.saturating_add(charge.heap);
+        mapped = mapped.saturating_add(charge.mapped);
     }
-    if start < sizes.len() {
-        ranges.push(start..sizes.len());
+    if start < charges.len() {
+        ranges.push(start..charges.len());
     }
     ranges
+}
+
+/// Per-file sizes for reading, paired with their charges against the batch
+/// budgets.
+fn batch_sizes_and_charges(files: &[std::path::PathBuf]) -> (Vec<u64>, Vec<BatchCharge>) {
+    files
+        .par_iter()
+        .map(
+            |path| match std::fs::metadata(path).map(|meta| meta.len()) {
+                Ok(size) => (size, batch_charge(size)),
+                Err(_) => (INDEX_BUILD_BATCH_BYTES, UNKNOWN_SIZE_CHARGE),
+            },
+        )
+        .unzip()
 }
 
 /// Smallest file worth memory-mapping instead of reading.
@@ -262,7 +341,7 @@ enum FileBytes {
     Mapped(memmap2::Mmap),
 }
 
-type ExtractedFile = (String, HashMap<u32, TrigramMasks>);
+type ExtractedFile = (String, trigram::TrigramMaskMap);
 
 impl std::ops::Deref for FileBytes {
     type Target = [u8];
@@ -359,22 +438,9 @@ pub fn build_index_with_options(
 
     // The walk already stats every entry but discards the size, so recover it
     // here rather than widening WalkResult into the search and serve paths.
-    //
-    // An unknown size counts as a whole batch rather than as zero. A file that
-    // failed to stat may still read, and calling it empty would both let it
-    // slip into an already-full batch and route it to the heap instead of a
-    // map — losing the bound precisely for the file whose size is unknown.
-    let sizes: Vec<u64> = walk
-        .files
-        .par_iter()
-        .map(|path| {
-            std::fs::metadata(path)
-                .map(|m| m.len())
-                .unwrap_or(INDEX_BUILD_BATCH_BYTES)
-        })
-        .collect();
+    let (sizes, charges) = batch_sizes_and_charges(&walk.files);
 
-    for range in batch_ranges(&sizes, INDEX_BUILD_BATCH_BYTES) {
+    for range in batch_ranges(&charges, INDEX_BUILD_BATCH_BYTES) {
         let batch = &walk.files[range.clone()];
         let batch_sizes = &sizes[range];
         let batch_data: Vec<ExtractedFile> = batch
@@ -474,18 +540,11 @@ pub fn build_index_for_files(
     let root = std::fs::canonicalize(root)?;
     std::fs::create_dir_all(index_dir)?;
 
-    let sizes: Vec<u64> = files
-        .par_iter()
-        .map(|path| {
-            std::fs::metadata(path)
-                .map(|m| m.len())
-                .unwrap_or(INDEX_BUILD_BATCH_BYTES)
-        })
-        .collect();
+    let (sizes, charges) = batch_sizes_and_charges(files);
     let mut file_id_map: Vec<(u32, String)> = Vec::with_capacity(files.len());
     let mut sorter = ExternalSorter::new(index_dir, buffer_bytes);
 
-    for range in batch_ranges(&sizes, INDEX_BUILD_BATCH_BYTES) {
+    for range in batch_ranges(&charges, INDEX_BUILD_BATCH_BYTES) {
         let batch = &files[range.clone()];
         let batch_sizes = &sizes[range];
         let batch_data: Result<Vec<Option<ExtractedFile>>> = batch
@@ -1197,18 +1256,57 @@ mod tests {
 
     const MB: u64 = 1024 * 1024;
 
+    fn charges(sizes: &[u64]) -> Vec<BatchCharge> {
+        sizes.iter().copied().map(batch_charge).collect()
+    }
+
     #[test]
-    fn batches_are_bounded_by_cumulative_bytes() {
-        // Five 20 MB files against a 64 MB budget: three fit, then the rest.
-        let sizes = vec![20 * MB; 5];
-        assert_eq!(batch_ranges(&sizes, 64 * MB), vec![0..3, 3..5]);
+    fn batches_are_bounded_by_cumulative_heap_bytes() {
+        // Files below the mapping threshold are read, so their whole length is
+        // heap: five 900 KiB reads against a 2 MiB budget fit two at a time.
+        let charges = charges(&[900 * 1024; 5]);
+        assert_eq!(batch_ranges(&charges, 2 * MB), vec![0..2, 2..4, 4..5]);
+    }
+
+    #[test]
+    fn large_mapped_files_still_fill_a_batch() {
+        // Regression: charging a mapped file its own length against the heap
+        // budget made a batch of large files degenerate to one or two, leaving
+        // every worker but one idle. Mapped bytes never reach the heap, so only
+        // the mapped budget bounds these: 256 MiB / 32 MiB is eight per batch.
+        let charges = charges(&[32 * MB; 16]);
+        assert_eq!(
+            batch_ranges(&charges, INDEX_BUILD_BATCH_BYTES),
+            vec![0..8, 8..16]
+        );
+    }
+
+    #[test]
+    fn mapped_bytes_in_flight_stay_bounded() {
+        // The other half of the bound: a batch may not map more than the mapped
+        // budget, whatever mix of sizes it is handed.
+        let sizes: Vec<u64> = (0..200).map(|i| (i % 9 + 1) * 8 * MB).collect();
+        let charges = charges(&sizes);
+        for range in batch_ranges(&charges, INDEX_BUILD_BATCH_BYTES) {
+            let single = range.end - range.start == 1;
+            let mapped: u64 = charges[range.clone()].iter().map(|c| c.mapped).sum();
+            let heap: u64 = charges[range.clone()].iter().map(|c| c.heap).sum();
+            assert!(
+                single || mapped <= MAPPED_BATCH_BYTES,
+                "batch {range:?} maps {mapped} bytes"
+            );
+            assert!(
+                single || heap <= INDEX_BUILD_BATCH_BYTES,
+                "batch {range:?} reads {heap} bytes"
+            );
+        }
     }
 
     #[test]
     fn batches_are_still_bounded_by_file_count() {
-        // Tiny files never reach the byte budget, so the count bound applies.
-        let sizes = vec![1u64; INDEX_BUILD_BATCH_SIZE * 2 + 5];
-        let ranges = batch_ranges(&sizes, 64 * MB);
+        // Tiny files never reach either byte budget, so the count bound applies.
+        let charges = charges(&[1u64; INDEX_BUILD_BATCH_SIZE * 2 + 5]);
+        let ranges = batch_ranges(&charges, 64 * MB);
         assert_eq!(ranges.len(), 3);
         assert_eq!(ranges[0], 0..INDEX_BUILD_BATCH_SIZE);
     }
@@ -1216,8 +1314,11 @@ mod tests {
     #[test]
     fn a_file_larger_than_the_budget_gets_its_own_batch() {
         // The oversized file is never split, and never drags neighbours along.
-        let sizes = vec![MB, 500 * MB, MB];
-        assert_eq!(batch_ranges(&sizes, 64 * MB), vec![0..1, 1..2, 2..3]);
+        let charges = charges(&[MB, 500 * MB, MB]);
+        assert_eq!(
+            batch_ranges(&charges, INDEX_BUILD_BATCH_BYTES),
+            vec![0..1, 1..2, 2..3]
+        );
     }
 
     #[test]
@@ -1225,14 +1326,18 @@ mod tests {
         // A failed `metadata()` is recorded as a whole budget rather than as
         // zero, so the unstattable file is isolated instead of being waved into
         // a full batch as if it were empty.
-        let sizes = vec![MB, 64 * MB, MB];
-        assert_eq!(batch_ranges(&sizes, 64 * MB), vec![0..1, 1..2, 2..3]);
+        let charges = vec![batch_charge(MB), UNKNOWN_SIZE_CHARGE, batch_charge(MB)];
+        assert_eq!(
+            batch_ranges(&charges, INDEX_BUILD_BATCH_BYTES),
+            vec![0..1, 1..2, 2..3]
+        );
     }
 
     #[test]
     fn batches_cover_every_file_exactly_once() {
         let sizes: Vec<u64> = (0..500).map(|i| (i as u64 % 7) * 9 * MB).collect();
-        let ranges = batch_ranges(&sizes, 64 * MB);
+        let charges = charges(&sizes);
+        let ranges = batch_ranges(&charges, 64 * MB);
         let mut next = 0usize;
         for range in &ranges {
             assert_eq!(range.start, next, "gap or overlap between batches");

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -90,10 +90,6 @@ pub struct BuildOptions {
     /// [`IndexStrategy::InMemory`].
     pub buffer_bytes: usize,
     /// Skip files larger than this. `None` indexes files of any size.
-    ///
-    /// Indexing every byte of a huge repository is expensive, so the default
-    /// keeps a cap — but searching must be able to raise it, otherwise large
-    /// files are invisible to indexed queries.
     pub max_file_size: Option<u64>,
 }
 
@@ -266,6 +262,8 @@ enum FileBytes {
     Mapped(memmap2::Mmap),
 }
 
+type ExtractedFile = (String, HashMap<u32, TrigramMasks>);
+
 impl std::ops::Deref for FileBytes {
     type Target = [u8];
 
@@ -282,7 +280,7 @@ impl std::ops::Deref for FileBytes {
 ///
 /// Falls back to reading whenever mapping is unavailable, so a filesystem that
 /// cannot map still indexes correctly.
-fn read_for_index(path: &Path, size: u64) -> Option<FileBytes> {
+fn read_for_index(path: &Path, size: u64) -> std::io::Result<FileBytes> {
     if size >= MMAP_MIN_BYTES {
         // SAFETY: the map is read-only and owned by the returned value, which
         // is dropped once the file's trigrams have been extracted. A concurrent
@@ -292,10 +290,10 @@ fn read_for_index(path: &Path, size: u64) -> Option<FileBytes> {
         let mapped =
             std::fs::File::open(path).and_then(|file| unsafe { memmap2::Mmap::map(&file) });
         if let Ok(map) = mapped {
-            return Some(FileBytes::Mapped(map));
+            return Ok(FileBytes::Mapped(map));
         }
     }
-    std::fs::read(path).ok().map(FileBytes::Read)
+    std::fs::read(path).map(FileBytes::Read)
 }
 
 /// Build a trigram index, choosing how postings are accumulated.
@@ -379,11 +377,11 @@ pub fn build_index_with_options(
     for range in batch_ranges(&sizes, INDEX_BUILD_BATCH_BYTES) {
         let batch = &walk.files[range.clone()];
         let batch_sizes = &sizes[range];
-        let batch_data: Vec<(String, HashMap<u32, TrigramMasks>)> = batch
+        let batch_data: Vec<ExtractedFile> = batch
             .par_iter()
             .zip(batch_sizes.par_iter())
             .filter_map(|(path, &size)| {
-                let data = read_for_index(path, size)?;
+                let data = read_for_index(path, size).ok()?;
                 let text = crate::encoding::decode_for_index(&data);
                 if trigram::is_binary(&text) {
                     binary_skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -455,6 +453,84 @@ pub fn build_index_with_options(
         gitignore_files,
         ignore_files,
     })
+}
+
+/// Build an external-sort index for an exact list of absolute file paths.
+///
+/// This is used by `tgrep serve` to build a bounded delta for files that are
+/// absent from an otherwise-complete index. It deliberately skips the directory
+/// walk and filestamp write: the caller already has both from its stale-state
+/// scan and publishes the complete stamp set with the merged index.
+///
+/// Returns the number of text files written. Files that become unreadable or
+/// binary after the stale scan are omitted, matching a normal index build.
+pub fn build_index_for_files(
+    root: &Path,
+    index_dir: &Path,
+    files: &[std::path::PathBuf],
+    buffer_bytes: usize,
+) -> Result<usize> {
+    let input_root = root;
+    let root = std::fs::canonicalize(root)?;
+    std::fs::create_dir_all(index_dir)?;
+
+    let sizes: Vec<u64> = files
+        .par_iter()
+        .map(|path| {
+            std::fs::metadata(path)
+                .map(|m| m.len())
+                .unwrap_or(INDEX_BUILD_BATCH_BYTES)
+        })
+        .collect();
+    let mut file_id_map: Vec<(u32, String)> = Vec::with_capacity(files.len());
+    let mut sorter = ExternalSorter::new(index_dir, buffer_bytes);
+
+    for range in batch_ranges(&sizes, INDEX_BUILD_BATCH_BYTES) {
+        let batch = &files[range.clone()];
+        let batch_sizes = &sizes[range];
+        let batch_data: Result<Vec<Option<ExtractedFile>>> = batch
+            .par_iter()
+            .zip(batch_sizes.par_iter())
+            .map(|(path, &size)| {
+                let data = read_for_index(path, size).map_err(|error| {
+                    Error::Io(std::io::Error::new(
+                        error.kind(),
+                        format!("{}: {error}", path.display()),
+                    ))
+                })?;
+                let text = crate::encoding::decode_for_index(&data);
+                if trigram::is_binary(&text) {
+                    return Ok(None);
+                }
+                let rel = path
+                    .strip_prefix(&root)
+                    .or_else(|_| path.strip_prefix(input_root))
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                Ok(Some((rel, trigram::extract_merged_masks(&text))))
+            })
+            .collect();
+
+        for (path, per_tri) in batch_data?.into_iter().flatten() {
+            let file_id = u32::try_from(file_id_map.len()).map_err(|_| {
+                Error::IndexCorrupted("file count exceeds the u32 file-id limit".into())
+            })?;
+            file_id_map.push((file_id, path));
+            sorter.push_file(file_id, per_tri)?;
+        }
+    }
+
+    let (trigram_count, _) = sorter.write_postings(index_dir)?;
+    write_files_and_meta(
+        index_dir,
+        &root,
+        file_id_map.len(),
+        file_id_map.iter().map(|(_, path)| path.as_str()),
+        trigram_count,
+        Some(true),
+    )?;
+    Ok(file_id_map.len())
 }
 
 /// Return the default index directory for a given repo root.
@@ -865,6 +941,208 @@ pub fn append_overlay_to_index(
         out_dir,
         root,
         base as usize + overlay_paths.len(),
+        paths,
+        trigram_count,
+        Some(complete),
+    )
+}
+
+/// Stream-merge replacements and deletions into an existing index.
+///
+/// `delta` contains every new or replacement file. `removed_paths` identifies
+/// reader files to omit; replacement paths therefore appear in both
+/// `removed_paths` and `delta`. Reader file IDs are compacted through a dense
+/// `u32` remap while each posting list is streamed, so heap use is O(files)
+/// rather than O(all postings).
+pub fn merge_index_with_delta(
+    root: &Path,
+    out_dir: &Path,
+    reader: &IndexReader,
+    delta: &IndexReader,
+    removed_paths: &std::collections::HashSet<String>,
+    complete: bool,
+) -> Result<()> {
+    let append_only = removed_paths.is_empty();
+    std::fs::create_dir_all(out_dir)?;
+
+    const DROPPED: u32 = u32::MAX;
+    let mut next_id = 0u32;
+    let mut reader_id_map = Vec::with_capacity(reader.num_files());
+    for path in reader.all_paths() {
+        if removed_paths.contains(path) {
+            reader_id_map.push(DROPPED);
+        } else {
+            reader_id_map.push(next_id);
+            next_id = next_id.checked_add(1).ok_or_else(|| {
+                Error::IndexCorrupted("file count exceeds the u32 file-id limit".into())
+            })?;
+        }
+    }
+    let delta_base = next_id;
+    let total_files = (delta_base as usize)
+        .checked_add(delta.num_files())
+        .ok_or_else(|| Error::IndexCorrupted("file count overflow".into()))?;
+    u32::try_from(total_files)
+        .map_err(|_| Error::IndexCorrupted("file count exceeds the u32 file-id limit".into()))?;
+
+    let mut postings_file =
+        std::io::BufWriter::new(std::fs::File::create(out_dir.join("index.bin"))?);
+    let mut lookup_file =
+        std::io::BufWriter::new(std::fs::File::create(out_dir.join("lookup.bin"))?);
+    let mut lookup_scratch =
+        Vec::with_capacity(LOOKUP_WRITE_CHUNK_ENTRIES * ondisk::LOOKUP_ENTRY_SIZE);
+    let mut posting_scratch =
+        Vec::with_capacity(POSTING_WRITE_CHUNK_ENTRIES * ondisk::POSTING_ENTRY_SIZE);
+
+    let reader_trigram_count = reader.num_trigrams();
+    let delta_trigram_count = delta.num_trigrams();
+    let mut ri = 0usize;
+    let mut di = 0usize;
+    let mut offset = 0u64;
+    let mut trigram_count = 0usize;
+
+    while ri < reader_trigram_count || di < delta_trigram_count {
+        let reader_next = (ri < reader_trigram_count)
+            .then(|| reader.nth_trigram_raw(ri))
+            .flatten();
+        if ri < reader_trigram_count && reader_next.is_none() {
+            return Err(Error::IndexCorrupted(format!(
+                "reader trigram entry {ri} of {reader_trigram_count} has unreadable postings"
+            )));
+        }
+        let delta_next = (di < delta_trigram_count)
+            .then(|| delta.nth_trigram_raw(di))
+            .flatten();
+        if di < delta_trigram_count && delta_next.is_none() {
+            return Err(Error::IndexCorrupted(format!(
+                "delta trigram entry {di} of {delta_trigram_count} has unreadable postings"
+            )));
+        }
+
+        let (trigram, reader_bytes, delta_bytes) = match (reader_next, delta_next) {
+            (Some((rt, rbytes)), Some((dt, dbytes))) => match rt.cmp(&dt) {
+                std::cmp::Ordering::Less => {
+                    ri += 1;
+                    (rt, Some(rbytes), None)
+                }
+                std::cmp::Ordering::Greater => {
+                    di += 1;
+                    (dt, None, Some(dbytes))
+                }
+                std::cmp::Ordering::Equal => {
+                    ri += 1;
+                    di += 1;
+                    (rt, Some(rbytes), Some(dbytes))
+                }
+            },
+            (Some((rt, rbytes)), None) => {
+                ri += 1;
+                (rt, Some(rbytes), None)
+            }
+            (None, Some((dt, dbytes))) => {
+                di += 1;
+                (dt, None, Some(dbytes))
+            }
+            (None, None) => break,
+        };
+
+        let mut reader_len = reader_bytes.map_or(0, |bytes| {
+            usize::from(append_only) * (bytes.len() / ondisk::POSTING_ENTRY_SIZE)
+        });
+        if !append_only && let Some(bytes) = reader_bytes {
+            for raw in bytes.chunks_exact(ondisk::POSTING_ENTRY_SIZE) {
+                let old_id = u32::from_le_bytes(raw[0..4].try_into().expect("four-byte file id"));
+                let new_id = *reader_id_map.get(old_id as usize).ok_or_else(|| {
+                    Error::IndexCorrupted(format!(
+                        "posting for trigram {trigram} references missing file id {old_id}"
+                    ))
+                })?;
+                reader_len += usize::from(new_id != DROPPED);
+            }
+        }
+        let delta_len = delta_bytes.map_or(0, |bytes| bytes.len() / ondisk::POSTING_ENTRY_SIZE);
+        let length = u32::try_from(
+            reader_len
+                .checked_add(delta_len)
+                .ok_or_else(|| Error::IndexCorrupted("posting list length overflow".into()))?,
+        )
+        .map_err(|_| {
+            Error::IndexCorrupted(format!(
+                "posting list for trigram {trigram} exceeds the u32 length limit"
+            ))
+        })?;
+        if length == 0 {
+            continue;
+        }
+
+        write_lookup_entry(
+            &mut lookup_file,
+            LookupEntry {
+                trigram,
+                offset,
+                length,
+            },
+            &mut lookup_scratch,
+        )?;
+        if let Some(bytes) = reader_bytes {
+            if append_only {
+                postings_file.write_all(bytes)?;
+            } else {
+                for chunk in bytes.chunks(POSTING_WRITE_CHUNK_ENTRIES * ondisk::POSTING_ENTRY_SIZE)
+                {
+                    posting_scratch.clear();
+                    for raw in chunk.chunks_exact(ondisk::POSTING_ENTRY_SIZE) {
+                        let old_id =
+                            u32::from_le_bytes(raw[0..4].try_into().expect("four-byte file id"));
+                        let new_id = reader_id_map[old_id as usize];
+                        if new_id != DROPPED {
+                            posting_scratch.extend_from_slice(&new_id.to_le_bytes());
+                            posting_scratch.extend_from_slice(&raw[4..]);
+                        }
+                    }
+                    postings_file.write_all(&posting_scratch)?;
+                }
+            }
+        }
+        if let Some(bytes) = delta_bytes {
+            for chunk in bytes.chunks(POSTING_WRITE_CHUNK_ENTRIES * ondisk::POSTING_ENTRY_SIZE) {
+                posting_scratch.clear();
+                for raw in chunk.chunks_exact(ondisk::POSTING_ENTRY_SIZE) {
+                    let file_id =
+                        u32::from_le_bytes(raw[0..4].try_into().expect("four-byte file id"));
+                    if file_id as usize >= delta.num_files() {
+                        return Err(Error::IndexCorrupted(format!(
+                            "delta posting references missing file id {file_id}"
+                        )));
+                    }
+                    let file_id = delta_base.checked_add(file_id).ok_or_else(|| {
+                        Error::IndexCorrupted("delta file id overflow beyond u32".into())
+                    })?;
+                    posting_scratch.extend_from_slice(&file_id.to_le_bytes());
+                    posting_scratch.extend_from_slice(&raw[4..]);
+                }
+                postings_file.write_all(&posting_scratch)?;
+            }
+        }
+
+        offset += length as u64 * ondisk::POSTING_ENTRY_SIZE as u64;
+        trigram_count += 1;
+    }
+
+    flush_lookup_entries(&mut lookup_file, &mut lookup_scratch)?;
+    postings_file.flush()?;
+    lookup_file.flush()?;
+
+    let paths = reader
+        .all_paths()
+        .iter()
+        .filter(|path| !removed_paths.contains(path.as_str()))
+        .map(String::as_str)
+        .chain(delta.all_paths().iter().map(String::as_str));
+    write_files_and_meta(
+        out_dir,
+        root,
+        total_files,
         paths,
         trigram_count,
         Some(complete),
@@ -1408,6 +1686,195 @@ mod tests {
         let mut paths: Vec<&str> = ids.iter().filter_map(|&id| merged.file_path(id)).collect();
         paths.sort_unstable();
         assert_eq!(paths, vec!["src/a.txt", "src/b.txt", "src/c.txt"]);
+    }
+
+    #[test]
+    fn exact_file_delta_fails_if_an_input_cannot_be_read() {
+        let repo = tempfile::tempdir().unwrap();
+        let delta = tempfile::tempdir().unwrap();
+        let missing = repo.path().join("vanished.txt");
+
+        let error = build_index_for_files(
+            repo.path(),
+            delta.path(),
+            &[missing],
+            DEFAULT_INDEX_BUFFER_BYTES,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("vanished.txt"));
+    }
+
+    #[test]
+    fn exact_file_delta_streams_onto_an_existing_index() {
+        let repo = tempfile::tempdir().unwrap();
+        let src = repo.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("a.txt"), "hello world\nneedle one\n").unwrap();
+        std::fs::write(src.join("b.txt"), "needle two\nother content\n").unwrap();
+
+        let base_dir = tempfile::tempdir().unwrap();
+        build_index(repo.path(), Some(base_dir.path()), false, false, &[]).unwrap();
+        let base_reader = IndexReader::open(base_dir.path()).unwrap();
+
+        let c = src.join("c.txt");
+        let d = src.join("d.txt");
+        let binary = src.join("binary.dat");
+        std::fs::write(&c, "Needle three\n").unwrap();
+        std::fs::write(&d, "zzz unique\n").unwrap();
+        std::fs::write(&binary, b"text prefix\0binary tail").unwrap();
+
+        let delta_dir = tempfile::tempdir().unwrap();
+        let delta_count =
+            build_index_for_files(repo.path(), delta_dir.path(), &[c, d, binary], 1).unwrap();
+        assert_eq!(delta_count, 2, "binary files must stay out of the delta");
+        let delta_reader = IndexReader::open(delta_dir.path()).unwrap();
+
+        let merged_dir = tempfile::tempdir().unwrap();
+        merge_index_with_delta(
+            repo.path(),
+            merged_dir.path(),
+            &base_reader,
+            &delta_reader,
+            &std::collections::HashSet::new(),
+            true,
+        )
+        .unwrap();
+
+        let merged = IndexReader::open(merged_dir.path()).unwrap();
+        merged.validate_lookup().unwrap();
+        assert_eq!(merged.num_files(), 4);
+        assert_eq!(merged.file_path(0), base_reader.file_path(0));
+        assert_eq!(merged.file_path(1), base_reader.file_path(1));
+        assert_eq!(merged.file_path(2), Some("src/c.txt"));
+        assert_eq!(merged.file_path(3), Some("src/d.txt"));
+
+        let needle = crate::trigram::hash(b'n', b'e', b'e');
+        let entries = merged.lookup_trigram_with_masks(needle);
+        let mut paths: Vec<&str> = entries
+            .iter()
+            .filter_map(|entry| merged.file_path(entry.file_id))
+            .collect();
+        paths.sort_unstable();
+        assert_eq!(
+            paths,
+            vec!["src/a.txt", "src/b.txt", "src/c.txt"],
+            "delta postings must be offset and merged with base postings"
+        );
+        let c_entry = entries
+            .iter()
+            .find(|entry| merged.file_path(entry.file_id) == Some("src/c.txt"))
+            .unwrap();
+        assert_ne!(
+            (c_entry.loc_mask, c_entry.next_mask),
+            (u8::MAX, u8::MAX),
+            "the external delta must preserve real masks"
+        );
+    }
+
+    #[test]
+    fn streamed_delta_can_replace_and_delete_reader_files() {
+        let repo = tempfile::tempdir().unwrap();
+        let src = repo.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("a.txt"), "keep alpha needle\n").unwrap();
+        std::fs::write(src.join("b.txt"), "old beta needle\n").unwrap();
+        std::fs::write(src.join("c.txt"), "delete gamma needle\n").unwrap();
+
+        let base_dir = tempfile::tempdir().unwrap();
+        build_index(repo.path(), Some(base_dir.path()), false, false, &[]).unwrap();
+        let base_reader = IndexReader::open(base_dir.path()).unwrap();
+
+        let b = src.join("b.txt");
+        let d = src.join("d.txt");
+        std::fs::write(&b, "replacement beta unique\n").unwrap();
+        std::fs::remove_file(src.join("c.txt")).unwrap();
+        std::fs::write(&d, "new delta unique\n").unwrap();
+
+        let delta_dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            build_index_for_files(repo.path(), delta_dir.path(), &[b, d], 1).unwrap(),
+            2
+        );
+        let delta_reader = IndexReader::open(delta_dir.path()).unwrap();
+        let removed =
+            std::collections::HashSet::from(["src/b.txt".to_string(), "src/c.txt".to_string()]);
+
+        let merged_dir = tempfile::tempdir().unwrap();
+        merge_index_with_delta(
+            repo.path(),
+            merged_dir.path(),
+            &base_reader,
+            &delta_reader,
+            &removed,
+            true,
+        )
+        .unwrap();
+
+        let merged = IndexReader::open(merged_dir.path()).unwrap();
+        merged.validate_lookup().unwrap();
+        assert_eq!(merged.num_files(), 3);
+        assert_eq!(merged.file_path(0), Some("src/a.txt"));
+        assert_eq!(merged.file_path(1), Some("src/b.txt"));
+        assert_eq!(merged.file_path(2), Some("src/d.txt"));
+        assert!(
+            merged.all_paths().iter().all(|path| path != "src/c.txt"),
+            "deleted reader paths must not survive the merge"
+        );
+
+        let needle = crate::trigram::hash(b'n', b'e', b'e');
+        let needle_paths: Vec<&str> = merged
+            .lookup_trigram(needle)
+            .iter()
+            .filter_map(|&id| merged.file_path(id))
+            .collect();
+        assert_eq!(
+            needle_paths,
+            vec!["src/a.txt"],
+            "the replacement must not retain the old reader posting"
+        );
+        let unique = crate::trigram::hash(b'u', b'n', b'i');
+        let mut unique_paths: Vec<&str> = merged
+            .lookup_trigram(unique)
+            .iter()
+            .filter_map(|&id| merged.file_path(id))
+            .collect();
+        unique_paths.sort_unstable();
+        assert_eq!(unique_paths, vec!["src/b.txt", "src/d.txt"]);
+    }
+
+    #[test]
+    fn streamed_delta_supports_deletion_without_new_files() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("keep.txt"), "keep needle\n").unwrap();
+        std::fs::write(repo.path().join("delete.txt"), "delete needle\n").unwrap();
+
+        let base_dir = tempfile::tempdir().unwrap();
+        build_index(repo.path(), Some(base_dir.path()), false, false, &[]).unwrap();
+        let base_reader = IndexReader::open(base_dir.path()).unwrap();
+
+        let delta_dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            build_index_for_files(repo.path(), delta_dir.path(), &[], 1).unwrap(),
+            0
+        );
+        let delta_reader = IndexReader::open(delta_dir.path()).unwrap();
+        let removed = std::collections::HashSet::from(["delete.txt".to_string()]);
+
+        let merged_dir = tempfile::tempdir().unwrap();
+        merge_index_with_delta(
+            repo.path(),
+            merged_dir.path(),
+            &base_reader,
+            &delta_reader,
+            &removed,
+            true,
+        )
+        .unwrap();
+
+        let merged = IndexReader::open(merged_dir.path()).unwrap();
+        merged.validate_lookup().unwrap();
+        assert_eq!(merged.num_files(), 1);
+        assert_eq!(merged.file_path(0), Some("keep.txt"));
     }
 
     #[test]

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -521,6 +521,26 @@ pub fn build_index_with_options(
     })
 }
 
+/// Outcome of [`build_index_for_files`].
+#[derive(Debug, Default)]
+pub struct FileDeltaOutcome {
+    /// Number of text files written into the delta index.
+    pub indexed: usize,
+    /// Paths that could not be read, and are therefore absent from the delta.
+    ///
+    /// The caller must drop these from the filestamp set it publishes. A stamp
+    /// asserts "this file is indexed at this version"; publishing one for a
+    /// file that was skipped makes the miss permanent, because every later
+    /// reconcile sees a current stamp and never revisits the file. Withholding
+    /// the stamp instead leaves the file looking new, so the next pass retries
+    /// it — which is what should happen for a transient lock or permission
+    /// error.
+    ///
+    /// Binary files are *not* listed here. They are skipped deliberately and
+    /// permanently, so their stamps should be published as normal.
+    pub unreadable: Vec<std::path::PathBuf>,
+}
+
 /// Build an external-sort index for an exact list of absolute file paths.
 ///
 /// This is used by `tgrep serve` to build a bounded delta for files that are
@@ -528,14 +548,18 @@ pub fn build_index_with_options(
 /// walk and filestamp write: the caller already has both from its stale-state
 /// scan and publishes the complete stamp set with the merged index.
 ///
-/// Returns the number of text files written. Files that become unreadable or
-/// binary after the stale scan are omitted, matching a normal index build.
+/// Files that become unreadable or binary after the stale scan are omitted
+/// rather than fatal, matching a normal index build. Aborting instead would be
+/// far worse than it looks: for `tgrep serve` this delta is how the index is
+/// persisted, so a single locked or deleted file would fail every save attempt
+/// for the life of the process and no work would ever reach disk. See
+/// [`FileDeltaOutcome::unreadable`] for the caller's obligation.
 pub fn build_index_for_files(
     root: &Path,
     index_dir: &Path,
     files: &[std::path::PathBuf],
     buffer_bytes: usize,
-) -> Result<usize> {
+) -> Result<FileDeltaOutcome> {
     let input_root = root;
     let root = std::fs::canonicalize(root)?;
     std::fs::create_dir_all(index_dir)?;
@@ -543,23 +567,25 @@ pub fn build_index_for_files(
     let (sizes, charges) = batch_sizes_and_charges(files);
     let mut file_id_map: Vec<(u32, String)> = Vec::with_capacity(files.len());
     let mut sorter = ExternalSorter::new(index_dir, buffer_bytes);
+    let mut unreadable: Vec<std::path::PathBuf> = Vec::new();
 
     for range in batch_ranges(&charges, INDEX_BUILD_BATCH_BYTES) {
         let batch = &files[range.clone()];
         let batch_sizes = &sizes[range];
-        let batch_data: Result<Vec<Option<ExtractedFile>>> = batch
+        let batch_data: Vec<std::result::Result<ExtractedFile, std::path::PathBuf>> = batch
             .par_iter()
             .zip(batch_sizes.par_iter())
-            .map(|(path, &size)| {
-                let data = read_for_index(path, size).map_err(|error| {
-                    Error::Io(std::io::Error::new(
-                        error.kind(),
-                        format!("{}: {error}", path.display()),
-                    ))
-                })?;
+            .filter_map(|(path, &size)| {
+                let data = match read_for_index(path, size) {
+                    Ok(data) => data,
+                    Err(error) => {
+                        eprintln!("tgrep: skipping {}: {error}", path.display());
+                        return Some(Err(path.clone()));
+                    }
+                };
                 let text = crate::encoding::decode_for_index(&data);
                 if trigram::is_binary(&text) {
-                    return Ok(None);
+                    return None;
                 }
                 let rel = path
                     .strip_prefix(&root)
@@ -567,11 +593,18 @@ pub fn build_index_for_files(
                     .unwrap_or(path)
                     .to_string_lossy()
                     .replace('\\', "/");
-                Ok(Some((rel, trigram::extract_merged_masks(&text))))
+                Some(Ok((rel, trigram::extract_merged_masks(&text))))
             })
             .collect();
 
-        for (path, per_tri) in batch_data?.into_iter().flatten() {
+        for entry in batch_data {
+            let (path, per_tri) = match entry {
+                Ok(extracted) => extracted,
+                Err(skipped) => {
+                    unreadable.push(skipped);
+                    continue;
+                }
+            };
             let file_id = u32::try_from(file_id_map.len()).map_err(|_| {
                 Error::IndexCorrupted("file count exceeds the u32 file-id limit".into())
             })?;
@@ -589,7 +622,10 @@ pub fn build_index_for_files(
         trigram_count,
         Some(true),
     )?;
-    Ok(file_id_map.len())
+    Ok(FileDeltaOutcome {
+        indexed: file_id_map.len(),
+        unreadable,
+    })
 }
 
 /// Return the default index directory for a given repo root.
@@ -1793,20 +1829,58 @@ mod tests {
         assert_eq!(paths, vec!["src/a.txt", "src/b.txt", "src/c.txt"]);
     }
 
+    /// An unreadable input must not sink the whole delta. For `tgrep serve`
+    /// this build *is* index persistence, so aborting on one locked or
+    /// vanished file would stop anything from ever reaching disk. The file is
+    /// skipped and reported so the caller can withhold its stamp and retry.
     #[test]
-    fn exact_file_delta_fails_if_an_input_cannot_be_read() {
+    fn exact_file_delta_skips_and_reports_an_unreadable_input() {
         let repo = tempfile::tempdir().unwrap();
-        let delta = tempfile::tempdir().unwrap();
+        let readable = repo.path().join("present.txt");
+        std::fs::write(&readable, "needle one\n").unwrap();
         let missing = repo.path().join("vanished.txt");
+        let delta = tempfile::tempdir().unwrap();
 
-        let error = build_index_for_files(
+        let outcome = build_index_for_files(
             repo.path(),
             delta.path(),
-            &[missing],
+            &[readable, missing.clone()],
             DEFAULT_INDEX_BUFFER_BYTES,
         )
-        .unwrap_err();
-        assert!(error.to_string().contains("vanished.txt"));
+        .unwrap();
+
+        assert_eq!(
+            outcome.indexed, 1,
+            "the readable file must still be indexed"
+        );
+        assert_eq!(outcome.unreadable, vec![missing]);
+
+        // The delta is usable, not a half-written casualty of the failure.
+        let reader = IndexReader::open(delta.path()).unwrap();
+        assert_eq!(reader.num_files(), 1);
+        assert_eq!(reader.file_path(0), Some("present.txt"));
+    }
+
+    /// A binary file is skipped deliberately and permanently, so it must *not*
+    /// be reported as unreadable - doing so would make the caller re-read it
+    /// on every reconcile forever.
+    #[test]
+    fn exact_file_delta_does_not_report_binary_files_as_unreadable() {
+        let repo = tempfile::tempdir().unwrap();
+        let binary = repo.path().join("blob.bin");
+        std::fs::write(&binary, [0u8, 1, 2, 0, 3, 0]).unwrap();
+        let delta = tempfile::tempdir().unwrap();
+
+        let outcome = build_index_for_files(
+            repo.path(),
+            delta.path(),
+            &[binary],
+            DEFAULT_INDEX_BUFFER_BYTES,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.indexed, 0);
+        assert!(outcome.unreadable.is_empty());
     }
 
     #[test]
@@ -1829,8 +1903,9 @@ mod tests {
         std::fs::write(&binary, b"text prefix\0binary tail").unwrap();
 
         let delta_dir = tempfile::tempdir().unwrap();
-        let delta_count =
-            build_index_for_files(repo.path(), delta_dir.path(), &[c, d, binary], 1).unwrap();
+        let delta_count = build_index_for_files(repo.path(), delta_dir.path(), &[c, d, binary], 1)
+            .unwrap()
+            .indexed;
         assert_eq!(delta_count, 2, "binary files must stay out of the delta");
         let delta_reader = IndexReader::open(delta_dir.path()).unwrap();
 
@@ -1897,7 +1972,9 @@ mod tests {
 
         let delta_dir = tempfile::tempdir().unwrap();
         assert_eq!(
-            build_index_for_files(repo.path(), delta_dir.path(), &[b, d], 1).unwrap(),
+            build_index_for_files(repo.path(), delta_dir.path(), &[b, d], 1)
+                .unwrap()
+                .indexed,
             2
         );
         let delta_reader = IndexReader::open(delta_dir.path()).unwrap();
@@ -1959,7 +2036,9 @@ mod tests {
 
         let delta_dir = tempfile::tempdir().unwrap();
         assert_eq!(
-            build_index_for_files(repo.path(), delta_dir.path(), &[], 1).unwrap(),
+            build_index_for_files(repo.path(), delta_dir.path(), &[], 1)
+                .unwrap()
+                .indexed,
             0
         );
         let delta_reader = IndexReader::open(delta_dir.path()).unwrap();

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -107,7 +107,7 @@ impl Default for BuildOptions {
             collect_gitignore_files: false,
             strategy: IndexStrategy::default(),
             buffer_bytes: external::DEFAULT_BUFFER_BYTES,
-            max_file_size: Some(walker::DEFAULT_MAX_FILE_SIZE),
+            max_file_size: walker::DEFAULT_MAX_FILE_SIZE,
         }
     }
 }
@@ -361,10 +361,19 @@ pub fn build_index_with_options(
 
     // The walk already stats every entry but discards the size, so recover it
     // here rather than widening WalkResult into the search and serve paths.
+    //
+    // An unknown size counts as a whole batch rather than as zero. A file that
+    // failed to stat may still read, and calling it empty would both let it
+    // slip into an already-full batch and route it to the heap instead of a
+    // map — losing the bound precisely for the file whose size is unknown.
     let sizes: Vec<u64> = walk
         .files
         .par_iter()
-        .map(|path| std::fs::metadata(path).map(|m| m.len()).unwrap_or(0))
+        .map(|path| {
+            std::fs::metadata(path)
+                .map(|m| m.len())
+                .unwrap_or(INDEX_BUILD_BATCH_BYTES)
+        })
         .collect();
 
     for range in batch_ranges(&sizes, INDEX_BUILD_BATCH_BYTES) {
@@ -930,6 +939,15 @@ mod tests {
     fn a_file_larger_than_the_budget_gets_its_own_batch() {
         // The oversized file is never split, and never drags neighbours along.
         let sizes = vec![MB, 500 * MB, MB];
+        assert_eq!(batch_ranges(&sizes, 64 * MB), vec![0..1, 1..2, 2..3]);
+    }
+
+    #[test]
+    fn a_file_whose_size_is_unknown_gets_its_own_batch() {
+        // A failed `metadata()` is recorded as a whole budget rather than as
+        // zero, so the unstattable file is isolated instead of being waved into
+        // a full batch as if it were empty.
+        let sizes = vec![MB, 64 * MB, MB];
         assert_eq!(batch_ranges(&sizes, 64 * MB), vec![0..1, 1..2, 2..3]);
     }
 

--- a/tgrep-core/src/encoding.rs
+++ b/tgrep-core/src/encoding.rs
@@ -208,9 +208,11 @@ pub fn decode_for_index(bytes: &[u8]) -> Cow<'_, [u8]> {
             if crate::trigram::is_binary(body) {
                 return Cow::Borrowed(body);
             }
-            // `lossy_utf8` is what the search path uses, so this produces the
-            // exact bytes a later search will match against.
-            Cow::Owned(lossy_utf8(body).0.into_bytes())
+            // `lossy_utf8_into` is the same repair the search path uses, so
+            // this produces the exact bytes a later search will match against.
+            // The fixups it can record are for mapping match offsets back to
+            // the original file, which indexing has no use for.
+            Cow::Owned(lossy_utf8_into(body, None).into_bytes())
         }
     }
 }
@@ -227,13 +229,36 @@ fn transcode(enc: &'static Encoding, bytes: &[u8]) -> String {
 /// The loop mirrors the standard library's: one `U+FFFD` per maximal invalid
 /// subsequence, so the text produced here is identical.
 fn lossy_utf8(bytes: &[u8]) -> (String, LossyFixups) {
-    let mut rest = match std::str::from_utf8(bytes) {
-        Ok(s) => return (s.to_string(), LossyFixups::default()),
-        Err(_) => bytes,
-    };
-
-    let mut out = String::with_capacity(bytes.len());
     let mut shifts = Vec::new();
+    let out = lossy_utf8_into(bytes, Some(&mut shifts));
+    (out, LossyFixups { shifts })
+}
+
+/// The repair loop, shared so the two callers cannot drift apart.
+///
+/// `shifts` is `None` for indexing, which only needs the repaired bytes. That
+/// is not just a micro-optimisation: one entry is recorded per repair, so a
+/// large file of single-byte-invalid text (a 135 MB Latin-1 log, say) builds
+/// tens of megabytes of offset table that indexing then drops on the floor.
+///
+/// The output is measured before it is filled. A `String` that starts at
+/// `bytes.len()` is *almost* big enough, so the first repair to overflow it
+/// triggers a doubling reallocation — turning a 135 MB decode into a 270 MB
+/// buffer with both halves live during the copy. Sizing it exactly costs one
+/// extra validation pass, which is SIMD-fast and far cheaper than that copy.
+fn lossy_utf8_into(bytes: &[u8], shifts: Option<&mut Vec<(usize, usize)>>) -> String {
+    if let Ok(s) = std::str::from_utf8(bytes) {
+        return s.to_string();
+    }
+
+    let (out_len, repairs) = lossy_utf8_shape(bytes);
+    let mut out = String::with_capacity(out_len);
+    let mut shifts = shifts;
+    if let Some(shifts) = shifts.as_deref_mut() {
+        shifts.reserve_exact(repairs);
+    }
+
+    let mut rest = bytes;
     let mut gained = 0usize;
     loop {
         let err = match std::str::from_utf8(rest) {
@@ -248,17 +273,46 @@ fn lossy_utf8(bytes: &[u8]) -> (String, LossyFixups) {
         // `None` means the input ended mid-sequence: everything left is one
         // replacement and there is nothing after it.
         let replaced = err.error_len().unwrap_or(rest.len() - valid);
-        shifts.push((out.len(), {
+        if let Some(shifts) = shifts.as_deref_mut() {
             gained += REPLACEMENT_LEN - replaced.min(REPLACEMENT_LEN);
-            gained
-        }));
+            shifts.push((out.len(), gained));
+        }
         out.push(char::REPLACEMENT_CHARACTER);
         match err.error_len() {
             Some(n) => rest = &rest[valid + n..],
             None => break,
         }
     }
-    (out, LossyFixups { shifts })
+    debug_assert_eq!(out.len(), out_len);
+    out
+}
+
+/// `(exact output length, number of replacements)` for [`lossy_utf8_into`].
+///
+/// Walks the input exactly as the repair loop does, so the two agree by
+/// construction; a `debug_assert` in the repair loop pins that agreement.
+fn lossy_utf8_shape(bytes: &[u8]) -> (usize, usize) {
+    let mut rest = bytes;
+    let mut len = 0usize;
+    let mut repairs = 0usize;
+    loop {
+        match std::str::from_utf8(rest) {
+            Ok(s) => {
+                len += s.len();
+                break;
+            }
+            Err(e) => {
+                let valid = e.valid_up_to();
+                len += valid + REPLACEMENT_LEN;
+                repairs += 1;
+                match e.error_len() {
+                    Some(n) => rest = &rest[valid + n..],
+                    None => break,
+                }
+            }
+        }
+    }
+    (len, repairs)
 }
 
 #[cfg(test)]
@@ -410,6 +464,44 @@ mod tests {
             indexed.windows(3).any(|w| w == "\u{FFFD}".as_bytes()),
             "the replacement character has to be indexable"
         );
+    }
+
+    #[test]
+    fn index_and_search_repairs_agree_on_every_invalid_shape() {
+        // The index repair skips the offset fixups the search repair records.
+        // Both walk the same loop so they cannot drift, but the exact-size
+        // pre-pass they now share has to agree with it for every shape of
+        // invalid input — including one truncated at EOF, where `error_len`
+        // is `None` and the walk stops early.
+        let cases: &[&[u8]] = &[
+            b"\xff",
+            b"\xffleading\n",
+            b"trailing\xff",
+            b"two \xff\xfe apart \xff\n",
+            b"adjacent \xff\xff\xff runs\n",
+            b"truncated 2-byte \xc3",
+            b"truncated 3-byte \xe2\x82",
+            b"truncated 4-byte \xf0\x9f\x92",
+            b"mixed \xc3\xa9 valid then \xff invalid\n",
+            "no repairs at all\n".as_bytes(),
+        ];
+        for raw in cases {
+            let indexed = decode_for_index(raw);
+            let searched = decode(raw, EncodingMode::Auto);
+            assert_eq!(
+                indexed.as_ref(),
+                searched.as_bytes(),
+                "index and search disagree on {raw:?}"
+            );
+            // Pins the pre-pass against the loop it sizes, which `debug_assert`
+            // only checks in debug builds.
+            let (predicted, repairs) = lossy_utf8_shape(raw);
+            let (repaired, fixups) = lossy_utf8(raw);
+            if std::str::from_utf8(raw).is_err() {
+                assert_eq!(predicted, repaired.len(), "bad length for {raw:?}");
+                assert_eq!(repairs, fixups.shifts.len(), "bad count for {raw:?}");
+            }
+        }
     }
 
     #[test]

--- a/tgrep-core/src/encoding.rs
+++ b/tgrep-core/src/encoding.rs
@@ -123,7 +123,11 @@ pub fn decode_owned_with_fixups(bytes: Vec<u8>, mode: EncodingMode) -> (String, 
 /// That is the only case where the caller's buffer is exactly the bytes to be
 /// searched and can therefore be reused; a trimmed BOM or a transcode means the
 /// result is a different sequence of bytes.
-fn borrows_whole_input(bytes: &[u8], mode: EncodingMode) -> bool {
+///
+/// Public because it is also the precondition for searching a file straight out
+/// of a memory map: if decoding would rewrite the bytes, the mapped pages are
+/// not the bytes to search and the file has to be read and decoded instead.
+pub fn borrows_whole_input(bytes: &[u8], mode: EncodingMode) -> bool {
     match mode {
         EncodingMode::None => true,
         EncodingMode::Auto => Encoding::for_bom(bytes).is_none(),

--- a/tgrep-core/src/encoding.rs
+++ b/tgrep-core/src/encoding.rs
@@ -154,6 +154,15 @@ impl LossyFixups {
         self.shifts.is_empty()
     }
 
+    /// Heap bytes held by this fixup table.
+    ///
+    /// A file of mostly-invalid bytes produces one shift per replacement, so
+    /// this can rival the decoded text itself. Callers that budget memory (the
+    /// `serve` content cache) must count it.
+    pub fn heap_bytes(&self) -> u64 {
+        (self.shifts.capacity() * std::mem::size_of::<(usize, usize)>()) as u64
+    }
+
     /// Map an offset in the decoded text to the corresponding offset in the
     /// source bytes.
     ///

--- a/tgrep-core/src/external.rs
+++ b/tgrep-core/src/external.rs
@@ -637,7 +637,9 @@ mod tests {
     fn trigram_ids(index_dir: &Path) -> Vec<u32> {
         std::fs::read(index_dir.join("lookup.bin"))
             .unwrap()
-            .chunks_exact(ondisk::LOOKUP_ENTRY_SIZE)
+            .as_chunks::<{ ondisk::LOOKUP_ENTRY_SIZE }>()
+            .0
+            .iter()
             .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .collect()
     }

--- a/tgrep-core/src/git_index.rs
+++ b/tgrep-core/src/git_index.rs
@@ -1,0 +1,437 @@
+//! Reading the set of files git tracks, and whether it compares paths without
+//! regard to case.
+//!
+//! Both answers come from the repository itself — `.git/index` and
+//! `.git/config` — rather than from running `git`, so this works with no git
+//! installation and costs no subprocess.
+//!
+//! # Why a walker needs this
+//!
+//! An ignore rule and a tracked file can both match the same path, and git has
+//! a rule for that: **a tracked file is never ignored**. Ignore rules only
+//! decide what to do with files git does not already know about.
+//!
+//! That distinction does not matter while ignore matching is case-sensitive,
+//! because a rule that matches a tracked file exactly would have stopped it
+//! being added in the first place. It matters as soon as matching ignores case,
+//! which is what git does when `core.ignorecase` is set — the state git chooses
+//! automatically when it clones onto a case-insensitive filesystem. Then rules
+//! start matching files that are already tracked, and without the exemption
+//! they would disappear from the search.
+//!
+//! Measured on a 299,126-file Windows enlistment: matching ignore rules without
+//! regard to case removes 274 files, and 273 of them are tracked — `.JPG`,
+//! `.PNG` and `.RLL` files caught by rules written in lower case. The 274th is
+//! a 13.4 GiB untracked build artifact in a directory the root `.gitignore`
+//! spells `QLogs` and the filesystem spells `qlogs`. Applying the exemption
+//! leaves exactly that one file excluded, and every tracked file in place.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// The paths git has in its index, lowercased for case-insensitive lookup.
+///
+/// Only ever consulted to *rescue* a path an ignore rule matched, so a path
+/// missing from here can only cost an exclusion that git would also make.
+pub struct TrackedFiles {
+    /// Repo-relative, `/`-separated, lowercased.
+    paths: HashSet<Box<str>>,
+}
+
+impl TrackedFiles {
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    /// Whether git tracks `rel_path`, which must be repo-relative.
+    ///
+    /// Compared without regard to case: this is only used where the ignore
+    /// matching is itself case-insensitive, and there the on-disk spelling of a
+    /// path need not match the spelling git recorded.
+    pub fn contains(&self, rel_path: &str) -> bool {
+        let normalised = normalise(rel_path);
+        self.paths.contains(normalised.as_str())
+    }
+
+    /// Whether git tracks anything beneath `rel_dir`.
+    ///
+    /// A directory cannot be skipped just because a rule matches it — git still
+    /// reports the tracked files inside. `qlogs/` is prunable because nothing
+    /// under it is tracked; a directory holding even one tracked file is not.
+    pub fn contains_any_under(&self, rel_dir: &str) -> bool {
+        let mut prefix = normalise(rel_dir);
+        if prefix.is_empty() {
+            return !self.paths.is_empty();
+        }
+        prefix.push('/');
+        // Linear, but only ever reached for a directory an ignore rule already
+        // matched — a handful per walk, not one per entry.
+        self.paths.iter().any(|p| p.starts_with(prefix.as_str()))
+    }
+}
+
+fn normalise(path: &str) -> String {
+    path.replace('\\', "/")
+        .trim_matches('/')
+        .to_ascii_lowercase()
+}
+
+/// Locate the directory holding a repository's `.git` metadata.
+///
+/// `.git` is usually a directory, but is a file holding `gitdir: <path>` in a
+/// linked worktree or a submodule.
+fn git_dir(repo_root: &Path) -> Option<PathBuf> {
+    let dot_git = repo_root.join(".git");
+    let meta = std::fs::metadata(&dot_git).ok()?;
+    if meta.is_dir() {
+        return Some(dot_git);
+    }
+    let contents = std::fs::read_to_string(&dot_git).ok()?;
+    let target = contents.strip_prefix("gitdir:")?.trim();
+    if target.is_empty() {
+        return None;
+    }
+    let path = Path::new(target);
+    Some(if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        repo_root.join(path)
+    })
+}
+
+/// Whether the repository compares paths without regard to case.
+///
+/// git writes `core.ignorecase = true` into the repository's own config when it
+/// detects a case-insensitive filesystem, so the per-repository config is the
+/// authoritative place to read it and needs no config-precedence handling.
+pub fn ignores_case(repo_root: &Path) -> bool {
+    let Some(git_dir) = git_dir(repo_root) else {
+        return false;
+    };
+    let Ok(config) = std::fs::read_to_string(git_dir.join("config")) else {
+        return false;
+    };
+    let mut in_core = false;
+    for line in config.lines() {
+        let line = line.trim();
+        if let Some(section) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+            in_core = section.trim().eq_ignore_ascii_case("core");
+            continue;
+        }
+        if !in_core {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim().eq_ignore_ascii_case("ignorecase") {
+            // git spells boolean true several ways.
+            let value = value.trim();
+            return matches!(
+                value.to_ascii_lowercase().as_str(),
+                "true" | "yes" | "on" | "1"
+            );
+        }
+    }
+    false
+}
+
+/// Read the tracked paths from `.git/index`.
+///
+/// Returns `None` when there is no readable index, which the caller must treat
+/// as "exempt nothing" only where that is the safe direction.
+pub fn load_tracked(repo_root: &Path) -> Option<TrackedFiles> {
+    let git_dir = git_dir(repo_root)?;
+    let bytes = std::fs::read(git_dir.join("index")).ok()?;
+    parse_index(&bytes)
+}
+
+/// Parse the git index format.
+///
+/// Versions 2 and 3 store each path in full, NUL-terminated and padded so the
+/// next entry starts on an 8-byte boundary. Version 4 drops the padding and
+/// stores each path as "strip N bytes off the end of the previous path, then
+/// append this suffix", so entries can only be read in order.
+fn parse_index(bytes: &[u8]) -> Option<TrackedFiles> {
+    /// 62 bytes of stat data, hash and flags precede the path.
+    const ENTRY_HEADER: usize = 62;
+
+    if bytes.len() < 12 || &bytes[..4] != b"DIRC" {
+        return None;
+    }
+    let version = u32::from_be_bytes(bytes[4..8].try_into().ok()?);
+    if !(2..=4).contains(&version) {
+        return None;
+    }
+    let count = u32::from_be_bytes(bytes[8..12].try_into().ok()?) as usize;
+
+    let mut paths = HashSet::with_capacity(count);
+    let mut pos = 12;
+    let mut previous: Vec<u8> = Vec::new();
+    for _ in 0..count {
+        if pos + ENTRY_HEADER > bytes.len() {
+            return None;
+        }
+        let entry_start = pos;
+        let flags = u16::from_be_bytes(bytes[pos + 60..pos + 62].try_into().ok()?);
+        pos += ENTRY_HEADER;
+        // Version 3 introduced a second flag word, present only when the
+        // extended bit is set. Version 4 keeps that rule; version 2 has no
+        // such word at all.
+        if version >= 3 && flags & 0x4000 != 0 {
+            pos += 2;
+            if pos > bytes.len() {
+                return None;
+            }
+        }
+
+        let path = if version >= 4 {
+            let (strip, next) = read_varint(bytes, pos)?;
+            pos = next;
+            let keep = previous.len().checked_sub(strip)?;
+            let end = memchr::memchr(0, bytes.get(pos..)?)? + pos;
+            let mut path = Vec::with_capacity(keep + (end - pos));
+            path.extend_from_slice(&previous[..keep]);
+            path.extend_from_slice(&bytes[pos..end]);
+            pos = end + 1;
+            path
+        } else {
+            // The low 12 bits hold the length, but saturate at 0xFFF; a longer
+            // path is delimited only by its NUL.
+            let named = (flags & 0x0FFF) as usize;
+            let end = if named < 0x0FFF {
+                let end = pos.checked_add(named)?;
+                if bytes.get(end) != Some(&0) {
+                    return None;
+                }
+                end
+            } else {
+                memchr::memchr(0, bytes.get(pos..)?)? + pos
+            };
+            let path = bytes.get(pos..end)?.to_vec();
+            // Pad the whole entry to a multiple of 8, measured from its start.
+            let unpadded = end + 1 - entry_start;
+            pos = entry_start + unpadded.div_ceil(8) * 8;
+            path
+        };
+
+        if version >= 4 {
+            previous = path.clone();
+        }
+        if let Ok(text) = String::from_utf8(path) {
+            paths.insert(normalise(&text).into_boxed_str());
+        }
+    }
+    Some(TrackedFiles { paths })
+}
+
+/// git's offset-encoded varint, as used by index version 4.
+///
+/// Big-endian, 7 bits per byte, and each continuation adds one to the value so
+/// that no integer has two encodings.
+fn read_varint(bytes: &[u8], mut pos: usize) -> Option<(usize, usize)> {
+    let mut byte = *bytes.get(pos)?;
+    pos += 1;
+    let mut value = (byte & 0x7F) as usize;
+    while byte & 0x80 != 0 {
+        value = value.checked_add(1)?.checked_shl(7)?;
+        byte = *bytes.get(pos)?;
+        pos += 1;
+        value = value.checked_add((byte & 0x7F) as usize)?;
+    }
+    Some((value, pos))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a version 2 index the way git writes one, so the parser is tested
+    /// against the layout rather than against itself.
+    fn v2_index(paths: &[&str]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(b"DIRC");
+        out.extend_from_slice(&2u32.to_be_bytes());
+        out.extend_from_slice(&(paths.len() as u32).to_be_bytes());
+        for path in paths {
+            let start = out.len();
+            out.extend_from_slice(&[0u8; 60]);
+            let named = path.len().min(0x0FFF) as u16;
+            out.extend_from_slice(&named.to_be_bytes());
+            out.extend_from_slice(path.as_bytes());
+            out.push(0);
+            while (out.len() - start) % 8 != 0 {
+                out.push(0);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn reads_a_version_2_index() {
+        let index = v2_index(&["src/main.rs", "a.txt", "deeply/nested/path/file.cs"]);
+        let tracked = parse_index(&index).expect("parses");
+        assert_eq!(tracked.len(), 3);
+        assert!(tracked.contains("src/main.rs"));
+        assert!(tracked.contains("a.txt"));
+        assert!(tracked.contains("deeply/nested/path/file.cs"));
+        assert!(!tracked.contains("src/other.rs"));
+    }
+
+    #[test]
+    fn matches_paths_without_regard_to_case_or_separator() {
+        let index = v2_index(&["Assets/Logo.PNG"]);
+        let tracked = parse_index(&index).expect("parses");
+        // The point of the exemption: the rule that matched said `*.png`, and
+        // the walker hands back whatever the filesystem spelled.
+        assert!(tracked.contains("assets/logo.png"));
+        assert!(tracked.contains("Assets\\Logo.PNG"));
+        assert!(tracked.contains("/Assets/Logo.PNG"));
+    }
+
+    #[test]
+    fn finds_tracked_files_under_a_directory() {
+        let index = v2_index(&["keep/a.txt", "qlogs_like/but_tracked.txt"]);
+        let tracked = parse_index(&index).expect("parses");
+        assert!(tracked.contains_any_under("keep"));
+        assert!(tracked.contains_any_under("Keep"));
+        assert!(!tracked.contains_any_under("qlogs"));
+        // A prefix must stop at a path separator, or `qlogs` would claim
+        // `qlogs_like/`.
+        assert!(tracked.contains_any_under("qlogs_like"));
+    }
+
+    #[test]
+    fn handles_a_path_at_and_beyond_the_length_field_limit() {
+        // The 12-bit length field saturates, after which the NUL is the only
+        // delimiter. Straddle that boundary.
+        for len in [0x0FFE, 0x0FFF, 0x1000, 0x1100] {
+            let long = "d/".to_string() + &"x".repeat(len - 2);
+            let index = v2_index(&[&long, "after.txt"]);
+            let tracked = parse_index(&index).unwrap_or_else(|| panic!("parses at {len}"));
+            assert_eq!(tracked.len(), 2, "at {len}");
+            assert!(tracked.contains(&long), "at {len}");
+            assert!(tracked.contains("after.txt"), "at {len}");
+        }
+    }
+
+    #[test]
+    fn rejects_input_that_is_not_an_index() {
+        assert!(parse_index(b"").is_none());
+        assert!(parse_index(b"NOPE\0\0\0\x02\0\0\0\x01").is_none());
+        // A version it does not understand is refused rather than guessed at.
+        let mut wrong_version = v2_index(&["a.txt"]);
+        wrong_version[7] = 9;
+        assert!(parse_index(&wrong_version).is_none());
+    }
+
+    #[test]
+    fn refuses_a_truncated_index_instead_of_inventing_entries() {
+        let index = v2_index(&["src/main.rs", "b.txt"]);
+        // Cuts that land in the header, inside the first entry's path, and
+        // inside the second entry's path.
+        for cut in [13, 20, 40, 79, 157] {
+            assert!(
+                parse_index(&index[..cut]).is_none(),
+                "accepted an index truncated to {cut}"
+            );
+        }
+    }
+
+    #[test]
+    fn tolerates_the_trailing_data_a_real_index_carries() {
+        // Entries are not the end of the file: git appends extensions and a
+        // trailing checksum. Requiring the last entry to end the file would
+        // reject every index git actually writes.
+        let mut index = v2_index(&["src/main.rs", "b.txt"]);
+        index.extend_from_slice(b"TREE");
+        index.extend_from_slice(&[0u8; 24]);
+        let tracked = parse_index(&index).expect("parses despite trailing data");
+        assert_eq!(tracked.len(), 2);
+        assert!(tracked.contains("src/main.rs"));
+    }
+
+    #[test]
+    fn a_count_larger_than_the_data_is_refused() {
+        let mut index = v2_index(&["a.txt"]);
+        index[11] = 40;
+        assert!(parse_index(&index).is_none());
+    }
+
+    #[test]
+    fn reads_a_version_4_index_with_prefix_compressed_paths() {
+        // Written by hand because v4 entries are only decodable in order, so a
+        // round-trip through our own writer would not prove much.
+        let mut out = Vec::new();
+        out.extend_from_slice(b"DIRC");
+        out.extend_from_slice(&4u32.to_be_bytes());
+        out.extend_from_slice(&3u32.to_be_bytes());
+        // Each entry: 62 bytes, then varint strip count, then suffix + NUL.
+        for (strip, suffix) in [(0usize, "src/alpha.rs"), (8, "beta.rs"), (7, "gamma.rs")] {
+            out.extend_from_slice(&[0u8; 60]);
+            out.extend_from_slice(&(suffix.len() as u16).to_be_bytes());
+            out.push(strip as u8);
+            out.extend_from_slice(suffix.as_bytes());
+            out.push(0);
+        }
+        let tracked = parse_index(&out).expect("parses");
+        assert_eq!(tracked.len(), 3);
+        assert!(tracked.contains("src/alpha.rs"));
+        assert!(tracked.contains("src/beta.rs"));
+        assert!(tracked.contains("src/gamma.rs"));
+    }
+
+    #[test]
+    fn reads_ignorecase_from_a_repository_config() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let git = tmp.path().join(".git");
+        std::fs::create_dir_all(&git).expect("mkdir");
+
+        let cases = [
+            ("[core]\n\tignorecase = true\n", true),
+            ("[core]\n\tignorecase = false\n", false),
+            ("[core]\n\tignorecase = True\n", true),
+            ("[CORE]\n\tIgnoreCase = yes\n", true),
+            // Set, but in another section: not ours to read.
+            ("[core]\n\tbare = false\n[other]\n\tignorecase = true\n", false),
+            ("[core]\n\tbare = false\n", false),
+            ("", false),
+        ];
+        for (config, want) in cases {
+            std::fs::write(git.join("config"), config).expect("write");
+            assert_eq!(ignores_case(tmp.path()), want, "for config {config:?}");
+        }
+    }
+
+    #[test]
+    fn follows_a_gitdir_pointer_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = tmp.path().join("real-git-dir");
+        std::fs::create_dir_all(&real).expect("mkdir");
+        std::fs::write(real.join("config"), "[core]\n\tignorecase = true\n").expect("write");
+        std::fs::write(real.join("index"), v2_index(&["worktree/file.rs"])).expect("write");
+
+        let worktree = tmp.path().join("worktree");
+        std::fs::create_dir_all(&worktree).expect("mkdir");
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", real.display()),
+        )
+        .expect("write");
+
+        assert!(ignores_case(&worktree));
+        let tracked = load_tracked(&worktree).expect("loads through the pointer");
+        assert!(tracked.contains("worktree/file.rs"));
+    }
+
+    #[test]
+    fn a_directory_without_git_reports_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!ignores_case(tmp.path()));
+        assert!(load_tracked(tmp.path()).is_none());
+    }
+}

--- a/tgrep-core/src/git_index.rs
+++ b/tgrep-core/src/git_index.rs
@@ -169,7 +169,12 @@ fn parse_index(bytes: &[u8]) -> Option<TrackedFiles> {
     }
     let count = u32::from_be_bytes(bytes[8..12].try_into().ok()?) as usize;
 
-    let mut paths = HashSet::with_capacity(count);
+    // The header is attacker-controlled — reserving `count` outright lets a
+    // 12-byte file claim 4 billion entries and abort the process in the
+    // allocator, which is not catchable. No entry can be shorter than its
+    // 62-byte header plus a NUL and padding, so the file length is a hard
+    // ceiling on how many there really are.
+    let mut paths = HashSet::with_capacity(count.min((bytes.len() - 12) / (ENTRY_HEADER + 1)));
     let mut pos = 12;
     let mut previous: Vec<u8> = Vec::new();
     for _ in 0..count {
@@ -359,6 +364,19 @@ mod tests {
     fn a_count_larger_than_the_data_is_refused() {
         let mut index = v2_index(&["a.txt"]);
         index[11] = 40;
+        assert!(parse_index(&index).is_none());
+    }
+
+    #[test]
+    fn a_header_claiming_four_billion_entries_does_not_reserve_for_them() {
+        // A bare header claiming u32::MAX entries. Reserving that many would ask
+        // the allocator for roughly 146GB and abort the process before any of the
+        // per-entry length checks below ever run, so the clamp has to happen at
+        // the reservation itself. Reaching the `None` at all proves it did.
+        let mut index = Vec::from(*b"DIRC");
+        index.extend_from_slice(&2u32.to_be_bytes());
+        index.extend_from_slice(&u32::MAX.to_be_bytes());
+        assert_eq!(index.len(), 12);
         assert!(parse_index(&index).is_none());
     }
 

--- a/tgrep-core/src/git_index.rs
+++ b/tgrep-core/src/git_index.rs
@@ -415,7 +415,10 @@ mod tests {
             ("[core]\n\tignorecase = True\n", true),
             ("[CORE]\n\tIgnoreCase = yes\n", true),
             // Set, but in another section: not ours to read.
-            ("[core]\n\tbare = false\n[other]\n\tignorecase = true\n", false),
+            (
+                "[core]\n\tbare = false\n[other]\n\tignorecase = true\n",
+                false,
+            ),
             ("[core]\n\tbare = false\n", false),
             ("", false),
         ];

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -353,7 +353,6 @@ impl P4IgnoreMatcher {
 /// Build a matcher containing only root-level `p4ignore.ini` rules.
 pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
     use ignore::gitignore::GitignoreBuilder;
-
     let (_, lines) = p4ignore_lines(root)?;
     let mut builder = GitignoreBuilder::new(root);
     if !add_p4ignore_rules(&mut builder, root) {
@@ -375,6 +374,107 @@ pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
         matcher,
         reinclude_prefixes,
     })
+}
+
+/// Git's repository-wide ignore rules, matched the way git matches them on a
+/// case-insensitive filesystem, with git's tracked-file exemption applied.
+///
+/// # Why this exists
+///
+/// git sets `core.ignorecase` when it clones onto a filesystem that does not
+/// distinguish case, and from then on it matches ignore rules without regard to
+/// case. The `ignore` crate always matches case-sensitively, so on such a
+/// repository a rule written `QLogs` does not hide a directory named `qlogs` —
+/// and everything inside it gets walked, read and indexed even though `git
+/// status` never mentions it. On one Windows enlistment that was a single 13.4
+/// GiB build artifact making up 71% of the corpus.
+///
+/// This only ever *adds* exclusions, and only for paths the case-sensitive pass
+/// already let through, so it cannot resurrect a file the normal rules hid.
+///
+/// # The tracked-file exemption
+///
+/// Matching without regard to case starts catching files that are already
+/// tracked, which git would never hide — on that same enlistment, 273 `.JPG`,
+/// `.PNG` and `.RLL` files caught by rules written in lower case. git's rule is
+/// that ignore rules only decide the fate of files it does not already track,
+/// so tracked paths are exempt here too. With the exemption, exactly one file
+/// is excluded: the untracked artifact.
+///
+/// # Limits
+///
+/// Only the repository's own rules are matched this way — the root
+/// `.gitignore` and `.git/info/exclude`. Rules in nested `.gitignore` files are
+/// not, because the walk does not know they exist until it reaches their
+/// directory, by which point the parent may already have been pruned; nor is
+/// the user's global ignore file, whose rules are not repository state. Missing
+/// one only leaves a file visible that git would hide, which is the behaviour
+/// without any of this.
+pub struct CaseInsensitiveIgnore {
+    matcher: Gitignore,
+    repo_root: std::path::PathBuf,
+    /// Loaded on the first path this matcher actually claims, which for most
+    /// repositories is never. Reading it costs 163 ms and ~30 MB on a
+    /// 299k-file repository, and nothing at all if no rule ever matches.
+    tracked: std::sync::OnceLock<Option<crate::git_index::TrackedFiles>>,
+}
+
+impl CaseInsensitiveIgnore {
+    /// Returns `None` unless `root` is in a git repository that sets
+    /// `core.ignorecase` and has repository-wide rules to apply.
+    pub fn new(root: &Path) -> Option<Self> {
+        use ignore::gitignore::GitignoreBuilder;
+
+        let repo_root = git_repo_root(root)?.to_path_buf();
+        if !crate::git_index::ignores_case(&repo_root) {
+            return None;
+        }
+
+        let mut builder = GitignoreBuilder::new(&repo_root);
+        builder.case_insensitive(true).ok()?;
+        let _ = builder.add(repo_root.join(GITIGNORE_FILENAME));
+        let _ = builder.add(repo_root.join(".git").join("info").join("exclude"));
+        let matcher = builder.build().ok()?;
+        if matcher.is_empty() {
+            return None;
+        }
+        Some(Self {
+            matcher,
+            repo_root,
+            tracked: std::sync::OnceLock::new(),
+        })
+    }
+
+    /// Whether git would hide `path`, which must be absolute.
+    pub fn excludes(&self, path: &Path, is_dir: bool) -> bool {
+        let Ok(relative) = path.strip_prefix(&self.repo_root) else {
+            return false;
+        };
+        if !self
+            .matcher
+            .matched_path_or_any_parents(relative, is_dir)
+            .is_ignore()
+        {
+            return false;
+        }
+        // Only now is the index worth reading.
+        let Some(tracked) = self
+            .tracked
+            .get_or_init(|| crate::git_index::load_tracked(&self.repo_root))
+        else {
+            // No readable index means no way to tell tracked from untracked.
+            // Excluding could hide real source, so decline instead.
+            return false;
+        };
+        let relative = relative.to_string_lossy();
+        if is_dir {
+            // A rule matching a directory does not hide tracked files inside
+            // it, so the walk still has to descend.
+            !tracked.contains_any_under(&relative)
+        } else {
+            !tracked.contains(&relative)
+        }
+    }
 }
 
 /// Build an [`IgnoreMatcher`] from already-discovered `.gitignore` paths.

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -422,18 +422,47 @@ pub struct CaseInsensitiveIgnore {
 impl CaseInsensitiveIgnore {
     /// Returns `None` unless `root` is in a git repository that sets
     /// `core.ignorecase` and has repository-wide rules to apply.
-    pub fn new(root: &Path) -> Option<Self> {
+    ///
+    /// `use_gitignore`, `use_exclude` and `use_parents` mirror the flags the
+    /// case-sensitive pass was built with. They are not a convenience: this
+    /// matcher is only sound as a *narrowing* of that pass, so it must never
+    /// consult a source the case-sensitive pass was told to ignore. With
+    /// `--no-ignore-vcs` the case-sensitive pass lets everything through, which
+    /// would leave this the only thing excluding — the exact opposite of what
+    /// the flag asks for.
+    pub fn new(
+        root: &Path,
+        use_gitignore: bool,
+        use_exclude: bool,
+        use_parents: bool,
+    ) -> Option<Self> {
         use ignore::gitignore::GitignoreBuilder;
+
+        if !use_gitignore && !use_exclude {
+            return None;
+        }
 
         let repo_root = git_repo_root(root)?.to_path_buf();
         if !crate::git_index::ignores_case(&repo_root) {
             return None;
         }
 
+        // Everything below is repository-wide, so when the walk starts inside a
+        // subdirectory these rules reach it only as parent rules. `--no-ignore-parent`
+        // switches those off in the case-sensitive pass, and we must follow.
+        // `git_repo_root` returns an ancestor of `root`, so this compares exactly.
+        if !use_parents && root != repo_root {
+            return None;
+        }
+
         let mut builder = GitignoreBuilder::new(&repo_root);
         builder.case_insensitive(true).ok()?;
-        let _ = builder.add(repo_root.join(GITIGNORE_FILENAME));
-        let _ = builder.add(repo_root.join(".git").join("info").join("exclude"));
+        if use_gitignore {
+            let _ = builder.add(repo_root.join(GITIGNORE_FILENAME));
+        }
+        if use_exclude {
+            let _ = builder.add(repo_root.join(".git").join("info").join("exclude"));
+        }
         let matcher = builder.build().ok()?;
         if matcher.is_empty() {
             return None;

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -72,13 +72,27 @@ struct NestedIgnore {
     matcher: Gitignore,
 }
 
+/// An ignore file above the served root. `prefix` is the served root relative
+/// to the directory that owns the matcher, so a root-relative event path can be
+/// queried with the same anchoring the filesystem walk used.
+struct AncestorIgnore {
+    prefix: String,
+    kind: IgnoreKind,
+    matcher: Gitignore,
+}
+
 pub struct IgnoreMatcher {
-    /// Root-scoped rules: the root `.gitignore`, `.git/info/exclude`,
-    /// `p4ignore.ini`, and the root `.ignore` (added last so it wins).
+    /// Root-scoped custom rules such as `p4ignore.ini`.
     local: Gitignore,
-    /// Nested ignore files, deepest first and `.ignore` before `.gitignore`
-    /// within a directory.
+    /// `p4ignore.ini` is a separate walker filter: its ignores are additive,
+    /// while its whitelists do not override the standard ignore sources.
+    local_is_filter: bool,
+    /// Ignore files inside (or at) the served root, deepest first.
     nested: Vec<NestedIgnore>,
+    /// Parent `.ignore` / `.gitignore` files, closest directory first.
+    ancestors: Vec<AncestorIgnore>,
+    /// Repository-local `.git/info/exclude`, below global rules in precedence.
+    repo_exclude: Option<(String, Gitignore)>,
     global: Gitignore,
 }
 
@@ -103,6 +117,17 @@ impl IgnoreMatcher {
         nested: Vec<(String, IgnoreKind, Gitignore)>,
         global: Gitignore,
     ) -> Option<Self> {
+        Self::with_all_sources(local, false, nested, Vec::new(), None, global)
+    }
+
+    fn with_all_sources(
+        local: Gitignore,
+        local_is_filter: bool,
+        nested: Vec<(String, IgnoreKind, Gitignore)>,
+        ancestors: Vec<(String, IgnoreKind, Gitignore)>,
+        repo_exclude: Option<(String, Gitignore)>,
+        global: Gitignore,
+    ) -> Option<Self> {
         let mut nested: Vec<NestedIgnore> = nested
             .into_iter()
             .filter(|(_, _, matcher)| !matcher.is_empty())
@@ -124,9 +149,28 @@ impl IgnoreMatcher {
                 .then_with(|| a.kind.cmp(&b.kind))
         });
 
-        (!local.is_empty() || !nested.is_empty() || !global.is_empty()).then_some(Self {
+        let ancestors = ancestors
+            .into_iter()
+            .filter(|(_, _, matcher)| !matcher.is_empty())
+            .map(|(prefix, kind, matcher)| AncestorIgnore {
+                prefix,
+                kind,
+                matcher,
+            })
+            .collect::<Vec<_>>();
+        let repo_exclude = repo_exclude.filter(|(_, matcher)| !matcher.is_empty());
+
+        (!local.is_empty()
+            || !nested.is_empty()
+            || !ancestors.is_empty()
+            || repo_exclude.is_some()
+            || !global.is_empty())
+        .then_some(Self {
             local,
+            local_is_filter,
             nested,
+            ancestors,
+            repo_exclude,
             global,
         })
     }
@@ -135,31 +179,103 @@ impl IgnoreMatcher {
         let rel = path.to_string_lossy().replace('\\', "/");
         let rel = rel.trim_start_matches("./").trim_start_matches('/');
 
-        for entry in &self.nested {
-            // Only consult a nested file for paths beneath its directory, and
-            // match against the path *relative to that directory*, which is
-            // the scope its patterns were written for.
-            let Some(under) = strip_dir_prefix(rel, &entry.dir) else {
-                continue;
+        // The ignore crate resolves each source independently, then gives
+        // `.ignore` files precedence over every `.gitignore`, regardless of
+        // directory depth.
+        let mut standard_decision = None;
+        for kind in [IgnoreKind::DotIgnore, IgnoreKind::GitIgnore] {
+            for entry in self.nested.iter().filter(|entry| entry.kind == kind) {
+                // Only consult a nested file for paths beneath its directory,
+                // relative to the directory where its patterns were written.
+                let Some(under) = strip_dir_prefix(rel, &entry.dir) else {
+                    continue;
+                };
+                match entry
+                    .matcher
+                    .matched_path_or_any_parents(Path::new(under), is_dir)
+                {
+                    Match::Ignore(_) => {
+                        standard_decision = Some(true);
+                        break;
+                    }
+                    Match::Whitelist(_) => {
+                        standard_decision = Some(false);
+                        break;
+                    }
+                    Match::None => {}
+                }
+            }
+            if standard_decision.is_some() {
+                break;
+            }
+
+            for entry in self.ancestors.iter().filter(|entry| entry.kind == kind) {
+                let path = if entry.prefix.is_empty() {
+                    rel.to_string()
+                } else {
+                    format!("{}/{rel}", entry.prefix)
+                };
+                match entry
+                    .matcher
+                    .matched_path_or_any_parents(Path::new(&path), is_dir)
+                {
+                    Match::Ignore(_) => {
+                        standard_decision = Some(true);
+                        break;
+                    }
+                    Match::Whitelist(_) => {
+                        standard_decision = Some(false);
+                        break;
+                    }
+                    Match::None => {}
+                }
+            }
+            if standard_decision.is_some() {
+                break;
+            }
+        }
+
+        // `with_nested` historically takes an already-combined root matcher;
+        // nested files must retain their deeper-path precedence over it.
+        if standard_decision.is_none() && !self.local_is_filter {
+            standard_decision = match self.local.matched_path_or_any_parents(path, is_dir) {
+                Match::Ignore(_) => Some(true),
+                Match::Whitelist(_) => Some(false),
+                Match::None => None,
             };
-            match entry
-                .matcher
-                .matched_path_or_any_parents(Path::new(under), is_dir)
-            {
-                Match::Ignore(_) => return true,
-                Match::Whitelist(_) => return false,
+        }
+
+        if standard_decision.is_none()
+            && let Some((prefix, matcher)) = &self.repo_exclude
+        {
+            let path = if prefix.is_empty() {
+                rel.to_string()
+            } else {
+                format!("{prefix}/{rel}")
+            };
+            match matcher.matched_path_or_any_parents(Path::new(&path), is_dir) {
+                Match::Ignore(_) => standard_decision = Some(true),
+                Match::Whitelist(_) => standard_decision = Some(false),
                 Match::None => {}
             }
         }
 
-        match self.local.matched_path_or_any_parents(path, is_dir) {
-            Match::Ignore(_) => true,
-            Match::Whitelist(_) => false,
-            Match::None => self
-                .global
-                .matched_path_or_any_parents(path, is_dir)
-                .is_ignore(),
+        if standard_decision.is_none() {
+            standard_decision = match self.global.matched_path_or_any_parents(path, is_dir) {
+                Match::Ignore(_) => Some(true),
+                Match::Whitelist(_) => Some(false),
+                Match::None => None,
+            };
         }
+
+        if standard_decision == Some(true) {
+            return true;
+        }
+        self.local_is_filter
+            && self
+                .local
+                .matched_path_or_any_parents(path, is_dir)
+                .is_ignore()
     }
 }
 
@@ -268,12 +384,10 @@ pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
 /// stripping `root` from its parent directory, so repo-relative paths would
 /// leave every nested rule out of the matcher.
 ///
-/// Root-level rules (`.git/info/exclude`, `p4ignore.ini`, a `.gitignore`
-/// directly in `root`, and finally the root `.ignore`) share the root matcher,
-/// added in that order so the last match wins and `.ignore` outranks
-/// `.gitignore`. Every deeper ignore file gets its own matcher anchored at its
-/// directory, because its patterns are written relative to that directory —
-/// see [`IgnoreMatcher::with_nested`].
+/// Every `.ignore` and `.gitignore`, including files directly in `root`, keeps
+/// its own directory anchoring. Source classes are resolved separately so
+/// `.ignore` outranks `.gitignore` across directory levels, matching
+/// `WalkBuilder`. `p4ignore.ini` remains a root-scoped custom source.
 ///
 /// Whether `root` sits inside a git repository, detected by scanning `root` and
 /// its ancestors for a `.git` entry so a subdirectory of a repo still counts.
@@ -282,6 +396,10 @@ pub fn build_p4ignore_matcher(root: &Path) -> Option<P4IgnoreMatcher> {
 /// whether `.gitignore` files are honoured at all.
 pub fn in_git_repo(root: &Path) -> bool {
     root.ancestors().any(|dir| dir.join(".git").exists())
+}
+
+fn git_repo_root(root: &Path) -> Option<&Path> {
+    root.ancestors().find(|dir| dir.join(".git").exists())
 }
 
 /// `.gitignore` and `.git/info/exclude` are **git-gated** to match the indexing
@@ -295,32 +413,30 @@ pub fn matcher_from_ignore_paths(
     gitignore_files: &[std::path::PathBuf],
     ignore_files: &[std::path::PathBuf],
 ) -> Option<IgnoreMatcher> {
+    matcher_from_ignore_paths_with_options(root, gitignore_files, ignore_files, false)
+}
+
+/// Build a matcher from already-discovered ignore files with the same git gate
+/// used by a file walk.
+pub fn matcher_from_ignore_paths_with_options(
+    root: &Path,
+    gitignore_files: &[std::path::PathBuf],
+    ignore_files: &[std::path::PathBuf],
+    no_require_git: bool,
+) -> Option<IgnoreMatcher> {
     use ignore::gitignore::GitignoreBuilder;
 
     // `root` is inside a git repo if it or any ancestor holds a `.git` entry.
-    let in_git_repo = in_git_repo(root);
+    let repo_root = git_repo_root(root);
+    let git_rules_enabled = repo_root.is_some() || no_require_git;
 
     let mut root_builder = GitignoreBuilder::new(root);
-    if in_git_repo {
-        // `.git/info/exclude` is anchored at the repo root, but this matcher is
-        // queried with paths relative to `root`. Only apply it when `root` is
-        // itself the repo root — a `.git` *directory*, not a worktree's `.git`
-        // file — so its anchoring matches.
-        if root.join(".git").is_dir() {
-            let info_exclude = root.join(".git").join("info").join("exclude");
-            if info_exclude.is_file() {
-                let _ = root_builder.add(&info_exclude);
-            }
-        }
-    }
     add_p4ignore_rules(&mut root_builder, root);
 
     let mut nested: Vec<(String, IgnoreKind, Gitignore)> = Vec::new();
 
-    // `.gitignore` first, then `.ignore`, so that within the root matcher the
-    // later-added `.ignore` patterns win.
     let sources = [
-        (IgnoreKind::GitIgnore, gitignore_files, in_git_repo),
+        (IgnoreKind::GitIgnore, gitignore_files, git_rules_enabled),
         (IgnoreKind::DotIgnore, ignore_files, true),
     ];
     for (kind, paths, enabled) in sources {
@@ -349,23 +465,67 @@ pub fn matcher_from_ignore_paths(
             let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
             let rel_dir = rel_dir.trim_matches('/');
 
-            if rel_dir.is_empty() {
-                let _ = root_builder.add(path);
-                continue;
-            }
-
             let mut builder = GitignoreBuilder::new(dir);
-            if builder.add(path).is_some() {
-                continue;
-            }
+            let _ = builder.add(path);
             if let Ok(matcher) = builder.build() {
                 nested.push((rel_dir.to_string(), kind, matcher));
             }
         }
     }
 
+    // WalkBuilder applies `.ignore` files from every ancestor. Its git boundary
+    // is independent: with the default `require_git`, ancestor `.gitignore`
+    // files stop after the nearest repository root; with `--no-require-git`
+    // they continue to the filesystem root.
+    let mut ancestors = Vec::new();
+    for dir in root.ancestors().skip(1) {
+        let prefix = root
+            .strip_prefix(dir)
+            .unwrap_or(root)
+            .to_string_lossy()
+            .replace('\\', "/");
+        for (kind, path, enabled) in [
+            (IgnoreKind::DotIgnore, dir.join(DOT_IGNORE_FILENAME), true),
+            (
+                IgnoreKind::GitIgnore,
+                dir.join(GITIGNORE_FILENAME),
+                no_require_git || repo_root.is_some_and(|repo| dir.starts_with(repo)),
+            ),
+        ] {
+            if !enabled || !path.is_file() {
+                continue;
+            }
+            let mut builder = GitignoreBuilder::new(dir);
+            let _ = builder.add(&path);
+            if let Ok(matcher) = builder.build() {
+                ancestors.push((prefix.clone(), kind, matcher));
+            }
+        }
+    }
+
+    let repo_exclude = repo_root.and_then(|repo| {
+        let path = repo.join(".git").join("info").join("exclude");
+        if !path.is_file() {
+            return None;
+        }
+        let mut builder = GitignoreBuilder::new(repo);
+        let _ = builder.add(&path);
+        let matcher = builder.build().ok()?;
+        let prefix = root
+            .strip_prefix(repo)
+            .ok()?
+            .to_string_lossy()
+            .replace('\\', "/");
+        Some((prefix, matcher))
+    });
+
     let local = root_builder.build().ok()?;
-    IgnoreMatcher::with_nested(local, nested, build_global_matcher(root))
+    let global = if git_rules_enabled {
+        build_global_matcher(root)
+    } else {
+        GitignoreBuilder::new(root).build().ok()?
+    };
+    IgnoreMatcher::with_all_sources(local, true, nested, ancestors, repo_exclude, global)
 }
 
 /// Convenience wrapper for callers that only have `.gitignore` paths.
@@ -525,6 +685,17 @@ mod tests {
     }
 
     #[test]
+    fn malformed_ignore_line_does_not_discard_valid_rules() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        std::fs::write(tmp.path().join(".gitignore"), "*.tmp\n[\n*.log\n").unwrap();
+
+        let matcher = build_matcher(tmp.path()).expect("valid rules should still build");
+        assert!(matcher.is_ignored(Path::new("cache.tmp"), false));
+        assert!(matcher.is_ignored(Path::new("trace.log"), false));
+    }
+
+    #[test]
     fn builds_matcher_from_dot_ignore_without_a_git_repo() {
         // `.ignore` is not git-gated: it applies with no `.git` present.
         let tmp = TempDir::new().unwrap();
@@ -599,6 +770,31 @@ mod tests {
 
         assert!(!matcher.is_ignored(Path::new("keep.log"), false));
         assert!(matcher.is_ignored(Path::new("drop.log"), false));
+    }
+
+    #[test]
+    fn with_nested_keeps_deeper_rules_ahead_of_local_rules() {
+        use ignore::gitignore::GitignoreBuilder;
+
+        let tmp = TempDir::new().unwrap();
+        let mut local = GitignoreBuilder::new(tmp.path());
+        local.add_line(None, "*.log").unwrap();
+        let mut nested = GitignoreBuilder::new(tmp.path().join("pkg"));
+        nested.add_line(None, "!keep.log").unwrap();
+        let global = GitignoreBuilder::new(tmp.path()).build().unwrap();
+        let matcher = IgnoreMatcher::with_nested(
+            local.build().unwrap(),
+            vec![(
+                "pkg".to_string(),
+                IgnoreKind::GitIgnore,
+                nested.build().unwrap(),
+            )],
+            global,
+        )
+        .unwrap();
+
+        assert!(!matcher.is_ignored(Path::new("pkg/keep.log"), false));
+        assert!(matcher.is_ignored(Path::new("pkg/drop.log"), false));
     }
 
     #[test]

--- a/tgrep-core/src/lib.rs
+++ b/tgrep-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod encoding;
 pub mod error;
 pub(crate) mod external;
 pub mod filetypes;
+pub mod git_index;
 pub mod gitignore;
 pub mod hybrid;
 pub mod live;

--- a/tgrep-core/src/live.rs
+++ b/tgrep-core/src/live.rs
@@ -72,14 +72,14 @@ impl LiveIndex {
     /// computation — safe to call outside any index lock so callers
     /// (e.g. the file watcher) can do the heavy work without blocking
     /// concurrent searches.
-    pub fn compute_trigram_masks(content: &[u8]) -> HashMap<u32, trigram::TrigramMasks> {
+    pub fn compute_trigram_masks(content: &[u8]) -> trigram::TrigramMaskMap {
         trigram::extract_merged_masks(content)
     }
 
     /// Commit a pre-computed set of (trigram, masks) entries for a file.
     /// Intended to run under the index write lock after the caller has
     /// already done the expensive extraction outside the lock.
-    pub fn commit_upsert(&mut self, rel_path: &str, per_tri: HashMap<u32, trigram::TrigramMasks>) {
+    pub fn commit_upsert(&mut self, rel_path: &str, per_tri: trigram::TrigramMaskMap) {
         // Remove old entry if exists
         if let Some(&old_id) = self.path_to_id.get(rel_path) {
             self.remove_file_by_id(old_id);

--- a/tgrep-core/src/live.rs
+++ b/tgrep-core/src/live.rs
@@ -211,6 +211,11 @@ impl LiveIndex {
         self.dirty_count
     }
 
+    /// Whether the overlay contains an active file or a reader tombstone.
+    pub fn has_pending_changes(&self) -> bool {
+        !self.path_to_id.is_empty() || !self.deleted_paths.is_empty()
+    }
+
     /// Reset the dirty counter (e.g., after saving).
     pub fn reset_dirty_count(&mut self) {
         self.dirty_count = 0;
@@ -375,6 +380,16 @@ impl LiveIndex {
         self.masks.retain(|&(_, fid), _| !ids.contains(&fid));
     }
 
+    /// Clear live entries and tombstones that a serialized reconciliation has
+    /// incorporated. The caller must prevent newer mutations to these paths
+    /// until this returns.
+    pub fn clear_reconciled_paths(&mut self, paths: &[String]) {
+        self.batch_remove_overlay_entries(paths);
+        for path in paths {
+            self.deleted_paths.remove(path);
+        }
+    }
+
     /// Fast post-flush prune: if every overlay entry is reflected in
     /// `reader_paths`, swap all overlay maps out for empty ones and drop
     /// the old contents on a background thread. Returns `true` if the
@@ -454,6 +469,11 @@ impl LiveIndex {
         self.path_to_id.keys().cloned().collect()
     }
 
+    /// Return every reader path currently hidden by a deletion tombstone.
+    pub fn tombstone_paths(&self) -> Vec<String> {
+        self.deleted_paths.iter().cloned().collect()
+    }
+
     fn remove_file_by_id(&mut self, file_id: u32) {
         // Remove from inverted index and masks
         let mut trigrams_to_clean = Vec::new();
@@ -472,5 +492,32 @@ impl LiveIndex {
         if let Some(path) = self.file_paths.remove(&file_id) {
             self.path_to_id.remove(&path);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clearing_reconciled_paths_removes_entries_and_tombstones_only_for_them() {
+        let mut live = LiveIndex::new();
+        live.upsert_file("omitted.txt", b"abc");
+        live.upsert_file("newer.txt", b"def");
+        live.delete_file("deleted.txt");
+
+        live.clear_reconciled_paths(&["omitted.txt".to_string(), "deleted.txt".to_string()]);
+
+        assert_eq!(live.overlay_paths(), vec!["newer.txt"]);
+        assert!(live.tombstone_paths().is_empty());
+        assert!(
+            live.lookup_trigram(crate::trigram::hash(b'a', b'b', b'c'))
+                .is_empty()
+        );
+        assert_eq!(
+            live.lookup_trigram(crate::trigram::hash(b'd', b'e', b'f'))
+                .len(),
+            1
+        );
     }
 }

--- a/tgrep-core/src/query.rs
+++ b/tgrep-core/src/query.rs
@@ -89,6 +89,291 @@ pub fn build_multi_pattern_plan(
     })
 }
 
+/// Build a plan for PCRE-style patterns that `regex-syntax` cannot parse.
+///
+/// Each pattern is first relaxed (see [`relax_for_indexing`]); anything that
+/// cannot be relaxed, or that still fails to parse afterwards, degrades to
+/// `MatchAll`. Relaxation failure is never an error: it only costs the index
+/// optimisation, and the caller still runs the real PCRE matcher over whatever
+/// candidates come back.
+pub fn build_relaxed_multi_pattern_plan(patterns: &[String], case_insensitive: bool) -> QueryPlan {
+    let mut plans = Vec::with_capacity(patterns.len());
+    for pattern in patterns {
+        let plan = relax_for_indexing(pattern)
+            .and_then(|relaxed| build_query_plan(&relaxed, case_insensitive).ok());
+        match plan {
+            Some(plan) if !plan.is_match_all() => plans.push(plan),
+            _ => return QueryPlan::MatchAll,
+        }
+    }
+
+    match plans.len() {
+        0 => QueryPlan::MatchAll,
+        1 => plans.pop().unwrap(),
+        _ => QueryPlan::Or(plans),
+    }
+}
+
+/// What kind of group a `(` opens.
+enum GroupKind {
+    /// `(?=`, `(?!`, `(?<=`, `(?<!` — a zero-width assertion.
+    Lookaround,
+    /// `(?>` — an atomic group.
+    Atomic,
+    /// `(?(...)...)` — a conditional, which has no relaxation.
+    Unsupported,
+    /// A capturing, named or plain non-capturing group.
+    Plain,
+}
+
+/// Rewrite a PCRE-style pattern into a more permissive one that `regex-syntax`
+/// can parse, so `-P` queries can still narrow candidates through the index.
+///
+/// Returns `None` when the pattern uses a construct that cannot be widened
+/// safely, in which case the caller must scan every file.
+///
+/// # Soundness
+///
+/// Every rewrite only ever *widens* the matched language, so
+/// `L(pattern) ⊆ L(relaxed)`:
+///
+/// * deleting a zero-width lookaround removes a constraint on the match;
+/// * turning `(?>…)` into `(?:…)` only restores backtracking paths.
+///
+/// That direction is the one the index needs. A trigram the relaxed pattern
+/// requires is therefore required by the original too, so no file that really
+/// matches can be filtered out. Narrowing would be a correctness bug — it could
+/// drop a genuine hit — which is why anything ambiguous returns `None` instead
+/// of being rewritten optimistically. Backreferences, conditionals, `\K` and
+/// `\G` all bail out for that reason, as do possessive quantifiers: `}` is not
+/// reliably distinguishable from a literal brace, and dropping the wrong `+`
+/// would narrow an anchored pattern.
+pub fn relax_for_indexing(pattern: &str) -> Option<String> {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut out = String::with_capacity(pattern.len());
+    let mut i = 0;
+    // Whether the previous token was an unescaped quantifier, which is what
+    // makes a following `+` a possessive modifier rather than a repeat.
+    let mut after_quantifier = false;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if c == '\\' {
+            let next = *chars.get(i + 1)?;
+            // `\1`-`\9` and `\k`/`\g` are backreferences, `\K` resets the match
+            // start and `\G` anchors to the previous match. None has a
+            // regex-syntax equivalent, and none can be widened.
+            if next.is_ascii_digit() || matches!(next, 'k' | 'g' | 'K' | 'G') {
+                return None;
+            }
+            out.push(c);
+            out.push(next);
+            i += 2;
+            after_quantifier = false;
+            continue;
+        }
+
+        match c {
+            // A character class is copied through verbatim. Its extent has to be
+            // found exactly, because `(?=`, `(?<!` and `(?>` are ordinary members
+            // inside one - treating them as syntax would delete real class
+            // members and *narrow* the pattern.
+            '[' => {
+                let end = skip_class(&chars, i)?;
+                out.extend(&chars[i..end]);
+                i = end;
+                after_quantifier = false;
+            }
+            '(' => {
+                match group_kind(&chars, i) {
+                    GroupKind::Lookaround => i = skip_group(&chars, i)?,
+                    GroupKind::Atomic => {
+                        out.push_str("(?:");
+                        i += 3;
+                    }
+                    GroupKind::Unsupported => return None,
+                    GroupKind::Plain => {
+                        out.push(c);
+                        i += 1;
+                    }
+                }
+                after_quantifier = false;
+            }
+            // Only a real `{n,m}` counts as a quantifier. A brace that is part of
+            // `\p{L}` or a literal is not, and treating it as one would bail out
+            // of perfectly relaxable patterns.
+            '{' => match repetition_end(&chars, i) {
+                Some(end) => {
+                    out.extend(&chars[i..end]);
+                    i = end;
+                    after_quantifier = true;
+                }
+                None => {
+                    out.push(c);
+                    i += 1;
+                    after_quantifier = false;
+                }
+            },
+            // A possessive quantifier. Rewriting it means deciding which `+` is
+            // the modifier, which is not always knowable; bail instead.
+            '+' if after_quantifier => return None,
+            _ => {
+                out.push(c);
+                i += 1;
+                after_quantifier = matches!(c, '*' | '+' | '?');
+            }
+        }
+    }
+
+    Some(out)
+}
+
+/// Return the index just past the `]` that closes the class at `chars[open]`,
+/// or `None` if it is unterminated.
+///
+/// This has to agree with the engines it feeds, both of which have the same two
+/// rules: a `]` in the *first* position (after an optional `^`) is a literal
+/// member rather than the terminator, and `[` nests, so `[[:digit:]]` closes on
+/// the second `]`, not the first.
+///
+/// Erring long is safe - the extra text is copied verbatim, and any lookaround
+/// swallowed with it survives into a pattern `regex-syntax` rejects, which
+/// degrades to a full scan. Erring *short* is the dangerous direction, because
+/// the rest of the class body would then be reinterpreted as regex syntax.
+fn skip_class(chars: &[char], open: usize) -> Option<usize> {
+    debug_assert_eq!(chars.get(open), Some(&'['));
+    let mut i = open + 1;
+    if chars.get(i) == Some(&'^') {
+        i += 1;
+    }
+    if chars.get(i) == Some(&']') {
+        i += 1;
+    }
+
+    let mut depth = 1usize;
+    while i < chars.len() {
+        match chars[i] {
+            '\\' => i += 1,
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Return the index just past the `}` of a `{n}`, `{n,}` or `{n,m}` repetition
+/// starting at `chars[open]`, or `None` if this brace is not one.
+fn repetition_end(chars: &[char], open: usize) -> Option<usize> {
+    debug_assert_eq!(chars.get(open), Some(&'{'));
+    let mut i = open + 1;
+    let digits = |i: &mut usize| {
+        let start = *i;
+        while chars.get(*i).is_some_and(char::is_ascii_digit) {
+            *i += 1;
+        }
+        *i > start
+    };
+
+    if !digits(&mut i) {
+        return None;
+    }
+    if chars.get(i) == Some(&',') {
+        i += 1;
+        digits(&mut i);
+    }
+    (chars.get(i) == Some(&'}')).then_some(i + 1)
+}
+
+/// Classify the group opening at `chars[open]`, which must be `(`.
+fn group_kind(chars: &[char], open: usize) -> GroupKind {
+    if chars.get(open + 1) != Some(&'?') {
+        return GroupKind::Plain;
+    }
+    match chars.get(open + 2) {
+        Some('=') | Some('!') => GroupKind::Lookaround,
+        // `(?<=` and `(?<!` are lookbehind; `(?<name>` is just a named group.
+        Some('<') => match chars.get(open + 3) {
+            Some('=') | Some('!') => GroupKind::Lookaround,
+            _ => GroupKind::Plain,
+        },
+        Some('>') => GroupKind::Atomic,
+        // `(?(1)yes|no)` — a conditional.
+        Some('(') => GroupKind::Unsupported,
+        // `(?P=name)` is a backreference; `(?P<name>` is a named group.
+        Some('P') if chars.get(open + 3) == Some(&'=') => GroupKind::Unsupported,
+        // `(?#…)` is a comment, whose body is arbitrary text rather than syntax.
+        Some('#') => GroupKind::Unsupported,
+        // `(?x)` switches on verbose mode, which changes how whitespace and `#`
+        // are lexed for the rest of the pattern. This scanner does not model
+        // that, so a `(?=`-looking sequence inside an x-mode comment would be
+        // read as a real lookaround. Bail rather than reason about it.
+        _ if enables_extended_mode(chars, open + 2) => GroupKind::Unsupported,
+        _ => GroupKind::Plain,
+    }
+}
+
+/// Whether the `(?…` at `start` is an inline flag group that turns on `x`.
+///
+/// Only a group made up entirely of flag letters counts, terminated by `)` or
+/// `:`; anything else is some other construct and is left alone.
+fn enables_extended_mode(chars: &[char], start: usize) -> bool {
+    let mut i = start;
+    let mut negated = false;
+    let mut extended = false;
+
+    while let Some(&c) = chars.get(i) {
+        match c {
+            '-' => negated = true,
+            'x' if !negated => extended = true,
+            'i' | 'm' | 's' | 'u' | 'U' | 'R' | 'x' => {}
+            ':' | ')' => return extended,
+            _ => return false,
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Return the index just past the `)` that closes the group at `chars[open]`,
+/// or `None` if the pattern is unbalanced.
+fn skip_group(chars: &[char], open: usize) -> Option<usize> {
+    debug_assert_eq!(chars.get(open), Some(&'('));
+    // Starts at the opening paren, so `depth` is 1 before any `)` is seen and
+    // the decrement below cannot underflow.
+    let mut depth = 0usize;
+    let mut i = open;
+
+    while i < chars.len() {
+        match chars[i] {
+            '\\' => i += 2,
+            // A class body can contain unescaped `(` and `)`, so it has to be
+            // skipped as a unit or the depth count goes wrong.
+            '[' => i = skip_class(chars, i)?,
+            '(' => {
+                depth += 1;
+                i += 1;
+            }
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}
+
 /// Convert a byte sequence into a QueryPlan of AND'd trigram queries.
 /// Each `TrigramQuery` carries the expected next byte (if any) so that
 /// next_mask Bloom-filter checks use the correct literal byte — not the
@@ -450,6 +735,229 @@ fn sort_dedup_postings_by_file_id(entries: &mut Vec<PostingEntry>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // Relaxing PCRE patterns for indexing
+    //
+    // `-P` patterns used to bypass the index wholesale, because `regex-syntax`
+    // rejects lookaround and the plan builder is written against its HIR. That
+    // turned a pattern with a perfectly good mandatory literal into a full-corpus
+    // scan. Relaxation recovers the literal; these tests pin the property that
+    // makes it safe, namely that the rewrite only ever widens the language.
+    // -----------------------------------------------------------------------
+
+    /// Every trigram the relaxed pattern demands must also be demanded by the
+    /// original, so no genuinely matching file can be filtered out.
+    fn assert_relaxes_to(pattern: &str, expected: &str) {
+        assert_eq!(
+            relax_for_indexing(pattern).as_deref(),
+            Some(expected),
+            "relaxing {pattern:?}"
+        );
+    }
+
+    #[test]
+    fn negative_lookbehind_is_dropped_but_its_literal_survives() {
+        // The Substrate benchmark's `pcre2-lookaround` query. `ExchangePrincipal`
+        // is mandatory for any match, so the plan must be able to see it.
+        assert_relaxes_to("(?<!//)ExchangePrincipal", "ExchangePrincipal");
+
+        let plan = build_query_plan("ExchangePrincipal", false).unwrap();
+        assert!(
+            !plan.is_match_all(),
+            "the relaxed pattern yields a real trigram plan, not a full scan"
+        );
+    }
+
+    #[test]
+    fn every_lookaround_flavour_is_dropped() {
+        assert_relaxes_to("(?=foo)bar", "bar");
+        assert_relaxes_to("(?!foo)bar", "bar");
+        assert_relaxes_to("(?<=foo)bar", "bar");
+        assert_relaxes_to("(?<!foo)bar", "bar");
+    }
+
+    #[test]
+    fn nested_groups_inside_a_lookaround_are_skipped_wholesale() {
+        assert_relaxes_to("(?=a(b(c))d)needle", "needle");
+        // A `)` inside a character class must not be mistaken for the closer.
+        assert_relaxes_to("(?![)])needle", "needle");
+        // Nor must an escaped one.
+        assert_relaxes_to(r"(?=a\))needle", "needle");
+        // A class whose first member is a literal `]` still has to be skipped as
+        // a unit, or the `)` after it ends the group early.
+        assert_relaxes_to("(?=[])])needle", "needle");
+    }
+
+    // A `]` in first position is a class member, and `[` nests. Getting either
+    // wrong ends the class early, after which its remaining body is read as
+    // top-level syntax - and `(?=`, `(?<!` and `(?>` inside a class are ordinary
+    // members that would then be deleted. That NARROWS the pattern, which is the
+    // one direction relaxation must never take.
+    #[test]
+    fn a_leading_bracket_is_a_class_member_not_a_terminator() {
+        assert_relaxes_to("[]a]n", "[]a]n");
+        assert_relaxes_to("[^]a]n", "[^]a]n");
+        // The regression: these must survive untouched.
+        assert_relaxes_to("[](?=a)]n", "[](?=a)]n");
+        assert_relaxes_to("[^](?<!a)]n", "[^](?<!a)]n");
+        assert_relaxes_to("[](?>a)]n", "[](?>a)]n");
+    }
+
+    #[test]
+    fn character_classes_nest() {
+        assert_relaxes_to("[[:digit:]a]n", "[[:digit:]a]n");
+        // The regression: the inner `]` closed the class, exposing the lookahead.
+        assert_relaxes_to("[[:digit:](?=a)]n", "[[:digit:](?=a)]n");
+        assert_relaxes_to("[a[b]]n", "[a[b]]n");
+        // An unterminated class must bail rather than truncate.
+        assert_eq!(relax_for_indexing("[[:digit:]"), None);
+    }
+
+    #[test]
+    fn a_brace_is_only_a_quantifier_when_it_really_is_one() {
+        // `\p{L}+` is not a possessive quantifier, and bailing on it would
+        // forfeit the optimisation for a common construct.
+        assert_relaxes_to(r"\p{L}+x", r"\p{L}+x");
+        assert_relaxes_to(r"\p{Greek}+(?=x)", r"\p{Greek}+");
+        // A literal brace is not one either.
+        assert_relaxes_to("a{x}+b", "a{x}+b");
+        // But a real repetition still guards against the possessive form.
+        assert_eq!(relax_for_indexing("a{2,3}+b"), None);
+        assert_eq!(relax_for_indexing("a{2}+b"), None);
+        assert_eq!(relax_for_indexing("a{2,}+b"), None);
+        assert_relaxes_to("a{2,3}b", "a{2,3}b");
+    }
+
+    #[test]
+    fn named_groups_are_not_mistaken_for_lookbehind() {
+        assert_relaxes_to("(?<name>needle)", "(?<name>needle)");
+        assert_relaxes_to("(?P<name>needle)", "(?P<name>needle)");
+    }
+
+    #[test]
+    fn atomic_groups_become_ordinary_ones() {
+        // `(?>x)` matches a subset of `(?:x)`, so widening is safe.
+        assert_relaxes_to("(?>needle)s", "(?:needle)s");
+    }
+
+    #[test]
+    fn a_plain_pattern_is_returned_unchanged() {
+        for pattern in ["needle", r"foo\d+bar", "[a-z](x|y)z", r"a\(b"] {
+            assert_relaxes_to(pattern, pattern);
+        }
+    }
+
+    #[test]
+    fn verbose_mode_and_comments_bail_out() {
+        // In `x` mode whitespace is insignificant and `#` starts a comment, so a
+        // `(?=`-looking sequence inside a comment is not a lookaround at all.
+        // The scanner does not model that lexing, so these must not be relaxed.
+        assert_eq!(relax_for_indexing("(?x)needle (?=x)"), None);
+        assert_eq!(relax_for_indexing("(?x:needle)"), None);
+        assert_eq!(relax_for_indexing("(?ix)needle"), None);
+        assert_eq!(relax_for_indexing("(?xi:needle)"), None);
+        // A comment group's body is arbitrary text, not syntax.
+        assert_eq!(relax_for_indexing("(?#a comment)needle"), None);
+        // Turning `x` back off still means the pattern used it.
+        assert_eq!(relax_for_indexing("(?x-i)needle"), None);
+
+        // Flag groups that do not enable `x` are still relaxable, and `x` after
+        // a `-` is being switched off, not on.
+        assert_relaxes_to("(?i)needle(?=s)", "(?i)needle");
+        assert_relaxes_to("(?i:needle)(?=s)", "(?i:needle)");
+        assert_relaxes_to("(?-x)needle(?=s)", "(?-x)needle");
+        // `(?<name>` must not be mistaken for a flag group.
+        assert_relaxes_to("(?<name>needle)(?=s)", "(?<name>needle)");
+    }
+
+    #[test]
+    fn constructs_that_cannot_be_widened_bail_out() {
+        // Backreferences: no regex-syntax equivalent, and no safe superset that
+        // keeps the trigrams meaningful.
+        assert_eq!(relax_for_indexing(r"(a)\1"), None);
+        assert_eq!(relax_for_indexing(r"(?<n>a)\k<n>"), None);
+        assert_eq!(relax_for_indexing("(?P<n>a)(?P=n)"), None);
+        // `\K` resets the reported match start; `\G` anchors to the last match.
+        assert_eq!(relax_for_indexing(r"foo\Kbar"), None);
+        assert_eq!(relax_for_indexing(r"\Gfoo"), None);
+        // Conditionals.
+        assert_eq!(relax_for_indexing("(a)(?(1)b|c)"), None);
+        // Unbalanced input must not panic or silently truncate.
+        assert_eq!(relax_for_indexing("(?=abc"), None);
+        assert_eq!(relax_for_indexing("[abc"), None);
+        assert_eq!(relax_for_indexing(r"abc\"), None);
+    }
+
+    #[test]
+    fn possessive_quantifiers_bail_rather_than_guess() {
+        // Dropping the modifier off `x}+` would turn one-or-more `}` into
+        // exactly one, which narrows an anchored pattern. `}` is not reliably
+        // distinguishable from a literal brace, so every case bails.
+        assert_eq!(relax_for_indexing("a*+b"), None);
+        assert_eq!(relax_for_indexing("a++b"), None);
+        assert_eq!(relax_for_indexing("a?+b"), None);
+        assert_eq!(relax_for_indexing("a{2,3}+b"), None);
+        // An escaped `+` after a quantifier is a literal, not a modifier.
+        assert_relaxes_to(r"a*\+b", r"a*\+b");
+        // And a `+` after an *escaped* quantifier character is an ordinary
+        // repeat, so it must not be mistaken for a modifier either.
+        assert_relaxes_to(r"a\*+b", r"a\*+b");
+    }
+
+    #[test]
+    fn relaxed_multi_pattern_plan_degrades_instead_of_erroring() {
+        // One unrelaxable pattern poisons the union, exactly as `MatchAll` does
+        // for alternation — but it is a plan, never an error.
+        let plan = build_relaxed_multi_pattern_plan(
+            &["(?<!//)ExchangePrincipal".to_string(), r"(a)\1".to_string()],
+            false,
+        );
+        assert!(plan.is_match_all());
+
+        let plan = build_relaxed_multi_pattern_plan(
+            &[
+                "(?<!//)ExchangePrincipal".to_string(),
+                "(?=x)Serialization".to_string(),
+            ],
+            false,
+        );
+        assert!(
+            !plan.is_match_all(),
+            "two relaxable patterns union into a usable plan"
+        );
+    }
+
+    #[test]
+    fn a_lookaround_only_pattern_falls_back_to_a_full_scan() {
+        // Relaxing leaves `^`, which constrains nothing the index can use. The
+        // result must be `MatchAll`, not an empty (and therefore empty-result)
+        // plan.
+        let plan = build_relaxed_multi_pattern_plan(&["^(?=.*foo)".to_string()], false);
+        assert!(plan.is_match_all());
+    }
+
+    #[test]
+    fn relaxation_never_narrows_the_language() {
+        // The soundness property, checked concretely: anything the original
+        // matches, the relaxed pattern matches too.
+        let cases: [(&str, &[&str]); 4] = [
+            ("(?<!//)ExchangePrincipal", &["x ExchangePrincipal"]),
+            ("(?=.*foo)bar", &["foo bar", "bar foo"]),
+            ("(?>ab)c", &["abc"]),
+            ("a(?!b)c", &["ac"]),
+        ];
+        for (pattern, haystacks) in cases {
+            let relaxed = relax_for_indexing(pattern).expect("relaxable");
+            let re = regex::Regex::new(&relaxed).expect("relaxed pattern parses");
+            for haystack in haystacks {
+                assert!(
+                    re.is_match(haystack),
+                    "{relaxed:?} (from {pattern:?}) must still match {haystack:?}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_literal_plan() {

--- a/tgrep-core/src/trigram.rs
+++ b/tgrep-core/src/trigram.rs
@@ -35,7 +35,7 @@ pub fn bloom_hash(byte: u8) -> u8 {
 }
 
 /// Per-trigram masks for a single file.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TrigramMasks {
     /// Positional mask: bit i is set if the trigram occurs at offset where offset % 8 == i.
     pub loc_mask: u8,
@@ -133,12 +133,26 @@ pub fn extract_merged_masks(content: &[u8]) -> HashMap<TrigramHash, TrigramMasks
         return per_tri;
     }
 
-    let lower = content.to_ascii_lowercase();
-    let lower_tri_masks = extract_with_masks(&lower);
-    for &(tri, m) in lower_tri_masks.iter() {
-        let entry = per_tri.entry(tri).or_default();
-        entry.loc_mask |= m.loc_mask;
-        entry.next_mask |= m.next_mask;
+    // Second pass over the same bytes, lowercased. Folding the case conversion
+    // into the window rather than materialising a lowercased duplicate of the
+    // file keeps peak memory independent of file size, which matters because
+    // the builder holds several whole files in flight at once.
+    //
+    // This is equivalent to extracting from a lowercased copy: ASCII
+    // lowercasing is 1:1 on bytes, so every offset — and therefore every
+    // `loc_bit` — is unchanged, and `|=` is associative, so merging per window
+    // lands on the same masks as merging two completed sets.
+    for (i, window) in content.windows(3).enumerate() {
+        let h = hash(
+            window[0].to_ascii_lowercase(),
+            window[1].to_ascii_lowercase(),
+            window[2].to_ascii_lowercase(),
+        );
+        let entry = per_tri.entry(h).or_default();
+        entry.loc_mask |= loc_bit(i);
+        if i + 3 < content.len() {
+            entry.next_mask |= next_bit(content[i + 3].to_ascii_lowercase());
+        }
     }
 
     per_tri
@@ -192,6 +206,55 @@ mod tests {
     fn test_is_binary() {
         assert!(!is_binary(b"hello world"));
         assert!(is_binary(b"hello\0world"));
+    }
+
+    /// `extract_merged_masks` folds the lowercase pass into the window instead
+    /// of materialising a lowercased copy of the file. Pin it against the
+    /// formulation it replaced, which is the definition of what it must produce.
+    fn merged_masks_via_materialised_copy(content: &[u8]) -> HashMap<TrigramHash, TrigramMasks> {
+        let mut expected: HashMap<TrigramHash, TrigramMasks> = HashMap::new();
+        for (tri, m) in extract_with_masks(content) {
+            expected.insert(tri, m);
+        }
+        let lower = content.to_ascii_lowercase();
+        for (tri, m) in extract_with_masks(&lower) {
+            let entry = expected.entry(tri).or_default();
+            entry.loc_mask |= m.loc_mask;
+            entry.next_mask |= m.next_mask;
+        }
+        expected
+    }
+
+    #[test]
+    fn merged_masks_match_a_materialised_lowercase_pass() {
+        // Mixed case, repeats across the 8-byte `loc_mask` period, non-ASCII,
+        // and a trailing window whose next byte does not exist.
+        for content in [
+            b"Foo BAR foo Baz QUX quux Foo".as_slice(),
+            b"AAAAAAAAAAAAAAAAA".as_slice(),
+            b"MixedCase\nMIXEDCASE\nmixedcase\r\n".as_slice(),
+            b"\xc3\x9cber STRASSE \xc3\xbcber strasse".as_slice(),
+            b"ABC".as_slice(),
+            b"ab".as_slice(),
+            b"".as_slice(),
+            b"no uppercase here at all".as_slice(),
+        ] {
+            assert_eq!(
+                extract_merged_masks(content),
+                merged_masks_via_materialised_copy(content),
+                "mismatch for {:?}",
+                String::from_utf8_lossy(content)
+            );
+        }
+    }
+
+    #[test]
+    fn merged_masks_cover_both_cases_of_a_trigram() {
+        let merged = extract_merged_masks(b"Foo");
+        // The literal bytes and their lowercased form are both present, so a
+        // case-insensitive query planned on either spelling finds the file.
+        assert!(merged.contains_key(&hash(b'F', b'o', b'o')));
+        assert!(merged.contains_key(&hash(b'f', b'o', b'o')));
     }
 
     #[test]

--- a/tgrep-core/src/trigram.rs
+++ b/tgrep-core/src/trigram.rs
@@ -7,6 +7,50 @@ use std::collections::{HashMap, HashSet};
 
 pub type TrigramHash = u32;
 
+/// Hasher for trigram-keyed maps.
+///
+/// A trigram key *is* its own hash: packing three bytes into 24 bits is
+/// injective, so there is nothing for a cryptographic hash to protect against.
+/// The default SipHash is not free, though, and extraction hashes once per
+/// input byte — twice for a file containing any uppercase — which put it
+/// directly on the critical path of every index build.
+///
+/// One multiply-xorshift replaces it. The xorshift is not optional: hashbrown
+/// takes the bucket index from the *low* bits of the hash, and the low `k` bits
+/// of `value * K` depend only on the low `k` bits of `value`, which for a
+/// trigram is its last byte alone. Folding the high half down mixes all 24 bits
+/// into both the bucket index and the top-7-bit control byte.
+#[derive(Default, Clone, Copy)]
+pub struct TrigramHasher(u64);
+
+impl std::hash::Hasher for TrigramHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    /// Only reachable if a key type other than `u32` is ever used with this
+    /// hasher; kept correct rather than fast.
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.0 = (self.0 ^ u64::from(byte)).wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+
+    #[inline]
+    fn write_u32(&mut self, value: u32) {
+        let mixed = u64::from(value).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        self.0 = mixed ^ (mixed >> 32);
+    }
+}
+
+/// [`std::hash::BuildHasher`] for [`TrigramHasher`].
+pub type BuildTrigramHasher = std::hash::BuildHasherDefault<TrigramHasher>;
+
+/// A file's trigrams with their merged masks.
+pub type TrigramMaskMap = HashMap<TrigramHash, TrigramMasks, BuildTrigramHasher>;
+
 /// Pack three bytes into a single u32 trigram hash.
 #[inline]
 pub fn hash(a: u8, b: u8, c: u8) -> TrigramHash {
@@ -71,7 +115,7 @@ pub fn extract_with_masks(data: &[u8]) -> Vec<(TrigramHash, TrigramMasks)> {
 
     // Use HashMap instead of 16M arrays — much less allocation pressure
     // since typical files have far fewer than 16M unique trigrams.
-    let mut masks: HashMap<TrigramHash, TrigramMasks> = HashMap::new();
+    let mut masks = TrigramMaskMap::default();
     let mut order: Vec<TrigramHash> = Vec::new();
 
     for (i, window) in data.windows(3).enumerate() {
@@ -86,10 +130,7 @@ pub fn extract_with_masks(data: &[u8]) -> Vec<(TrigramHash, TrigramMasks)> {
         }
     }
 
-    order
-        .into_iter()
-        .map(|h| (h, masks.remove(&h).unwrap()))
-        .collect()
+    order.into_iter().map(|h| (h, masks[&h])).collect()
 }
 
 /// Check whether consecutive trigrams from a literal can be adjacent based on masks.
@@ -121,38 +162,74 @@ pub fn check_next_byte(masks: &TrigramMasks, next_byte: u8) -> bool {
 /// Extract trigrams with masks from both original and lowercased content,
 /// merging masks per trigram. This is the standard extraction used by both
 /// the on-disk builder and the live index overlay.
-pub fn extract_merged_masks(content: &[u8]) -> HashMap<TrigramHash, TrigramMasks> {
-    let tri_masks = extract_with_masks(content);
-
-    let mut per_tri: HashMap<TrigramHash, TrigramMasks> = HashMap::with_capacity(tri_masks.len());
-    for (tri, m) in tri_masks {
-        per_tri.insert(tri, m);
-    }
-
-    if !content.iter().any(|&b| b.is_ascii_uppercase()) {
+pub fn extract_merged_masks(content: &[u8]) -> TrigramMaskMap {
+    let mut per_tri = TrigramMaskMap::default();
+    if content.len() < 3 {
         return per_tri;
     }
 
-    // Second pass over the same bytes, lowercased. Folding the case conversion
-    // into the window rather than materialising a lowercased duplicate of the
-    // file keeps peak memory independent of file size, which matters because
-    // the builder holds several whole files in flight at once.
+    // Folding the case conversion into the window rather than materialising a
+    // lowercased duplicate of the file keeps peak memory independent of file
+    // size, which matters because the builder holds several whole files in
+    // flight at once.
     //
     // This is equivalent to extracting from a lowercased copy: ASCII
     // lowercasing is 1:1 on bytes, so every offset — and therefore every
     // `loc_bit` — is unchanged, and `|=` is associative, so merging per window
     // lands on the same masks as merging two completed sets.
+    //
+    // Both cases are folded into the *same* pass rather than run as two passes
+    // over the file. Most windows in real source are already lowercase, so
+    // their lowered trigram is the same key; recognising that collapses the
+    // second pass's hash and probe into a single extra `|=` on an entry that is
+    // already in hand, and leaves genuine work only for windows that actually
+    // contain an uppercase byte.
+    let has_upper = content.iter().any(|byte| byte.is_ascii_uppercase());
+    let len = content.len();
+
     for (i, window) in content.windows(3).enumerate() {
-        let h = hash(
+        let trigram = hash(window[0], window[1], window[2]);
+        let loc = loc_bit(i);
+        let next = if i + 3 < len {
+            next_bit(content[i + 3])
+        } else {
+            0
+        };
+
+        if !has_upper {
+            // No uppercase anywhere means the lowercased pass would recompute
+            // this identical entry for every window.
+            let entry = per_tri.entry(trigram).or_default();
+            entry.loc_mask |= loc;
+            entry.next_mask |= next;
+            continue;
+        }
+
+        let lowered = hash(
             window[0].to_ascii_lowercase(),
             window[1].to_ascii_lowercase(),
             window[2].to_ascii_lowercase(),
         );
-        let entry = per_tri.entry(h).or_default();
-        entry.loc_mask |= loc_bit(i);
-        if i + 3 < content.len() {
-            entry.next_mask |= next_bit(content[i + 3].to_ascii_lowercase());
+        // The lowercased pass also lowercases the *following* byte, so an
+        // otherwise-lowercase window followed by an uppercase byte still
+        // contributes a second next_mask bit to the same entry.
+        let next_lowered = if i + 3 < len {
+            next_bit(content[i + 3].to_ascii_lowercase())
+        } else {
+            0
+        };
+
+        let entry = per_tri.entry(trigram).or_default();
+        entry.loc_mask |= loc;
+        if lowered == trigram {
+            entry.next_mask |= next | next_lowered;
+            continue;
         }
+        entry.next_mask |= next;
+
+        let lowered_entry = per_tri.entry(lowered).or_default();
+        lowered_entry.loc_mask |= loc;
+        lowered_entry.next_mask |= next_lowered;
     }
 
     per_tri
@@ -211,8 +288,8 @@ mod tests {
     /// `extract_merged_masks` folds the lowercase pass into the window instead
     /// of materialising a lowercased copy of the file. Pin it against the
     /// formulation it replaced, which is the definition of what it must produce.
-    fn merged_masks_via_materialised_copy(content: &[u8]) -> HashMap<TrigramHash, TrigramMasks> {
-        let mut expected: HashMap<TrigramHash, TrigramMasks> = HashMap::new();
+    fn merged_masks_via_materialised_copy(content: &[u8]) -> TrigramMaskMap {
+        let mut expected = TrigramMaskMap::default();
         for (tri, m) in extract_with_masks(content) {
             expected.insert(tri, m);
         }
@@ -238,6 +315,11 @@ mod tests {
             b"ab".as_slice(),
             b"".as_slice(),
             b"no uppercase here at all".as_slice(),
+            // An all-lowercase window whose *next* byte is uppercase. The
+            // lowercased pass folds onto the same key, so its next_mask bit has
+            // to reach the entry the original pass already created.
+            b"abcD abcd".as_slice(),
+            b"zzzZzzz".as_slice(),
         ] {
             assert_eq!(
                 extract_merged_masks(content),

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -192,6 +192,24 @@ fn display_ignore_error(err: &ignore::Error, root: &Path) -> String {
     format!("{shown}: {inner}")
 }
 
+/// Git's own case-insensitive ignore matching, when the repository asks for it.
+///
+/// Both walks build this the same way on purpose. They must agree on what the
+/// tree contains: the indexing walk decides what goes in, and the stale check
+/// decides what is missing and should be evicted. A file one includes and the
+/// other does not is indexed and then immediately deleted, every single time —
+/// the failure mode pinned by `tgrep-cli/tests/serve_max_filesize.rs`.
+///
+/// See [`crate::gitignore::CaseInsensitiveIgnore`] for what it matches and why.
+fn git_ignorecase_filter(
+    root: &Path,
+    no_ignore: bool,
+) -> Option<crate::gitignore::CaseInsensitiveIgnore> {
+    (!no_ignore)
+        .then(|| crate::gitignore::CaseInsensitiveIgnore::new(root))
+        .flatten()
+}
+
 /// Walk a directory tree, respecting .gitignore rules (unless disabled).
 /// Returns paths of text files suitable for indexing/searching.
 ///
@@ -217,6 +235,7 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
         .flatten()
         .map(std::sync::Arc::new);
     let p4ignore_root = root.clone();
+    let ignorecase = git_ignorecase_filter(&root, opts.no_ignore);
 
     let mut builder = WalkBuilder::new(&root);
     builder
@@ -235,16 +254,19 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
             if entry.file_name() == ".gitignore" {
                 return true;
             }
+            let is_dir = entry.file_type().is_some_and(|kind| kind.is_dir());
+            if let Some(ignorecase) = &ignorecase
+                && ignorecase.excludes(entry.path(), is_dir)
+            {
+                return false;
+            }
             let Some(matcher) = &p4ignore else {
                 return true;
             };
             let Ok(relative) = entry.path().strip_prefix(&p4ignore_root) else {
                 return true;
             };
-            !matcher.is_ignored(
-                relative,
-                entry.file_type().is_some_and(|kind| kind.is_dir()),
-            )
+            !matcher.is_ignored(relative, is_dir)
         })
         .threads(opts.threads.unwrap_or_else(walker_thread_count).max(1));
     // `--ignore-file` is applied even under `--no-ignore`: the user asked for
@@ -444,6 +466,7 @@ pub fn walk_file_metadata(root: &Path, opts: &MetaWalkOptions) -> MetaWalkResult
         .flatten()
         .map(std::sync::Arc::new);
     let match_root = root.to_path_buf();
+    let ignorecase = git_ignorecase_filter(root, no_ignore);
     let root = root.to_path_buf();
 
     let walker = WalkBuilder::new(&root)
@@ -453,16 +476,19 @@ pub fn walk_file_metadata(root: &Path, opts: &MetaWalkOptions) -> MetaWalkResult
         .git_global(!no_ignore)
         .git_exclude(!no_ignore)
         .filter_entry(move |entry| {
+            let is_dir = entry.file_type().is_some_and(|kind| kind.is_dir());
+            if let Some(ignorecase) = &ignorecase
+                && ignorecase.excludes(entry.path(), is_dir)
+            {
+                return false;
+            }
             let Some(matcher) = &p4ignore else {
                 return true;
             };
             let Ok(relative) = entry.path().strip_prefix(&match_root) else {
                 return true;
             };
-            !matcher.is_ignored(
-                relative,
-                entry.file_type().is_some_and(|kind| kind.is_dir()),
-            )
+            !matcher.is_ignored(relative, is_dir)
         })
         .threads(walker_thread_count())
         .build_parallel();
@@ -577,8 +603,7 @@ mod tests {
         dir
     }
 
-    fn sorted_filenames(result: &WalkResult, root: &Path) -> Vec<String> {
-        let mut names: Vec<String> = result
+    fn sorted_filenames(result: &WalkResult, root: &Path) -> Vec<String> {        let mut names: Vec<String> = result
             .files
             .iter()
             .map(|p| {
@@ -1252,5 +1277,157 @@ mod tests {
             MetaWalkOptions::default().max_file_size,
             WalkOptions::default().max_file_size
         );
+    }
+
+    // --- git's case-insensitive ignore matching ------------------------------
+    //
+    // On a case-insensitive filesystem git sets `core.ignorecase` and stops
+    // distinguishing case when matching ignore rules. The `ignore` crate does
+    // not, so a rule spelled `QLogs` left a `qlogs/` directory fully walked and
+    // indexed even though `git status` never mentions it. Matching the way git
+    // does starts catching *tracked* files too, which git would never hide, so
+    // the tracked-file exemption has to come with it.
+
+    /// A `.git` directory real enough for the walker: a config and an index.
+    fn fake_git_repo(root: &Path, ignorecase: bool, tracked: &[&str]) {
+        let git = root.join(".git");
+        fs::create_dir_all(&git).unwrap();
+        fs::write(
+            git.join("config"),
+            format!("[core]\n\tignorecase = {ignorecase}\n"),
+        )
+        .unwrap();
+
+        let mut index = Vec::new();
+        index.extend_from_slice(b"DIRC");
+        index.extend_from_slice(&2u32.to_be_bytes());
+        index.extend_from_slice(&(tracked.len() as u32).to_be_bytes());
+        for path in tracked {
+            let start = index.len();
+            index.extend_from_slice(&[0u8; 60]);
+            index.extend_from_slice(&(path.len() as u16).to_be_bytes());
+            index.extend_from_slice(path.as_bytes());
+            index.push(0);
+            while (index.len() - start) % 8 != 0 {
+                index.push(0);
+            }
+        }
+        fs::write(git.join("index"), index).unwrap();
+    }
+
+    /// The shape of the problem: a rule in one case, a directory in another,
+    /// and an untracked artifact inside it.
+    ///
+    /// Extensions are all ones the walker treats as text. A `.JPG` would be a
+    /// truer retelling of the enlistment this came from, but the binary
+    /// extension filter drops it before any of this runs, so it would prove
+    /// nothing.
+    fn ignorecase_fixture(ignorecase: bool, tracked: &[&str]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fake_git_repo(root, ignorecase, tracked);
+        fs::write(root.join(".gitignore"), "QLogs\n*.txt\n").unwrap();
+        fs::create_dir_all(root.join("qlogs")).unwrap();
+        fs::write(root.join("qlogs/artifact.rs"), "junk").unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+        // Matched by `*.txt` only when case is ignored.
+        fs::write(root.join("src/Kept.TXT"), "tracked").unwrap();
+        fs::write(root.join("src/Gone.TXT"), "untracked").unwrap();
+        dir
+    }
+
+    #[test]
+    fn ignorecase_hides_what_git_hides_and_keeps_what_git_tracks() {
+        // `src/Kept.TXT` is tracked, so `*.txt` must not hide it even though
+        // the rule now matches. `src/Gone.TXT` is identical but untracked, and
+        // the whole `qlogs/` directory goes — which is the point.
+        let dir = ignorecase_fixture(true, &["src/main.rs", "src/Kept.TXT"]);
+        let names = sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
+        assert!(
+            names.contains(&"src/Kept.TXT".to_string()),
+            "dropped a tracked file: {names:?}"
+        );
+        assert!(names.contains(&"src/main.rs".to_string()), "{names:?}");
+        assert!(
+            !names.contains(&"src/Gone.TXT".to_string()),
+            "kept an untracked file the rule matches: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.starts_with("qlogs/")),
+            "kept an untracked file inside an ignored directory: {names:?}"
+        );
+    }
+
+    #[test]
+    fn without_ignorecase_the_walk_is_unchanged() {
+        // The gate: a repository that distinguishes case gets git's ordinary
+        // case-sensitive behaviour, and pays nothing for this.
+        let dir = ignorecase_fixture(false, &["src/main.rs", "src/Kept.TXT"]);
+        let names = sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
+        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+        assert!(names.contains(&"src/Kept.TXT".to_string()), "{names:?}");
+        assert!(names.contains(&"src/Gone.TXT".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn a_tracked_file_keeps_its_ignored_directory_walkable() {
+        // A directory cannot be pruned just because a rule matches it: git
+        // still reports the tracked files inside.
+        let dir = ignorecase_fixture(true, &["qlogs/kept.rs"]);
+        fs::write(dir.path().join("qlogs/kept.rs"), "tracked").unwrap();
+        let names = sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
+        assert!(
+            names.contains(&"qlogs/kept.rs".to_string()),
+            "pruned a directory holding a tracked file: {names:?}"
+        );
+        assert!(
+            !names.contains(&"qlogs/artifact.rs".to_string()),
+            "{names:?}"
+        );
+    }
+
+    #[test]
+    fn no_ignore_turns_the_whole_thing_off() {
+        let dir = ignorecase_fixture(true, &["src/main.rs"]);
+        let names = sorted_filenames(
+            &walk_dir(
+                dir.path(),
+                &WalkOptions {
+                    no_ignore: true,
+                    ..Default::default()
+                },
+            ),
+            dir.path(),
+        );
+        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn an_unreadable_index_excludes_nothing() {
+        // Without the index there is no way to tell tracked from untracked,
+        // and guessing wrong would hide real source. Decline instead.
+        let dir = ignorecase_fixture(true, &[]);
+        fs::write(dir.path().join(".git/index"), b"not an index").unwrap();
+        let names = sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
+        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+        assert!(names.contains(&"src/Kept.TXT".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn both_walks_agree_on_what_the_tree_contains() {
+        // The indexing walk decides what goes into the index and the metadata
+        // walk decides what is missing from it. If they disagree, every build
+        // indexes a file the next stale check evicts.
+        let dir = ignorecase_fixture(true, &["src/main.rs", "src/Kept.TXT"]);
+        let indexed = sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
+        let mut seen: Vec<String> = walk_file_metadata(dir.path(), &MetaWalkOptions::default())
+            .files
+            .iter()
+            .map(|f| f.relative_path.replace('\\', "/"))
+            .filter(|p| !p.starts_with(".git/"))
+            .collect();
+        seen.sort();
+        assert_eq!(indexed, seen);
     }
 }

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -200,13 +200,28 @@ fn display_ignore_error(err: &ignore::Error, root: &Path) -> String {
 /// other does not is indexed and then immediately deleted, every single time —
 /// the failure mode pinned by `tgrep-cli/tests/serve_max_filesize.rs`.
 ///
+/// The flags must be the *same* ones handed to `WalkBuilder`, because this is
+/// only ever sound as a narrowing of the case-sensitive pass. A source that
+/// pass was told to skip must be skipped here too, or a `--no-ignore-*` flag
+/// would be silently undone.
+///
 /// See [`crate::gitignore::CaseInsensitiveIgnore`] for what it matches and why.
 fn git_ignorecase_filter(
     root: &Path,
     no_ignore: bool,
+    no_ignore_vcs: bool,
+    no_ignore_exclude: bool,
+    no_ignore_parent: bool,
 ) -> Option<crate::gitignore::CaseInsensitiveIgnore> {
     (!no_ignore)
-        .then(|| crate::gitignore::CaseInsensitiveIgnore::new(root))
+        .then(|| {
+            crate::gitignore::CaseInsensitiveIgnore::new(
+                root,
+                !no_ignore_vcs,
+                !no_ignore_exclude,
+                !no_ignore_parent,
+            )
+        })
         .flatten()
 }
 
@@ -235,7 +250,13 @@ pub fn walk_dir(root: &Path, opts: &WalkOptions) -> WalkResult {
         .flatten()
         .map(std::sync::Arc::new);
     let p4ignore_root = root.clone();
-    let ignorecase = git_ignorecase_filter(&root, opts.no_ignore);
+    let ignorecase = git_ignorecase_filter(
+        &root,
+        opts.no_ignore,
+        opts.no_ignore_vcs,
+        opts.no_ignore_exclude,
+        opts.no_ignore_parent,
+    );
 
     let mut builder = WalkBuilder::new(&root);
     builder
@@ -466,7 +487,11 @@ pub fn walk_file_metadata(root: &Path, opts: &MetaWalkOptions) -> MetaWalkResult
         .flatten()
         .map(std::sync::Arc::new);
     let match_root = root.to_path_buf();
-    let ignorecase = git_ignorecase_filter(root, no_ignore);
+    // `MetaWalkOptions` carries no finer ignore flags, and the builder below
+    // enables gitignore and exclude together on `!no_ignore`. Passing `false`
+    // for both mirrors that exactly, which is what keeps this walk and
+    // `walk_dir` agreeing about the tree under `serve`.
+    let ignorecase = git_ignorecase_filter(root, no_ignore, false, false, false);
     let root = root.to_path_buf();
 
     let walker = WalkBuilder::new(&root)
@@ -1401,6 +1426,79 @@ mod tests {
             dir.path(),
         );
         assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn no_ignore_vcs_turns_the_whole_thing_off_too() {
+        // The rules only live in `.gitignore` here, and `--no-ignore-vcs` tells
+        // the case-sensitive pass to skip that file. If the case-insensitive
+        // pass kept reading it, it would become the *only* thing excluding and
+        // the flag would exclude more than not passing it at all.
+        let dir = ignorecase_fixture(true, &["src/main.rs"]);
+        let names = sorted_filenames(
+            &walk_dir(
+                dir.path(),
+                &WalkOptions {
+                    no_ignore_vcs: true,
+                    ..Default::default()
+                },
+            ),
+            dir.path(),
+        );
+        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+        assert!(names.contains(&"src/Gone.TXT".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn no_ignore_exclude_leaves_the_repository_exclude_file_unread() {
+        // Same argument as above, for the other source this matcher reads. The
+        // rules live only in `.git/info/exclude`, so honouring the flag must
+        // leave nothing behind to match with.
+        let dir = ignorecase_fixture(true, &["src/main.rs"]);
+        fs::remove_file(dir.path().join(".gitignore")).unwrap();
+        fs::create_dir_all(dir.path().join(".git/info")).unwrap();
+        fs::write(dir.path().join(".git/info/exclude"), "QLogs\n").unwrap();
+
+        let with_exclude =
+            sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
+        assert!(
+            !with_exclude.contains(&"qlogs/artifact.rs".to_string()),
+            "the exclude file should have hidden this: {with_exclude:?}"
+        );
+
+        let names = sorted_filenames(
+            &walk_dir(
+                dir.path(),
+                &WalkOptions {
+                    no_ignore_exclude: true,
+                    ..Default::default()
+                },
+            ),
+            dir.path(),
+        );
+        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn no_ignore_parent_leaves_a_subdirectory_walk_alone() {
+        // Walking `src/` reaches the repository-wide rules only as parent rules,
+        // which is exactly what `--no-ignore-parent` switches off.
+        let dir = ignorecase_fixture(true, &["src/main.rs"]);
+        let src = dir.path().join("src");
+        let names = sorted_filenames(
+            &walk_dir(
+                &src,
+                &WalkOptions {
+                    no_ignore_parent: true,
+                    ..Default::default()
+                },
+            ),
+            &src,
+        );
+        assert!(
+            names.contains(&"Gone.TXT".to_string()),
+            "applied a parent rule the flag disabled: {names:?}"
+        );
     }
 
     #[test]

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -2,30 +2,30 @@
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
-/// Default maximum file size to index (64 MiB). Larger files are skipped.
+/// Whether a walk applies a size limit by default.
 ///
-/// This is a runaway guard, not a cost control. Size is a poor proxy for index
-/// cost, because the files that trip a cap are overwhelmingly generated and
-/// therefore repetitive: the kernel's 24 MB `dcn_3_2_0_sh_mask.h` contributes
-/// 7,263 distinct trigrams, *fewer* than the 10,936 of the 224 KB
-/// `fs/ext4/super.c`. Indexing all 489 MB of `drivers/gpu/drm/amd/include/
-/// asic_reg` rather than only its sub-1 MiB files grew the index by 5.9 MB —
-/// 1.3% of the added content, against 47% for the small files it already held.
+/// It does not. ripgrep has no default `--max-filesize`, and a cap costs
+/// correctness here in a way it does not cost ripgrep: oversized files are
+/// counted but their paths are never recorded, so an indexed search silently
+/// returned no match where both `--no-index` and ripgrep found one.
 ///
-/// The former 1 MiB cap bought little of that and cost correctness: because
-/// oversized files are counted but their paths are never recorded, an indexed
-/// search silently returned no match where both `--no-index` and ripgrep found
-/// one. What remains here only bounds the pathological case, such as a
-/// checked-in database dump that sniffs as text.
+/// A cap used to be the only thing bounding build memory, because the builder
+/// read every file whole and in parallel. It no longer does — files past
+/// [`crate::builder`]'s mapping threshold are memory-mapped, so their pages are
+/// file-backed and reclaimable rather than heap the process cannot give back.
+/// With memory no longer tied to the largest file, the cap was buying nothing
+/// but missing results.
 ///
-/// Raising it is not free — [`crate::builder`] reads each file whole, in
-/// parallel, so this also raises worst-case transient memory during a build.
-/// 64 MiB matches the default external-sort arena, keeping the two bounds in
-/// step.
+/// Size was always a poor proxy for index cost anyway, because the files that
+/// trip a cap are overwhelmingly generated and therefore repetitive: the
+/// kernel's 24 MB `dcn_3_2_0_sh_mask.h` contributes 7,263 distinct trigrams,
+/// *fewer* than the 10,936 of the 224 KB `fs/ext4/super.c`. Indexing all 489 MB
+/// of `drivers/gpu/drm/amd/include/asic_reg` rather than only its sub-1 MiB
+/// files grew the index by 5.9 MB — 1.3% of the added content, against 47% for
+/// the small files it already held.
 ///
-/// Search paths that scan the filesystem directly (`--no-index`, `--files`)
-/// have no such constraint and default to no limit, matching ripgrep.
-pub const DEFAULT_MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
+/// `--max-filesize` remains available for callers that want the bound.
+pub const DEFAULT_MAX_FILE_SIZE: Option<u64> = None;
 
 /// Binary extensions that can be rejected without reading file content.
 const BINARY_EXTENSIONS: &[&str] = &[
@@ -113,10 +113,9 @@ pub struct WalkOptions {
     pub threads: Option<usize>,
 }
 
-// Hand-written rather than derived: `Option::default()` is `None`, which would
-// silently turn the size limit off for every existing caller that builds this
-// struct with `..Default::default()` (the index builder and the server among
-// them). The default has to keep bounding the index.
+// Hand-written rather than derived so the size limit is a deliberate choice
+// rather than whatever `Option::default()` happens to be. It is `None` — no
+// limit — matching ripgrep; see [`DEFAULT_MAX_FILE_SIZE`].
 impl Default for WalkOptions {
     fn default() -> Self {
         Self {
@@ -124,7 +123,7 @@ impl Default for WalkOptions {
             no_ignore: false,
             search_binary: false,
             follow_links: false,
-            max_file_size: Some(DEFAULT_MAX_FILE_SIZE),
+            max_file_size: DEFAULT_MAX_FILE_SIZE,
             collect_gitignore_files: false,
             exclude_dirs: Vec::new(),
             max_depth: None,
@@ -388,15 +387,15 @@ pub struct MetaWalkOptions {
 }
 
 impl Default for MetaWalkOptions {
-    /// Hand-written rather than derived: `#[derive(Default)]` would make
-    /// `max_file_size` `None`, which means *no limit* and so would quietly
-    /// invert the default rather than matching [`WalkOptions::default`].
+    /// Hand-written rather than derived so the size limit stays an explicit
+    /// decision that matches [`WalkOptions::default`] rather than an accident
+    /// of `#[derive(Default)]`.
     fn default() -> Self {
         Self {
             exclude_dirs: Vec::new(),
             no_ignore: false,
             no_require_git: false,
-            max_file_size: Some(DEFAULT_MAX_FILE_SIZE),
+            max_file_size: DEFAULT_MAX_FILE_SIZE,
         }
     }
 }
@@ -1055,8 +1054,8 @@ mod tests {
             vec!["small.txt"]
         );
 
-        // The default is well above a couple of megabytes, so an ordinary
-        // large source file is indexed rather than silently dropped.
+        // The default applies no cap, so an ordinary large source file is
+        // indexed rather than silently dropped.
         assert_eq!(
             names(&MetaWalkOptions::default()),
             vec!["big.txt", "small.txt"]
@@ -1079,6 +1078,33 @@ mod tests {
                 ..Default::default()
             }),
             vec!["big.txt", "small.txt"]
+        );
+    }
+
+    #[test]
+    fn walks_default_to_no_size_cap() {
+        // Both option structs hand-write `Default` precisely so this cannot
+        // drift, and both are meant to agree with ripgrep: no limit.
+        assert_eq!(DEFAULT_MAX_FILE_SIZE, None);
+        assert_eq!(WalkOptions::default().max_file_size, None);
+        assert_eq!(MetaWalkOptions::default().max_file_size, None);
+
+        // Pinned against a file past the 64 MiB cap this used to carry, so the
+        // regression this guards against — an oversized file counted but never
+        // recorded, and so silently unsearchable — is what the test exercises.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let big = root.join("huge.txt");
+        // `set_len` rather than writing 65 MiB: the metadata walk only stats.
+        std::fs::File::create(&big)
+            .unwrap()
+            .set_len(65 * 1024 * 1024)
+            .unwrap();
+
+        let files = walk_file_metadata(root, &MetaWalkOptions::default()).files;
+        assert_eq!(
+            files.iter().map(|f| &f.relative_path).collect::<Vec<_>>(),
+            vec!["huge.txt"]
         );
     }
 

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -2,12 +2,30 @@
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
-/// Default maximum file size to index (1 MB). Larger files are skipped.
+/// Default maximum file size to index (64 MiB). Larger files are skipped.
 ///
-/// This bounds the index, which is why it stays the default for index builds.
+/// This is a runaway guard, not a cost control. Size is a poor proxy for index
+/// cost, because the files that trip a cap are overwhelmingly generated and
+/// therefore repetitive: the kernel's 24 MB `dcn_3_2_0_sh_mask.h` contributes
+/// 7,263 distinct trigrams, *fewer* than the 10,936 of the 224 KB
+/// `fs/ext4/super.c`. Indexing all 489 MB of `drivers/gpu/drm/amd/include/
+/// asic_reg` rather than only its sub-1 MiB files grew the index by 5.9 MB —
+/// 1.3% of the added content, against 47% for the small files it already held.
+///
+/// The former 1 MiB cap bought little of that and cost correctness: because
+/// oversized files are counted but their paths are never recorded, an indexed
+/// search silently returned no match where both `--no-index` and ripgrep found
+/// one. What remains here only bounds the pathological case, such as a
+/// checked-in database dump that sniffs as text.
+///
+/// Raising it is not free — [`crate::builder`] reads each file whole, in
+/// parallel, so this also raises worst-case transient memory during a build.
+/// 64 MiB matches the default external-sort arena, keeping the two bounds in
+/// step.
+///
 /// Search paths that scan the filesystem directly (`--no-index`, `--files`)
 /// have no such constraint and default to no limit, matching ripgrep.
-pub const DEFAULT_MAX_FILE_SIZE: u64 = 1_048_576;
+pub const DEFAULT_MAX_FILE_SIZE: u64 = 64 * 1024 * 1024;
 
 /// Binary extensions that can be rejected without reading file content.
 const BINARY_EXTENSIONS: &[&str] = &[
@@ -1026,8 +1044,23 @@ mod tests {
             v
         };
 
-        // Default cap is 1 MiB, so the 2 MiB file is skipped.
-        assert_eq!(names(&MetaWalkOptions::default()), vec!["small.txt"]);
+        // A cap below the file size hides it. Pinned explicitly rather than
+        // taken from the default, so the test states the behaviour it checks
+        // instead of tracking whatever the default happens to be.
+        assert_eq!(
+            names(&MetaWalkOptions {
+                max_file_size: Some(1024 * 1024),
+                ..Default::default()
+            }),
+            vec!["small.txt"]
+        );
+
+        // The default is well above a couple of megabytes, so an ordinary
+        // large source file is indexed rather than silently dropped.
+        assert_eq!(
+            names(&MetaWalkOptions::default()),
+            vec!["big.txt", "small.txt"]
+        );
 
         // Raising the cap must reveal it. If it does not, the stale check reads
         // the file as deleted and evicts it from an index built with this cap.

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -338,8 +338,14 @@ pub fn build_gitignore_matcher_from_files(
     root: &Path,
     gitignore_files: &[PathBuf],
     ignore_files: &[PathBuf],
+    no_require_git: bool,
 ) -> Option<crate::gitignore::IgnoreMatcher> {
-    crate::gitignore::matcher_from_ignore_paths(root, gitignore_files, ignore_files)
+    crate::gitignore::matcher_from_ignore_paths_with_options(
+        root,
+        gitignore_files,
+        ignore_files,
+        no_require_git,
+    )
 }
 
 /// Filesystem metadata for a single file (no content read).
@@ -357,6 +363,8 @@ pub struct MetaWalkResult {
     pub files: Vec<FileMeta>,
     pub gitignore_files: Vec<PathBuf>,
     pub ignore_files: Vec<PathBuf>,
+    /// Entries or metadata reads the walk could not inspect.
+    pub skipped_error: usize,
 }
 
 /// Options for [`walk_file_metadata`].
@@ -414,6 +422,7 @@ pub fn walk_file_metadata(root: &Path, opts: &MetaWalkOptions) -> MetaWalkResult
     let results = std::sync::Mutex::new(Vec::new());
     let gitignore_files = std::sync::Mutex::new(Vec::new());
     let ignore_files = std::sync::Mutex::new(Vec::new());
+    let skipped_error = std::sync::atomic::AtomicUsize::new(0);
     let exclude: std::sync::Arc<Vec<String>> = std::sync::Arc::new(opts.exclude_dirs.clone());
     let p4ignore = (!no_ignore)
         .then(|| crate::gitignore::build_p4ignore_matcher(root))
@@ -449,10 +458,14 @@ pub fn walk_file_metadata(root: &Path, opts: &MetaWalkOptions) -> MetaWalkResult
         let results = &results;
         let gitignore_files = &gitignore_files;
         let ignore_files = &ignore_files;
+        let skipped_error = &skipped_error;
         Box::new(move |entry| {
             let entry = match entry {
                 Ok(e) => e,
-                Err(_) => return ignore::WalkState::Continue,
+                Err(_) => {
+                    skipped_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    return ignore::WalkState::Continue;
+                }
             };
 
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
@@ -487,22 +500,27 @@ pub fn walk_file_metadata(root: &Path, opts: &MetaWalkOptions) -> MetaWalkResult
                 Err(_) => return ignore::WalkState::Continue,
             };
 
-            if let Ok(meta) = entry.metadata() {
-                if max_file_size.is_some_and(|limit| meta.len() > limit) {
+            let meta = match entry.metadata() {
+                Ok(meta) => meta,
+                Err(_) => {
+                    skipped_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     return ignore::WalkState::Continue;
                 }
-                let mtime = meta
-                    .modified()
-                    .ok()
-                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0);
-                results.lock().unwrap().push(FileMeta {
-                    relative_path: rel_path,
-                    mtime,
-                    size: meta.len(),
-                });
+            };
+            if max_file_size.is_some_and(|limit| meta.len() > limit) {
+                return ignore::WalkState::Continue;
             }
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            results.lock().unwrap().push(FileMeta {
+                relative_path: rel_path,
+                mtime,
+                size: meta.len(),
+            });
 
             ignore::WalkState::Continue
         })
@@ -512,6 +530,7 @@ pub fn walk_file_metadata(root: &Path, opts: &MetaWalkOptions) -> MetaWalkResult
         files: results.into_inner().unwrap(),
         gitignore_files: gitignore_files.into_inner().unwrap(),
         ignore_files: ignore_files.into_inner().unwrap(),
+        skipped_error: skipped_error.into_inner(),
     }
 }
 
@@ -731,9 +750,13 @@ mod tests {
                 ..Default::default()
             },
         );
-        let gi =
-            build_gitignore_matcher_from_files(&root, &walk.gitignore_files, &walk.ignore_files)
-                .expect("matcher should build from discovered .gitignore files");
+        let gi = build_gitignore_matcher_from_files(
+            &root,
+            &walk.gitignore_files,
+            &walk.ignore_files,
+            false,
+        )
+        .expect("matcher should build from discovered .gitignore files");
 
         assert!(gi.is_ignored(Path::new("build/output.log"), false));
         assert!(gi.is_ignored(Path::new("src/cache.tmp"), false));
@@ -792,9 +815,13 @@ mod tests {
                 ..Default::default()
             },
         );
-        let gi =
-            build_gitignore_matcher_from_files(&root, &walk.gitignore_files, &walk.ignore_files)
-                .expect("matcher should build from discovered .ignore files");
+        let gi = build_gitignore_matcher_from_files(
+            &root,
+            &walk.gitignore_files,
+            &walk.ignore_files,
+            false,
+        )
+        .expect("matcher should build from discovered .ignore files");
 
         assert!(gi.is_ignored(Path::new("server/output.log"), false));
         assert!(gi.is_ignored(Path::new("build/artifact.bin"), false));
@@ -808,9 +835,26 @@ mod tests {
         // serving a subdirectory of a repository.
         let tmp = TempDir::new().unwrap();
         fs::create_dir(tmp.path().join(".git")).unwrap();
+        fs::create_dir(tmp.path().join(".git").join("info")).unwrap();
+        fs::write(
+            tmp.path().join(".gitignore"),
+            "/sub/parent.txt\n/sub/git-precedence.txt\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join(".ignore"),
+            "/sub/parent.tmp\n/sub/precedence.txt\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join(".git").join("info").join("exclude"),
+            "/sub/info.bin\n",
+        )
+        .unwrap();
         let root = tmp.path().join("sub");
         fs::create_dir_all(&root).unwrap();
-        fs::write(root.join(".gitignore"), "*.log\n").unwrap();
+        fs::write(root.join(".gitignore"), "*.log\n!precedence.txt\n").unwrap();
+        fs::write(root.join(".ignore"), "!git-precedence.txt\n").unwrap();
 
         let walk = walk_dir(
             &root,
@@ -819,10 +863,60 @@ mod tests {
                 ..Default::default()
             },
         );
-        let gi =
-            build_gitignore_matcher_from_files(&root, &walk.gitignore_files, &walk.ignore_files)
-                .expect("`.gitignore` should apply in a subdirectory of a git repo");
+        let gi = build_gitignore_matcher_from_files(
+            &root,
+            &walk.gitignore_files,
+            &walk.ignore_files,
+            false,
+        )
+        .expect("`.gitignore` should apply in a subdirectory of a git repo");
         assert!(gi.is_ignored(Path::new("build/out.log"), false));
+        assert!(gi.is_ignored(Path::new("parent.txt"), false));
+        assert!(gi.is_ignored(Path::new("parent.tmp"), false));
+        assert!(gi.is_ignored(Path::new("info.bin"), false));
+        assert!(gi.is_ignored(Path::new("precedence.txt"), false));
+        assert!(!gi.is_ignored(Path::new("git-precedence.txt"), false));
+    }
+
+    #[test]
+    fn parent_ignore_crosses_repository_boundary_but_gitignore_does_not() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "/repo/from-parent-git.txt\n").unwrap();
+        fs::write(tmp.path().join(".ignore"), "/repo/from-parent-dot.txt\n").unwrap();
+
+        let root = tmp.path().join("repo");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join("from-parent-git.txt"), "kept\n").unwrap();
+        fs::write(root.join("from-parent-dot.txt"), "ignored\n").unwrap();
+
+        let options = MetaWalkOptions::default();
+        let walk = walk_file_metadata(&root, &options);
+        let paths = walk
+            .files
+            .iter()
+            .map(|file| file.relative_path.as_str())
+            .collect::<Vec<_>>();
+        assert!(paths.contains(&"from-parent-git.txt"));
+        assert!(!paths.contains(&"from-parent-dot.txt"));
+
+        let matcher = build_gitignore_matcher_from_files(
+            &root,
+            &walk.gitignore_files,
+            &walk.ignore_files,
+            false,
+        )
+        .unwrap();
+        assert!(!matcher.is_ignored(Path::new("from-parent-git.txt"), false));
+        assert!(matcher.is_ignored(Path::new("from-parent-dot.txt"), false));
+
+        let lifted = build_gitignore_matcher_from_files(
+            &root,
+            &walk.gitignore_files,
+            &walk.ignore_files,
+            true,
+        )
+        .unwrap();
+        assert!(lifted.is_ignored(Path::new("from-parent-git.txt"), false));
     }
 
     #[test]
@@ -987,6 +1081,23 @@ mod tests {
             vec!["src/main.rs".to_string()],
             "`.gitignore` must apply once the git gate is lifted"
         );
+
+        let metadata = walk_file_metadata(
+            root,
+            &MetaWalkOptions {
+                no_require_git: true,
+                ..Default::default()
+            },
+        );
+        let matcher = build_gitignore_matcher_from_files(
+            root,
+            &metadata.gitignore_files,
+            &metadata.ignore_files,
+            true,
+        )
+        .expect("the lifted matcher should load .gitignore outside a repository");
+        assert!(matcher.is_ignored(Path::new("build/out.rs"), false));
+        assert!(matcher.is_ignored(Path::new("noisy.log"), false));
     }
 
     /// The metadata walk feeds startup stale-file detection. If it stayed

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -628,7 +628,8 @@ mod tests {
         dir
     }
 
-    fn sorted_filenames(result: &WalkResult, root: &Path) -> Vec<String> {        let mut names: Vec<String> = result
+    fn sorted_filenames(result: &WalkResult, root: &Path) -> Vec<String> {
+        let mut names: Vec<String> = result
             .files
             .iter()
             .map(|p| {
@@ -1264,10 +1265,7 @@ mod tests {
         // indexing walk classified everything between the two caps as deleted
         // and evicted it (see `tests/serve_max_filesize.rs`).
         assert_eq!(DEFAULT_MAX_FILE_SIZE, Some(64 * 1024 * 1024));
-        assert_eq!(
-            WalkOptions::default().max_file_size,
-            DEFAULT_MAX_FILE_SIZE
-        );
+        assert_eq!(WalkOptions::default().max_file_size, DEFAULT_MAX_FILE_SIZE);
         assert_eq!(
             MetaWalkOptions::default().max_file_size,
             DEFAULT_MAX_FILE_SIZE
@@ -1390,7 +1388,10 @@ mod tests {
         // case-sensitive behaviour, and pays nothing for this.
         let dir = ignorecase_fixture(false, &["src/main.rs", "src/Kept.TXT"]);
         let names = sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
-        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+        assert!(
+            names.contains(&"qlogs/artifact.rs".to_string()),
+            "{names:?}"
+        );
         assert!(names.contains(&"src/Kept.TXT".to_string()), "{names:?}");
         assert!(names.contains(&"src/Gone.TXT".to_string()), "{names:?}");
     }
@@ -1425,7 +1426,10 @@ mod tests {
             ),
             dir.path(),
         );
-        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+        assert!(
+            names.contains(&"qlogs/artifact.rs".to_string()),
+            "{names:?}"
+        );
     }
 
     #[test]
@@ -1445,7 +1449,10 @@ mod tests {
             ),
             dir.path(),
         );
-        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+        assert!(
+            names.contains(&"qlogs/artifact.rs".to_string()),
+            "{names:?}"
+        );
         assert!(names.contains(&"src/Gone.TXT".to_string()), "{names:?}");
     }
 
@@ -1476,7 +1483,10 @@ mod tests {
             ),
             dir.path(),
         );
-        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+        assert!(
+            names.contains(&"qlogs/artifact.rs".to_string()),
+            "{names:?}"
+        );
     }
 
     #[test]
@@ -1508,7 +1518,10 @@ mod tests {
         let dir = ignorecase_fixture(true, &[]);
         fs::write(dir.path().join(".git/index"), b"not an index").unwrap();
         let names = sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
-        assert!(names.contains(&"qlogs/artifact.rs".to_string()), "{names:?}");
+        assert!(
+            names.contains(&"qlogs/artifact.rs".to_string()),
+            "{names:?}"
+        );
         assert!(names.contains(&"src/Kept.TXT".to_string()), "{names:?}");
     }
 

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -2,30 +2,45 @@
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
-/// Whether a walk applies a size limit by default.
+/// The size limit a walk applies when the caller does not name one.
 ///
-/// It does not. ripgrep has no default `--max-filesize`, and a cap costs
-/// correctness here in a way it does not cost ripgrep: oversized files are
-/// counted but their paths are never recorded, so an indexed search silently
-/// returned no match where both `--no-index` and ripgrep found one.
+/// 64 MiB, which is a deliberate divergence from ripgrep's "no limit". The
+/// divergence is affordable because tgrep is not a one-shot scanner: a file
+/// that a walk picks up is also a file the index carries and re-reads on every
+/// query that its trigrams make a candidate for, so an outlier's cost is paid
+/// repeatedly rather than once.
 ///
-/// A cap used to be the only thing bounding build memory, because the builder
-/// read every file whole and in parallel. It no longer does — files past
-/// [`crate::builder`]'s mapping threshold are memory-mapped, so their pages are
-/// file-backed and reclaimable rather than heap the process cannot give back.
-/// With memory no longer tied to the largest file, the cap was buying nothing
-/// but missing results.
+/// Measured on a 292,911-file Microsoft Substrate enlistment, where a single
+/// 13.41 GiB generated build artifact is **71% of all searchable bytes**:
 ///
-/// Size was always a poor proxy for index cost anyway, because the files that
-/// trip a cap are overwhelmingly generated and therefore repetitive: the
-/// kernel's 24 MB `dcn_3_2_0_sh_mask.h` contributes 7,263 distinct trigrams,
-/// *fewer* than the 10,936 of the 224 KB `fs/ext4/super.c`. Indexing all 489 MB
-/// of `drivers/gpu/drm/amd/include/asic_reg` rather than only its sub-1 MiB
-/// files grew the index by 5.9 MB — 1.3% of the added content, against 47% for
-/// the small files it already held.
+/// | | uncapped | 64 MiB cap |
+/// |---|---|---|
+/// | cold index build | 214.5 s | 64.2 s |
+/// | warm query, same pattern | 21.30 s | 0.55 s |
+/// | files the query matched | 2,990 | 2,989 |
 ///
-/// `--max-filesize` remains available for callers that want the bound.
-pub const DEFAULT_MAX_FILE_SIZE: Option<u64> = None;
+/// A 39x query win and a 3.3x build win for one lost match in one generated
+/// file. The cap excluded 2 files of 292,911.
+///
+/// Note what this is *not* buying. The cap is no longer what bounds memory —
+/// files past [`crate::builder`]'s mapping threshold are memory-mapped, so
+/// their pages are file-backed and reclaimable. And size remains a poor proxy
+/// for *index* cost, because oversized files are overwhelmingly generated and
+/// therefore repetitive: the kernel's 24 MB `dcn_3_2_0_sh_mask.h` contributes
+/// 7,263 distinct trigrams, *fewer* than the 10,936 of the 224 KB
+/// `fs/ext4/super.c`. What the cap buys is bounded *scan* time, and it buys it
+/// where the distribution is worst.
+///
+/// The cost is real and is the reason this constant is documented at length:
+/// an oversized file is counted but its path is never recorded, so a match
+/// inside one is reported as no match, with exit status 0. Two things keep
+/// that from being silent:
+///
+/// - `--no-max-filesize` restores the uncapped, ripgrep-identical behaviour.
+/// - A file named directly on the command line is never dropped by the
+///   *default* cap, only by one the user asked for. Pointing at a file is an
+///   unambiguous request to search it.
+pub const DEFAULT_MAX_FILE_SIZE: Option<u64> = Some(64 * 1024 * 1024);
 
 /// Binary extensions that can be rejected without reading file content.
 const BINARY_EXTENSIONS: &[&str] = &[
@@ -114,8 +129,8 @@ pub struct WalkOptions {
 }
 
 // Hand-written rather than derived so the size limit is a deliberate choice
-// rather than whatever `Option::default()` happens to be. It is `None` — no
-// limit — matching ripgrep; see [`DEFAULT_MAX_FILE_SIZE`].
+// rather than whatever `Option::default()` happens to be. See
+// [`DEFAULT_MAX_FILE_SIZE`], which diverges from ripgrep.
 impl Default for WalkOptions {
     fn default() -> Self {
         Self {
@@ -1165,8 +1180,8 @@ mod tests {
             vec!["small.txt"]
         );
 
-        // The default applies no cap, so an ordinary large source file is
-        // indexed rather than silently dropped.
+        // The default cap is well above this file, so an ordinary large source
+        // file is indexed rather than silently dropped.
         assert_eq!(
             names(&MetaWalkOptions::default()),
             vec!["big.txt", "small.txt"]
@@ -1193,29 +1208,39 @@ mod tests {
     }
 
     #[test]
-    fn walks_default_to_no_size_cap() {
+    fn walks_default_to_a_64_mib_size_cap() {
         // Both option structs hand-write `Default` precisely so this cannot
-        // drift, and both are meant to agree with ripgrep: no limit.
-        assert_eq!(DEFAULT_MAX_FILE_SIZE, None);
-        assert_eq!(WalkOptions::default().max_file_size, None);
-        assert_eq!(MetaWalkOptions::default().max_file_size, None);
+        // drift, and both must agree: a metadata walk that disagreed with the
+        // indexing walk classified everything between the two caps as deleted
+        // and evicted it (see `tests/serve_max_filesize.rs`).
+        assert_eq!(DEFAULT_MAX_FILE_SIZE, Some(64 * 1024 * 1024));
+        assert_eq!(
+            WalkOptions::default().max_file_size,
+            DEFAULT_MAX_FILE_SIZE
+        );
+        assert_eq!(
+            MetaWalkOptions::default().max_file_size,
+            DEFAULT_MAX_FILE_SIZE
+        );
 
-        // Pinned against a file past the 64 MiB cap this used to carry, so the
-        // regression this guards against — an oversized file counted but never
-        // recorded, and so silently unsearchable — is what the test exercises.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        let big = root.join("huge.txt");
-        // `set_len` rather than writing 65 MiB: the metadata walk only stats.
-        std::fs::File::create(&big)
+        // `set_len` rather than writing the bytes: the metadata walk only stats.
+        std::fs::File::create(root.join("huge.txt"))
             .unwrap()
             .set_len(65 * 1024 * 1024)
             .unwrap();
+        std::fs::File::create(root.join("large.txt"))
+            .unwrap()
+            .set_len(63 * 1024 * 1024)
+            .unwrap();
 
+        // Straddling the cap, so this pins the boundary rather than merely
+        // observing that some file survived.
         let files = walk_file_metadata(root, &MetaWalkOptions::default()).files;
         assert_eq!(
             files.iter().map(|f| &f.relative_path).collect::<Vec<_>>(),
-            vec!["huge.txt"]
+            vec!["large.txt"]
         );
     }
 


### PR DESCRIPTION
Fixes #101.

Started as the JSON `--stats` parity fix for #101 and grew: closing that gap surfaced a 1 MiB default file-size cap that silently dropped matches, and removing *that* exposed a chain of memory and throughput problems that only appear on very large trees. The sections are in the order the work happened, so the two most substantial changes — **reading each file once instead of four times**, and **a 64 MiB default cap with git-accurate ignore matching** — are in the middle rather than at the top. Reviewers short on time should start there and at [Verification](#verification).

## JSON `--stats` parity

Aligns tgrep with `rg 15.2.0` for the three divergences reported in #101:

- A single `OutputWriter` now spans all named targets, so JSON emits exactly one trailing `summary` per invocation and reports the real `searches` / `searches_with_match` totals.
- JSON ignores `-o`, matching ripgrep's JSON printer, and `matched_lines` counts distinct line numbers rather than emitted match events.
- `-c`, `--count-matches`, `-l`, `--files-without-match`, and `--files` select their plain-text printers and suppress JSON entirely.

The writer is explicitly finished on quiet/error exits because `process::exit` does not run destructors. Differential tests cover event order and stats across named files, repeated paths, directories, context, replacement, count/list modes, local-index, server, and brute-force paths.

## Large files: 1 MiB was too small, uncapped was too large

Indexed search previously omitted every file above the default 1 MiB cap, while both `--no-index` and ripgrep found the matches — a silent correctness gap. That cap was removed first, and the memory work below exists to make an uncapped build affordable. Measuring an uncapped build against a real 292K-file enlistment then showed why "uncapped, like ripgrep" is the wrong default for an *indexed* tool; the cap comes back at 64 MiB in [its own section](#a-64-mib-default-cap-and-git-accurate-ignores) below. Both steps are kept here because the memory work stands on its own: it is what makes an explicitly lifted cap usable at all.

Memory is decoupled from file size before removing the cap:

- Search and indexing memory-map files above 1 MiB rather than reading them into private heap memory.
- Index extraction batches are bounded by cumulative input bytes, not only file count.
- ASCII lowercasing is fused into trigram extraction instead of allocating a second whole-file copy.
- Lossy UTF-8 repair uses an exact-size allocation and omits the offset-fixup table during indexing.
- Unknown file sizes consume a whole batch budget, isolating the file and routing it through the mapped path (addressing [review feedback](https://github.com/microsoft/tgrep/pull/102#discussion_r3835503213)).

On the Linux kernel, no-cap mapped indexing reduced private bytes from 197.2/199.5 MiB to 152.4/152.4 MiB and build time from 41.1/42.2s to 27.0/27.0s. A 135 MiB invalid-UTF-8 fixture fell from 504.2 MiB to 204.6 MiB private memory.

## Bounded `tgrep serve` reconciliation

Opening an old capped index made the 698 formerly omitted Substrate files appear new. The stale path then retained mask-heavy live entries and called `HybridIndex::full_snapshot`, decoding every posting in the existing 286K-file index into heap. Periodic auto-save used the same unbounded snapshot.

Both paths now:

1. Build only new/replacement files as a byte-bounded external-sort delta.
2. Stream the old reader and delta into a staged index.
3. Filter replacements/deletions with an O(file-count) dense ID map.
4. Publish index + filestamps together and reconcile live overlays/tombstones.

The stale walk, matching ignore matcher, merge, and publication are serialized under one snapshot gate; searches continue on the prior reader throughout. Exact walk membership handles newly ignored files and Windows case-only renames. `.ignore`, `.gitignore`, parent rules, repository `info/exclude`, global rules, and `--no-require-git` retain `WalkBuilder` precedence. Transient walk/read/write/publish failures keep the old index and retry with backoff rather than permanently gating watcher updates.

A capped-index migration with three new 32 MiB files, one replacement, and one deletion peaked at **67.2 MiB private memory**; all additions/replacements were searchable and old/deleted content was absent. A sharing-violation repro confirmed a failed delta retries and recovers both the locked file and an event received while the matcher was pending.

The reported ~27.7 GiB WMI Performance Adapter process is separate from tgrep—tgrep reads process counters through PSAPI, not WMI—but the stale snapshot path was a real independent memory-pressure bug.

## Indexing large files at speed

Bounding that reconciliation made it fit in memory but left it slow: absorbing the 698 files still took **682.8s**. The merge is not the cost — a 143M-posting index absorbs 300 new files in 2.3s. Trigram extraction is, for two independent reasons.

**The byte budget charged mapped bytes it never allocated.** A file past 1 MiB is mapped and costs no heap, but was charged its full length against the 64 MiB batch budget, so a batch of 32 MiB files held two — and a batch is a rayon barrier, so a 16-core pool ran two files at a time. Mapped files are now charged a saturating stand-in for the one thing they *do* put on the heap, their extracted trigram map, against a second budget capping mapped bytes in flight at 256 MiB. Two budgets are required, not one: dropping the charge outright ran 0.8s but took peak working set to 529 MiB.

**Extraction hashed every byte with SipHash.** A trigram packs three bytes into 24 bits, so the key is already collision-free and the collision resistance bought nothing. It now uses a multiply-xorshift hasher — xor-folded, because hashbrown takes the bucket index from the low bits and a plain multiply would leave those depending only on the trigram's last byte. Merged extraction also re-walked the whole file whenever it held any uppercase byte; that pass is fused into the main window loop and does real work only for windows that lower to a different trigram. The subtle case is preserved and pinned by a differential test: an all-lowercase window followed by an uppercase byte still contributes an extra `next_mask` bit to the same entry.

Interleaved A/B, minimum of alternating runs:

| Workload | Before | After | |
| --- | ---: | ---: | ---: |
| 16 x 32 MiB, mixed case | 24.1s | **1.7s** | 14.2x |
| 16 x 32 MiB, lowercase | 9.4s | **1.0s** | 9.4x |
| 512 x 1 MiB, lowercase | 2.7s | **1.9s** | 1.4x |
| 20,000 x 8 KiB, mixed case | 12.5s | 12.6s | neutral |
| `serve` stale absorbing 16 x 32 MiB into a 40,300-file capped index | 26.3s | **3.4s** | 7.7x |

Ordinary trees are bound by I/O and the external sort, not extraction, so they neither gain nor lose — that row is the control. Criterion agrees at the unit level: 256 KiB merged mixed-case extraction went 8.4413ms to 2.2813ms.

Private bytes go 71.4 to 78.1 MiB. Resident set rises to 228.1 MiB, entirely reclaimable file-backed pages held under the mapped budget.

Correctness was verified by differential search, not by comparing index bytes: two runs of the *same unmodified binary* already produce different `index.bin`, because the parallel walker yields files in nondeterministic order and file ids shift. 48 search invocations across old and new agree with each other and with `--no-index` ground truth.

## Watcher gate released on a failed stale walk

From [review feedback](https://github.com/microsoft/tgrep/pull/102#discussion_r3837854978). `gitignore_pending` keeps the watcher off the index until an ignore matcher exists, and the stale check owns clearing it. It also refuses to touch the index when the walk could not inspect every entry, since unseen files would be misclassified as deleted. Those are separate decisions, but taking the second skipped the first — the `skipped_error` return ran before the matcher was built.

Nothing recovered from it: `handle_fs_event` drops every event while the flag is set, and the overflow-repair path also skips reconciling for the same reason, so the watcher stayed dead for the life of the process while the startup retry loop rewalked the whole tree every 30s forever. The trigger is small — `skipped_error` counts a single `entry.metadata()` failure, so one file losing a race with a delete was enough.

The matcher is now committed as soon as the walk returns, ahead of every exit, which also covers the merge-failure return that leaked the same flag. This is invisible on the paths that already worked: the function holds `snapshot_gate` for write across its whole body and the only reader of `state.gitignore` takes the read side first. The tradeoff is that a matcher from an incomplete walk can under-ignore, which the next successful stale check corrects — strictly better than a permanently dead watcher.

## `peak memory` reported the working set, not the memory tgrep owns

Mapping large files made the reported figure wrong. It was `PeakWorkingSetSize`/`VmHWM`, which counts resident mapped file pages, so once indexing mapped files past 1 MiB the number tracked the size of the files rather than the memory tgrep held. A Substrate `serve` bootstrap reporting **13.49 GiB** is that artifact.

Reproduced at scale, the build is bounded as designed: a generated 290,700-file / 4.2 GB corpus peaks at 318.0 MiB private for `index` and 386.8 MiB for a `serve` bootstrap. The divergence comes from single large files, which `batch_ranges` gives a batch of their own and maps whole:

| Corpus | Reported (old) | Private bytes | |
| --- | ---: | ---: | ---: |
| 1 x 2 GiB file | 1.99 GiB | **77.8 MiB** | 26x over |
| 200 x 8 MiB files | 470.2 MiB | **365.4 MiB** | 1.3x over |
| 290,700 files, 4.2 GB | 305.1 MiB | 318.0 MiB | accurate |

`index` and `serve` now lead with private bytes — `PagefileUsage` on Windows, `RssAnon` on Linux — and name the working set separately only when it is both 25% *and* 64 MiB larger, so mapped pages stay visible without being read as tgrep's own use. Both bounds are needed: every process maps its own executable, so a trivial Linux run shows 1.5 MiB private against a 12 MiB working set, which clears the ratio but means nothing. The 2 GiB case now prints `77.8 MiB private, 1.99 GiB working set incl. memory-mapped files`, matching an independent PSAPI sampler exactly.

Linux has no kernel high-water mark for anonymous memory alone, so a sampler thread tracks the peak across a build; without it the report would be whatever survived it, a small fraction of the true peak once the sorter drops its arena. macOS keeps reporting resident set, because the split is only reachable through Mach `TASK_VM_INFO`, which `libc` does not surface.

**The `serve` memory cap had the same bug, and there it was not cosmetic.** Charging file-backed pages against a heap budget fires the cap on memory no flush can reclaim: the build pays for a full overlay flush and is still over budget on the next check — the "flush did not reclaim memory" path the code already warned about. The cap now charges private bytes.

No test asserts that mapped pages stay resident, because they do not reliably: a 128 MiB file read in full grew the working set by ~1.1 MB here, while a real 2 GiB index run showed 1.99 GiB — Windows trims clean file-backed pages aggressively under cache pressure. The reporting decision is tested as a pure function over fixed inputs instead, including both boundary conditions, and the Linux sampler test was verified to fail when deliberately sabotaged.

---

The sections below come from running a purpose-built benchmark suite against a 292,911-file / 18.96 GiB Microsoft-internal enlistment — a corpus an order of magnitude past the public benchmark repos, and the first one large enough to make these effects visible. It found nine issues. The suite itself is not in this repo; every number is reproducible from the commands in each section.

## Reading each file once instead of four times

The largest search win here, and the one under every other number: tgrep moved bytes past its matcher at 0.42 GB/s against ripgrep's 1.5 GB/s. That floor bounded everything — an index that eliminated almost every candidate file still only won by ~1.2x, because the files it *did* open were being read nearly four times.

Measured breakdown of a 30.65s scan before the fix: mmap + `from_utf8` 8.69s, a scalar NUL scan 11.87s, `LineIndex::new` 4.74s, `collect_hits` 1.85s. Three of those four passes were avoidable:

- **The binary-detection NUL scan was a hand-rolled byte loop.** It is now `memchr`, and it is fused into the pass that follows it rather than standing alone.
- **`LineIndex` was built eagerly for every searched file.** It is now lazy. On the corpus, 201,724 files are searched and 5,068 match — so ~197K files never build a line table at all. This, not the NUL fix, is where the win on ordinary trees comes from.
- **Candidate lines were found one call at a time.** A single prescan replaces the per-line loop.

Same scan after: **18.43s**. On the corpus, **2.07-2.21x**; on a single 13.4 GiB file, 1.66x. tgrep now makes 2 passes per file to ripgrep's 1, at the same per-pass rate. The remaining pass is UTF-8 validation, and removing it means matching over `regex::bytes` on `&[u8]` — a design change that touches every matcher variant and Unicode semantics on invalid input, so it is left as follow-up rather than folded in here.

One caution for anyone re-measuring: after fusing the NUL scan into the following pass, `collect_hits` *rose* from 1.85s to 6.4s. That is not a regression — the separate NUL pass had been warming the pages that `collect_hits` later touched. Total passes is the thing to measure, not per-phase timings.

## A 64 MiB default cap, and git-accurate ignores

The enlistment contains a single **13.41 GiB** build artifact — 70.8% of everything ripgrep reads in the tree. It cost ripgrep essentially nothing:

| ripgrep full scan, pattern that cannot match | Files | Bytes | Time |
| --- | ---: | ---: | ---: |
| As-is | 292,911 | 18.96 GiB | 29.79s |
| `--max-filesize 8M` | 292,863 | 4.64 GiB | 30.10s |

Dropping 75.5% of the bytes leaves the time flat, because ripgrep's floor on this tree is per-file overhead across 292K files, not bytes. The artifact is one sequential streaming read.

**The asymmetry is the point.** ripgrep is expected to read everything, so one more large file amortises into a cost it always paid. tgrep's entire value is *not* reading files that cannot match — so when the index correctly narrows a query to ~31 candidates and one of them is 13.4 GiB, that file is the whole query. The artifact is a dependency-graph dump mentioning nearly every identifier in the repository, so its trigrams matched almost any realistic pattern. `index=4.9ms resolve=0.1ms search=16119.5ms` for 31 files.

Two independent fixes, because they cover different corpora:

**A 64 MiB default `--max-filesize`**, worth ~39x on the affected query and ~3.3x on the cold build against a genuinely uncapped build. The cost has to be stated plainly: a capped search silently does not search a file — exit 0, nothing printed, result set simply short, which is the one failure mode a `grep` must not have. It ships because the alternative is worse in the same direction: the uncapped user gets no signal either, just a server that appears to hang for 21s per query with nothing naming the cause. Two details make it defensible — a file **named explicitly on the command line is exempt** (`tgrep pattern huge.log` searches it), and the index build and the stale check share one cap, because otherwise a file the index holds but the metadata walk skips looks *deleted* and is evicted and re-indexed on every pass. Both are pinned by regression tests.

**Honouring `core.ignorecase`.** The artifact was in a directory git ignores; git on a Windows clone sets `core.ignorecase=true` and matches ignore rules case-insensitively, and tgrep did not — so tgrep indexed 5,974 files git considers ignored. This is not a new flag: it is matching what `git status` already does on the same repo. The safety property is that **tracked files are exempt** — without that carve-out, 273 tracked `.JPG`/`.PNG`/`.RLL` files would have vanished, since `filter_entry` can only exclude, never re-include. Scoped to repo-root `.gitignore` and `.git/info/exclude`; nested ignore files are not covered because the walk cannot know about them before descending, and under-exclusion is the safe direction.

With both in place, on the same warm server:

| Same query, same warm server | Time | Files |
| --- | ---: | ---: |
| Defaults (64 MiB cap, git-accurate ignores) | 526.9 ms | 2,989 |
| plus explicit `--max-filesize 8M` | 259.8 ms | 2,987 |

The first row is the number that used to be ~16s.

## Serve content cache bounded in bytes, not entries

`tgrep serve` cached decoded file contents in an LRU bounded by entry *count* (`CACHE_CAPACITY = 50_000`), so a single oversized candidate pinned its entire decoded size for the life of the process. After one query the server held **14.4 GiB** of private memory; it now holds **580.9 MiB**.

This is a real trade rather than a free win, and worth stating: the old cache did make repeat queries faster, because the second and third read of a large file were served from memory. Those files are re-read now. An unbounded cache that can pin 14.4 GiB on one query is not a defensible default for a long-lived daemon, and the underlying cost was the file, not the cache.

## Periodic reconcile, so a lost watcher event is bounded

A dropped or coalesced filesystem event could leave a phantom entry in the index indefinitely — nothing re-examined the tree unless something else triggered a stale check. `serve` now reconciles on a timer as well as on demand. It deliberately uses `compare_index_membership: false`: the exact-membership comparison would rebuild the entire index on a single misfire, which is far worse than the bounded staleness it fixes. The interval clock resets *before* the walk, so a slow walk cannot queue up back-to-back reconciles, and the whole thing is gated on `!no_watch`. Verified by killing the watcher and confirming create, modify and delete are all recovered.

## Three correctness fixes from review

- **A file whose read failed was still stamped as indexed.** The memo filter removed such a path from `changed`/`added`, but `new_stamps` was built unconditionally from every file in `current_meta` — so a file deliberately *not* built got a stamp saying "indexed at this mtime/size". The next reconcile classified it unchanged and skipped it for a reason the memo could no longer clear, the stamp survived in `filestamps.json` across restarts, and every automatic caller passes `compare_index_membership = false`, the one check that would have caught it. **A transient read failure removed a file from search permanently.** The existing test passed only because it duplicated the logic inline instead of calling it; it now calls the real functions, and fails without the fix.
- **`--no-ignore-vcs` / `--no-ignore-exclude` / `--no-ignore-parent` never reached the case-insensitive matcher.** It gated only on the master `no_ignore` while the case-sensitive pass gated on the finer flags, so with `--no-ignore-vcs` the case-sensitive pass let everything through and the case-insensitive matcher became the only thing excluding — a "hide less" flag that hid *more*. Three regression tests, each verified to fail without the fix.
- **A git index header claiming `0xFFFFFFFF` entries had that count trusted.** A 12-byte file could make tgrep reserve for ~4 billion entries — roughly 146 GB — which aborts the process uncatchably rather than returning an error, all from a 32-bit field read straight out of the file. The count is now clamped to what the file length can actually hold.

Also fixed here: `-P` patterns bypassed the index entirely and planned against it now (a 5-minute timeout becomes 25.1s, 1.18x faster than ripgrep, byte-identical output); `index` and `serve` reject discovery flags they cannot honour instead of silently ignoring them (exit 2, naming the flag); and the context separator is printed where ripgrep prints it.

## Substrate results

33 queries, 3 iterations each, both tools given the same `--max-filesize`:

| | |
| --- | --- |
| Search suite, both capped at 64 MiB | ripgrep 15.5 min vs tgrep 2.4 min — **6.38x** |
| Same suite at `--max-filesize 8M` | ripgrep 15.6 min vs tgrep 2.9 min — **5.40x** |
| Queries tgrep wins | 31 of 33 |
| Cold index build (`tgrep serve`) | 1.1 min, peak private 314.6 MiB, 2.84 GiB on disk |
| Warm start, index already built | first answer in 1.84s |
| Single-file edit visible in | 131.4 ms (median of 5) |
| Output parity vs ripgrep | 23 of 23 checks byte-identical |

Two notes on method. The harness handed ripgrep a matching `--max-filesize` in every comparison — without that the two tools are not searching the same bytes and the ratio is meaningless. And the harness's own median was wrong: it used `[int]($n / 2)`, and .NET rounds half to even, so for three iterations it indexed element 2 of a sorted triple and reported the **slowest** sample as the median. Every figure was a worst-of-three until that was fixed; the raw samples were retained, so the results were recomputed rather than re-measured.

## Still open

1. **Match over `regex::bytes` on `&[u8]`** rather than a validated `&str` — the last factor of two described above.
2. **Record the build-time size cap in `IndexMeta`**, so a query that raises `--max-filesize` above the cap the index was built with says so instead of silently missing files. This is the sharpest remaining edge of the new default.
3. **Warn when one file is a large share of the corpus.** The cap makes this less urgent, but a user who lifts it should be told that 71% of what was just indexed is one path.
4. **Nested `.gitignore` files in the case-insensitive path**, which needs the walk to know about a nested ignore file before descending into its directory.

## Benchmark refresh

An earlier commit in this PR reran all 12 large-repo workflows (18 platform cells) at `90a41a6` and rebased `README.md` and `BENCHMARKS.md` onto that single sweep, instead of mixing latest totals with historical minima. That sweep measured:

- Geometric mean speedup: **12.3x Windows, 6.8x macOS, 2.4x Linux**.
- Range: Kubernetes/Linux is effectively tied at 1.004x; Gecko/macOS is 42.9x.
- Peak index-build working set was harvested from current and prior logs for all 18 cells. The kernel moved from 142–176 MiB to 174–192 MiB after admitting the 110 files skipped by the old cap; Chromium changed by only 2–3 MiB.

Shared-runner absolute times are explicitly described as non-comparable between runs; ratios compare tgrep with ripgrep within the same job.

**A fresh sweep of all 12 workflows ran at `82b88a1`**, after the single-pass search work. All 18 cells succeeded. Speedup is ripgrep total / tgrep total across each repo's whole query suite; values below 1.0 mean ripgrep won.

| Repo | Files | Windows | macOS | Linux |
| --- | ---: | ---: | ---: | ---: |
| chromium/chromium | 503,903 | 13.5 → **17.60x** | 10.8 → **15.82x** | 2.36 → **3.81x** |
| mozilla/gecko-dev | 387,841 | 34.8 → **38.57x** | 42.9 → **51.95x** | 7.5 → 7.36x |
| torvalds/linux | 95,776 | 25.1 → **34.81x** | 22.4 → 21.05x | 5.5 → **9.38x** |
| rust-lang/rust | 62,179 | 8.1 → 7.69x | 1.78 → **2.69x** | 1.36 → **1.61x** |
| kubernetes/kubernetes | 31,300 | 5.9 → **7.08x** | 1.72 → **2.81x** | 1.00 → **0.93x** |
| golang/go | 15,826 | 6.2 → **7.53x** | 3.2 → 3.12x | 1.34 → 1.29x |

Geometric mean across the six repos:

| | `90a41a6` | `82b88a1` |
| --- | ---: | ---: |
| Windows | 12.3x | **14.6x** |
| macOS | 6.8x | **8.61x** |
| Linux | 2.4x | **2.82x** |

Three things are worth reading out of this rather than just the geomeans.

**The gains are largest where the corpus is largest.** Chromium — the biggest repo and the one whose queries touch the most files — improves on all three platforms, most sharply on macOS (10.8x to 15.8x). That is the lazy `LineIndex` doing what it should: the win scales with how many files are *searched but do not match*, and that ratio grows with repo size. The Substrate corpus is simply the extreme end of the same curve.

**The 64 MiB cap is inert here, as intended.** No file in any of the six repos comes near 64 MiB, so none of these movements can be attributed to it. That was the thing to check: a public-repo ratio moving on the cap alone would have meant it was excluding something it should not.

**Kubernetes on Linux is the one cell that got worse, and it is the one where tgrep now loses outright** — 1.004x to 0.93x. It was already the weakest cell by a wide margin, for a structural reason the doc explains: at 31K files there is little for the index to skip, so tgrep pays index lookup and IPC against a ripgrep run that was already fast (9.2s for 97 queries). Whether this is real or shared-runner noise is not resolvable from one sample — go/Linux and gecko/Linux also drifted down slightly while the other twelve cells rose, which reads more like a slow Linux runner than a regression in a code path that is platform-independent. It is called out rather than averaged away because it is the honest weak spot of the whole approach, and the geomean hides it.

`README.md` and `BENCHMARKS.md` are refreshed to the `82b88a1` sweep in a final commit. They deliberately use one sweep consistently — headline ratios, per-repo latencies, index sizes, build times, peak memory and run links all from the same run — so all 18 cells and their detail sections were replaced together rather than just the summary table. Two things that change in prose as well as numbers: Kubernetes/Linux is now a loss at 0.93x, so the claim that tgrep does not lose a cell is gone; and the peak-memory table is explicitly marked **not comparable** to the one it replaces, because `index` now reports private bytes where it used to report peak working set. The Criterion section is a local controlled run and is untouched.

## Verification

- `cargo test --workspace`: **644 tests, 0 failures** (up from 568; the new ones cover the size cap and its command-line exemption, case-insensitive ignores and the tracked-file carve-out, the periodic reconcile, lazy line indexing, and one regression test each for the three review fixes)
- Each of the three review fixes was mutation-tested: its regression test was confirmed to fail when the fix is reverted
- `cargo clippy --workspace --all-targets -- -D warnings`, on both the Windows and Linux targets
- `cargo fmt --all -- --check`
- End-to-end: capped/empty-index migration; add/replace/delete; stale retry after sharing violation; watcher overlay; ignore/unignore refresh; parent `.ignore` / `.gitignore` / `info/exclude`; `--no-require-git`; case-only rename; bounded auto-save
- Differential search old vs new and indexed vs `--no-index`: 0 mismatches across 48 invocations
- On the 292,911-file enlistment: 23 of 23 output-parity checks byte-identical to ripgrep, in both directions
- Peak-memory reporting checked against an independent external sampler on three corpora (2 GiB single file, 200 x 8 MiB, 290,700 files) on Windows and Linux
- Final Windows binary: `target\release\tgrep.exe`

