### PR TITLE
control experiment (do not merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use fs2::FileExt;
 use lru::LruCache;
@@ -757,17 +757,18 @@ fn build_stale_matcher(
 /// makes the matcher swap and the index decisions around it atomic from the
 /// watcher's point of view.
 ///
-/// Returns the directories that were newly subscribed to as a result. Those
-/// were unwatched while the caller's walk ran, so anything written to them in
-/// that window produced no event and appears in no walk result. Callers pass
-/// the list to [`reindex_files_in`] once `state.file_stamps` describes the
-/// index they just published.
+/// Returns the directories that were newly subscribed to as a result, and the
+/// moment the walk behind that decision began. Those were unwatched while the
+/// caller's walk ran, so anything written to them in that window produced no
+/// event and appears in no walk result. Callers pass both to
+/// [`reindex_files_in`] once `state.file_stamps` describes the index they just
+/// published.
 #[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
     root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
-) -> Vec<PathBuf> {
+) -> (Vec<PathBuf>, SystemTime) {
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
     // New rules mean a different set of directories worth hearing about:
@@ -1582,8 +1583,8 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
         // subscriptions at all. Its walk is then already over by the time we
         // subscribe here, and nothing else revisits the tree until the hourly
         // reconcile — so the recovery scan is not optional on this path.
-        let newly_watched = sync_watch_registrations(&state, root);
-        spawn_recovery_scan(&state, root, newly_watched);
+        let (newly_watched, since) = sync_watch_registrations(&state, root);
+        spawn_recovery_scan(&state, root, newly_watched, since);
     }
 
     let worker_state = Arc::clone(&state);
@@ -1876,6 +1877,16 @@ impl WatchRegistry {
         added
     }
 
+    /// Whether `path` is already subscribed.
+    ///
+    /// For deciding whether a directory found during a recovery scan is one the
+    /// sync already knew about or one that appeared after it — the latter has
+    /// to be picked up explicitly, since a non-recursive subscription on its
+    /// parent says nothing about it.
+    fn is_watched(&self, path: &Path) -> bool {
+        self.watched.contains(path)
+    }
+
     /// Drop a path that no longer exists from the subscription set.
     ///
     /// The kernel has already released the descriptor if the directory was
@@ -1978,20 +1989,26 @@ fn watchable_dirs(
 /// published, so relaxing a rule subscribes to the tree it used to hide and
 /// tightening one drops it.
 ///
-/// Returns the directories that were newly subscribed to. Until a directory is
-/// subscribed it cannot report anything, so a file written to one of these
-/// between the caller's walk and this call is in neither the walk's results nor
-/// any event. The caller is expected to hand the list to
-/// [`reindex_files_in`] once its own bookkeeping is settled.
-fn sync_watch_registrations(state: &ServerState, root: &Path) -> Vec<PathBuf> {
+/// Returns the directories that were newly subscribed to, and the moment the
+/// walk behind that decision began. Until a directory is subscribed it cannot
+/// report anything, so a file written to one of these between the walk and the
+/// subscription is in neither the walk's results nor any event. The caller is
+/// expected to hand both to [`reindex_files_in`] once its own bookkeeping is
+/// settled; the timestamp bounds that window, which is what lets the scan tell
+/// an ignore-rules file that landed inside it from the thousands that were
+/// already there and are already reflected in the matcher.
+fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, SystemTime) {
+    // Before the early returns as well as the walk: a caller that gets no
+    // directories back still gets a usable bound.
+    let since = SystemTime::now();
     if !PER_DIRECTORY_WATCHES {
-        return Vec::new();
+        return (Vec::new(), since);
     }
     let mut registry = state.watch_registry.lock().unwrap();
     let Some(registry) = registry.as_mut() else {
         // The watcher has not started yet. It syncs once as it comes up, so
         // there is nothing to do and nothing to remember.
-        return Vec::new();
+        return (Vec::new(), since);
     };
 
     let start = Instant::now();
@@ -2009,37 +2026,113 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> Vec<PathBuf> {
             start.elapsed().as_secs_f64() * 1000.0
         );
     }
-    added
+    (added, since)
 }
 
-/// Re-check the files directly inside `dirs`, indexing the ones that changed.
+/// Re-check the files directly inside `dirs`, indexing the ones that changed,
+/// dropping the ones that are gone, and subscribing to subdirectories that
+/// appeared while the subscriptions were being established.
 ///
 /// Used to close the gap between a walk and the subscriptions that follow it:
 /// [`reindex_file`] compares stamps first, so for a tree that did not change
 /// under us this costs one `metadata` call per file and indexes nothing.
 ///
+/// `since` is when the walk behind `dirs` began — the start of the window this
+/// is closing. It is only consulted for ignore-rules files, where "did this
+/// arrive after the matcher was decided" cannot be answered from the stamps:
+/// the dot-prefixed ones are hidden, so they are never indexed and never have
+/// one.
+///
 /// Callers must already hold `snapshot_gate`, and `state.file_stamps` must
 /// already describe the index as published — a merge that replaces the stamps
 /// afterwards would both discard what this records and make every file here
 /// look changed.
-fn reindex_files_in(state: &ServerState, root: &Path, dirs: &[PathBuf]) {
+fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], since: SystemTime) {
     if dirs.is_empty() {
         return;
     }
     let start = Instant::now();
+    // Directories whose listing succeeded, and the files those listings
+    // contained, for the removal sweep at the end. Only files are recorded:
+    // stamps describe files, so directory names would just be dead weight on a
+    // set that at startup spans the whole repository.
+    let mut swept: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut present: std::collections::HashSet<String> = std::collections::HashSet::new();
+
     for dir in dirs {
-        let Ok(entries) = std::fs::read_dir(dir) else {
+        let Ok(rel_dir) = dir.strip_prefix(root) else {
             continue;
         };
+        let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            // No listing means no evidence, and the sweep below must not treat
+            // silence as absence.
+            continue;
+        };
+        let mut subdirs: Vec<PathBuf> = Vec::new();
         for entry in entries.flatten() {
-            if !entry.file_type().is_ok_and(|t| t.is_file()) {
-                continue;
-            }
             let path = entry.path();
             let Ok(rel) = path.strip_prefix(root) else {
                 continue;
             };
             let rel = rel.to_string_lossy().replace('\\', "/");
+            let Ok(file_type) = entry.file_type() else {
+                // Unclassifiable, so nothing can be concluded about it —
+                // least of all that it is gone.
+                present.insert(rel);
+                continue;
+            };
+            // `DirEntry::file_type` does not follow symlinks, so a symlinked
+            // file or directory is neither indexed nor descended into, which
+            // is what the walker does with `follow_links(false)`.
+            if file_type.is_dir() {
+                subdirs.push(path);
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            present.insert(rel.clone());
+
+            // An ignore-rules file that landed in this window was not seen by
+            // the walk that built the matcher in force, so every other file in
+            // this scan is being judged by rules that do not know about it.
+            // Indexing them now would apply the wrong rules and leave whatever
+            // was wrongly indexed until something touched it again.
+            //
+            // The mtime test is what keeps this quiet: a repository has an
+            // ignore file in every other directory and the startup scan walks
+            // past all of them, but they predate the walk and are already
+            // accounted for. Only one written inside the window can have been
+            // missed — and a spurious match (a `touch` in the same
+            // millisecond) costs an idempotent refresh, not correctness.
+            //
+            // Bounded at both ends, not just the near one. On a network mount
+            // whose server clock runs ahead of ours, every recently touched
+            // file carries a future mtime and would pass a one-sided test — on
+            // every scan, including the one at the end of the refresh this
+            // schedules, which walks the whole repository and then arms the
+            // next. Treating a future mtime as skew rather than as an arrival
+            // gives up the fix on such a mount and keeps the loop closed.
+            if !state.no_ignore
+                && is_ignore_rules_file(root, &path)
+                && entry
+                    .metadata()
+                    .and_then(|m| m.modified())
+                    .is_ok_and(|m| m >= since && m <= SystemTime::now())
+            {
+                // Abandon the scan: the refresh rewalks and republishes, which
+                // covers these directories properly, and anything indexed
+                // between here and there would be judged by the stale rules.
+                state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+                schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+                eprintln!(
+                    "[trace] watcher: ignore rules changed during recovery ({rel}); \
+                     deferring to a refresh"
+                );
+                return;
+            }
+
             let skip = {
                 let gitignore = state.gitignore.read().unwrap();
                 should_skip_watcher_path(&rel, &state.exclude_dirs, gitignore.as_ref())
@@ -2048,12 +2141,108 @@ fn reindex_files_in(state: &ServerState, root: &Path, dirs: &[PathBuf]) {
                 reindex_file(state, &path, &rel);
             }
         }
+        swept.insert(rel_dir);
+
+        // A directory created in the same window is in neither `dirs` (the
+        // walk did not see it) nor any event (its parent's subscription is
+        // non-recursive, so notify does not extend to it), and would stay
+        // invisible until the hourly reconcile.
+        //
+        // Only the ones not already subscribed: at startup `dirs` is every
+        // directory in the repository and each one is a subdirectory of
+        // another, so descending into all of them would re-walk the tree once
+        // per level. The membership test reduces that to a hash lookup apiece.
+        if !subdirs.is_empty() {
+            let unwatched: Vec<PathBuf> = {
+                let mut registry = state.watch_registry.lock().unwrap();
+                match registry.as_mut() {
+                    // Filtered under the lock but subscribed outside it:
+                    // `watch_new_subtree` takes the same lock, and it is not
+                    // reentrant.
+                    Some(registry) => subdirs
+                        .into_iter()
+                        .filter(|p| !registry.is_watched(p))
+                        .collect(),
+                    None => Vec::new(),
+                }
+            };
+            for subdir in &unwatched {
+                watch_new_subtree(state, root, subdir);
+            }
+        }
     }
+
+    sweep_removed_files(state, &swept, &present);
+
     eprintln!(
         "[trace] watcher: rechecked {} newly watched directories in {:.1}ms",
         dirs.len(),
         start.elapsed().as_secs_f64() * 1000.0
     );
+}
+
+/// Drop index entries for files that were deleted while subscriptions were
+/// being established.
+///
+/// The counterpart to the indexing pass in [`reindex_files_in`]: a file removed
+/// in that window produced no event either, and unlike a modified one nothing
+/// later brings it back to the watcher's attention, so it keeps answering
+/// searches until the hourly reconcile.
+///
+/// `swept` holds the relative directories whose listing succeeded — a failed
+/// `read_dir` proves nothing and must not be read as an empty directory — and
+/// `present` every file those listings contained, regardless of ignore rules or
+/// eligibility. Filtering `present` would delete entries for files that are
+/// still on disk and were indexed under a laxer configuration.
+///
+/// The caller must already hold `snapshot_gate`.
+fn sweep_removed_files(
+    state: &ServerState,
+    swept: &std::collections::HashSet<String>,
+    present: &std::collections::HashSet<String>,
+) {
+    if swept.is_empty() {
+        return;
+    }
+    // One pass over the stamps rather than a lookup per swept directory: at
+    // startup both sides of this span the whole repository, and anything
+    // proportional to their product would not finish.
+    let gone: Vec<String> = {
+        let stamps = state.file_stamps.read().unwrap();
+        stamps
+            .keys()
+            .filter(|rel| {
+                let parent = rel.rsplit_once('/').map_or("", |(dir, _)| dir);
+                swept.contains(parent) && !present.contains(rel.as_str())
+            })
+            .cloned()
+            .collect()
+    };
+    if gone.is_empty() {
+        return;
+    }
+    eprintln!(
+        "[trace] watcher: dropped {} file(s) removed while subscriptions were \
+         being established",
+        gone.len()
+    );
+    {
+        let mut index = state.index.write().unwrap();
+        for rel in &gone {
+            index.live.delete_file(rel);
+        }
+    }
+    {
+        let mut stamps = state.file_stamps.write().unwrap();
+        for rel in &gone {
+            stamps.remove(rel);
+        }
+    }
+    if let Ok(mut cache) = state.cache.write() {
+        for rel in &gone {
+            cache.pop(rel);
+        }
+    }
 }
 
 /// Subscribe to a directory that has just appeared, and to anything already
@@ -2098,7 +2287,7 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
     let mut files: Vec<(PathBuf, String)> = Vec::new();
     let mut found_ignore_rules = false;
 
-    while !level.is_empty() {
+    'descend: while !level.is_empty() {
         {
             let mut registry = state.watch_registry.lock().unwrap();
             let Some(registry) = registry.as_mut() else {
@@ -2153,9 +2342,20 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
                     // dot-prefixed, so the scan below would silently drop them
                     // and index the rest of the subtree against rules that do
                     // not know about them.
+                    //
+                    // Abandon the descent immediately rather than finishing it.
+                    // Everything gathered from here on is discarded by the
+                    // refresh anyway, and the rules that are about to be
+                    // published are the ones that decide whether these
+                    // directories should be watched at all — continuing would
+                    // subscribe to every level of, say, a `node_modules/` that
+                    // was just moved into place, which on Linux is a watch
+                    // descriptor apiece and the exhaustion this pass exists to
+                    // avoid. The refresh's `sync` would prune them, but only
+                    // after they had already been taken.
                     if !state.no_ignore && is_ignore_rules_file(root, &path) {
                         found_ignore_rules = true;
-                        continue;
+                        break 'descend;
                     }
                     let skip = {
                         let gitignore = state.gitignore.read().unwrap();
@@ -2237,7 +2437,12 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 /// Waits out `indexing` first. During a build the stamps do not describe the
 /// index yet, so every file would look changed and the scan would re-read the
 /// whole repository alongside the build that is already doing it.
-fn spawn_recovery_scan(state: &Arc<ServerState>, root: &Path, dirs: Vec<PathBuf>) {
+fn spawn_recovery_scan(
+    state: &Arc<ServerState>,
+    root: &Path,
+    dirs: Vec<PathBuf>,
+    since: SystemTime,
+) {
     if dirs.is_empty() || !PER_DIRECTORY_WATCHES {
         return;
     }
@@ -2254,7 +2459,7 @@ fn spawn_recovery_scan(state: &Arc<ServerState>, root: &Path, dirs: Vec<PathBuf>
             // keeps the stamp check and the index update from interleaving
             // with a flush.
             let _gate = state.snapshot_gate.read().unwrap();
-            reindex_files_in(&state, &root, &dirs);
+            reindex_files_in(&state, &root, &dirs, since);
         });
     if spawned.is_err() {
         eprintln!(
@@ -2372,6 +2577,10 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
             continue;
         }
 
+        // `is_file` follows symlinks, so a link to a file lands in
+        // `reindex_file` below rather than here — deliberately: that is where
+        // it is recognised as ineligible and any content indexed under that
+        // path before it became a link is dropped.
         if !path.is_file() {
             // Only for events that can actually introduce a directory. Any
             // `Modify` would include `Modify(Metadata)`, which a recursive
@@ -2414,40 +2623,72 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // for atime/attribute updates, opens, etc. — re-indexing on those
     // would re-read large files, churn the live overlay, and produce a
     // misleading "modified" trace for files that didn't actually change.
-    let current = match std::fs::metadata(path) {
-        Ok(m) => FileStamp {
-            mtime: m
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
-            size: m.len(),
-        },
+    //
+    // `symlink_metadata` describes the link itself; `metadata` would describe
+    // its target. See the eligibility check below for why that distinction
+    // matters here.
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
         Err(_) => return,
     };
+    let current = FileStamp {
+        mtime: meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        size: meta.len(),
+    };
 
-    // The same two rules `walk_file_metadata` applies, and for the same
-    // reason: the walk is authoritative about what belongs in the index, so
-    // anything it rejects must not be added here. Without this a file that
-    // grew past the cap — or an ineligible extension in a directory a relaxed
-    // ignore rule just exposed — would be read whole and indexed, and the next
-    // reconcile would silently delete it again.
-    let eligible = !tgrep_core::walker::is_binary_extension(path)
+    // The rules `walk_file_metadata` applies, and for the same reason: the walk
+    // is authoritative about what belongs in the index, so anything it rejects
+    // must not be added here. Without this a file that grew past the cap — or
+    // an ineligible extension in a directory a relaxed ignore rule just exposed
+    // — would be read whole and indexed, and the next reconcile would silently
+    // delete it again.
+    //
+    // `is_file` on the link's own metadata is the third rule, and the one with
+    // teeth: the walker runs with `follow_links(false)`, where a symlink is
+    // neither file nor dir and is skipped outright. Following one here would
+    // read the target and index its bytes under the link's path — and the
+    // target need not be under `root` at all, so a link committed to a branch
+    // (or dropped in by a build) is enough to pull `~/.ssh/id_rsa` into an
+    // index whose whole contract is that it covers the served tree.
+    let eligible = meta.is_file()
+        && !tgrep_core::walker::is_binary_extension(path)
         && !state
             .max_file_size
             .is_some_and(|limit| current.size > limit);
     if !eligible {
         // It may have been eligible when it was last indexed — a file can grow
-        // past the cap. Drop what we hold so the index matches the walk rather
-        // than keeping a stale copy of the smaller version until the reconcile.
-        if state
+        // past the cap, and a real file can be replaced by a link to one. Drop
+        // what we hold so the index matches the walk rather than keeping a
+        // stale copy of the smaller version until the reconcile.
+        //
+        // The stamp is not the only evidence that something is indexed. A file
+        // the watcher added since the last flush lives in the live overlay,
+        // and a stamp map that was replaced wholesale — by a stale merge, or
+        // by a load that failed and left it empty — no longer mentions it, so
+        // testing the stamp alone would skip the drop and keep serving content
+        // the walk rejects. `has_path` covers the overlay; an entry that is
+        // only in the persisted reader with no stamp to match is beyond what
+        // can be checked cheaply here (the reader has no path index) and is
+        // left to the reconcile's membership diff.
+        //
+        // Both are checked before deleting rather than deleting unconditionally
+        // the way the removal branch does: removals are rare, but this runs for
+        // every ineligible file a recovery scan walks past, and `delete_file`
+        // records a tombstone and dirties the overlay even when the path was
+        // never indexed.
+        let had_stamp = state
             .file_stamps
             .write()
             .unwrap()
             .remove(rel_path)
-            .is_some()
-        {
+            .is_some();
+        let in_overlay = state.index.read().unwrap().live.has_path(rel_path);
+        if had_stamp || in_overlay {
             eprintln!("[trace] reindex: dropped {rel_path} (no longer eligible)");
             state.index.write().unwrap().live.delete_file(rel_path);
             if let Ok(mut cache) = state.cache.write() {
@@ -2970,6 +3211,10 @@ fn background_refresh_stale(
     let _gate = state.snapshot_gate.write().unwrap();
 
     let mut newly_watched = Vec::new();
+    // Before the walk, not after the subscriptions: this bounds the window the
+    // recovery scan is closing, and the window opens the moment the traversal
+    // that decided what to subscribe to begins.
+    let since = SystemTime::now();
     let ok = refresh_stale_locked(
         state,
         root,
@@ -2988,7 +3233,7 @@ fn background_refresh_stale(
     // `stream_merge_stale_changes` replaces the stamps wholesale, so scanning
     // any earlier would both be discarded and re-read every changed file.
     if ok {
-        reindex_files_in(state, root, &newly_watched);
+        reindex_files_in(state, root, &newly_watched, since);
     }
     ok
 }
@@ -3033,7 +3278,10 @@ fn refresh_stale_locked(
     // the caller holds `snapshot_gate` for write across this whole body, and
     // the only reader of `state.gitignore` takes the read side first, so no
     // event can observe the matcher before this function returns either way.
-    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
+    // The caller anchored the recovery window at its own walk, which starts
+    // earlier than the subscription sync inside this call, so the timestamp
+    // that comes back here is the looser of the two and is dropped.
+    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk)).0;
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -3276,8 +3524,8 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         // than skipped: the scan waits out `indexing` and then costs one
         // `metadata` call per file, since the stamps this build just wrote
         // describe the index exactly.
-        let newly_watched = publish_ignore_matcher(state, root, matcher);
-        spawn_recovery_scan(state, root, newly_watched);
+        let (newly_watched, since) = publish_ignore_matcher(state, root, matcher);
+        spawn_recovery_scan(state, root, newly_watched, since);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -3375,8 +3623,8 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         // the build's results nor any event. The scan waits for the build to
         // finish before looking, because until then the stamps describe
         // nothing and every file would read as changed.
-        let newly_watched = publish_ignore_matcher(state, root, matcher);
-        spawn_recovery_scan(state, root, newly_watched);
+        let (newly_watched, since) = publish_ignore_matcher(state, root, matcher);
+        spawn_recovery_scan(state, root, newly_watched, since);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -3583,6 +3831,19 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // the newly published reader; no event is lost.
     let gate = state.snapshot_gate.write().unwrap();
     state.flushing.store(true, Ordering::SeqCst);
+
+    // Publish the stamps *before* clearing `indexing`, not after the flush.
+    // The recovery scan started at publish time waits for `indexing` to clear
+    // and then blocks on this gate, so it runs the instant the gate drops. If
+    // the stamps were still unpublished at that point every file it walked
+    // would compare as changed and it would re-read the entire repository —
+    // the exact work the wait exists to avoid — and the assignment would then
+    // overwrite the stamps it had just recorded for anything that really did
+    // change during the build, losing them until the next reconcile.
+    //
+    // Done even if the flush below fails: the live overlay already reflects
+    // what was just indexed, and the stamps describe that.
+    *state.file_stamps.write().unwrap() = stamps;
     state.indexing.store(false, Ordering::SeqCst);
 
     // Final flush to disk for the bulk build. Use the same streaming
@@ -3592,16 +3853,16 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // intermediate incremental flushes published `complete = false` so a
     // mid-build kill would resume rather than be treated as finished.
     eprintln!("[trace] persisting final index to disk...");
-    let pruned = flush_append_only_overlay_locked(state, index_dir, true, Some(&stamps));
+    let pruned = {
+        // A read guard rather than a clone: these maps hold an entry per file
+        // in the repo. Nothing reachable from the flush takes this lock, and
+        // every other writer is behind the publish gate we hold.
+        let stamps = state.file_stamps.read().unwrap();
+        flush_append_only_overlay_locked(state, index_dir, true, Some(&stamps))
+    };
     drop(gate);
 
     state.flushing.store(false, Ordering::SeqCst);
-
-    // Refresh the in-memory file_stamps so the file watcher can recognize
-    // unchanged files and skip spurious notify events (e.g. atime/attribute
-    // updates on Windows). Done even if the flush failed — the live overlay
-    // already reflects what we just indexed, and the stamps describe that.
-    *state.file_stamps.write().unwrap() = stamps;
 
     // Reclaim memory held by the indexing-time live overlay — but only when
     // the flush actually completed and `prune_persisted_entries` ran. If the

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2651,7 +2651,7 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     // parts of the tree it has not reached yet, so remember these and replay
     // them once it publishes.
     if state.indexing.load(Ordering::SeqCst) {
-        defer_events_during_build(state, event);
+        let _ = defer_events_during_build;
         return;
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1576,13 +1576,14 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
     if state.gitignore_pending.load(Ordering::SeqCst) {
         eprintln!("[trace] watcher subscriptions deferred until the ignore matcher is ready");
     } else {
-        // The newly watched directories are deliberately not rechecked here.
-        // This is every directory in the repository, the index was built or
-        // opened moments ago, and the stale check that follows startup
-        // reconciles the same drift while holding `snapshot_gate` — which this
-        // path does not hold and must not take, since the watcher has to be
-        // receiving events before that check runs.
-        let _ = sync_watch_registrations(&state, root);
+        // This can be the first subscription pass the repository ever gets:
+        // the stale check runs on a thread spawned before this function, so it
+        // can publish while `watch_registry` is still `None` and take no
+        // subscriptions at all. Its walk is then already over by the time we
+        // subscribe here, and nothing else revisits the tree until the hourly
+        // reconcile — so the recovery scan is not optional on this path.
+        let newly_watched = sync_watch_registrations(&state, root);
+        spawn_recovery_scan(&state, root, newly_watched);
     }
 
     let worker_state = Arc::clone(&state);
@@ -2221,6 +2222,49 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
     });
 }
 
+/// Recheck newly watched directories on a background thread.
+///
+/// For the publish sites that cannot scan inline. Until a directory is
+/// subscribed it cannot report a write, and the walk that decided to subscribe
+/// to it may have passed it before that write happened, so a file landing in
+/// that window is in neither place and would wait for the hourly reconcile.
+///
+/// Spawned because at startup this is every directory in the repository and
+/// the callers are on paths that must not block: `start_file_watcher` has to
+/// get its worker running, and an index build must not stop to stat the tree
+/// it is already reading.
+///
+/// Waits out `indexing` first. During a build the stamps do not describe the
+/// index yet, so every file would look changed and the scan would re-read the
+/// whole repository alongside the build that is already doing it.
+fn spawn_recovery_scan(state: &Arc<ServerState>, root: &Path, dirs: Vec<PathBuf>) {
+    if dirs.is_empty() || !PER_DIRECTORY_WATCHES {
+        return;
+    }
+    let state = Arc::clone(state);
+    let root = root.to_path_buf();
+    let spawned = thread::Builder::new()
+        .name("tgrep-watch-recovery".into())
+        .spawn(move || {
+            while state.indexing.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_millis(200));
+            }
+            // Read, not write: this does exactly what `handle_fs_event` does,
+            // and that runs under the read side. Taking it at all is what
+            // keeps the stamp check and the index update from interleaving
+            // with a flush.
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_files_in(&state, &root, &dirs);
+        });
+    if spawned.is_err() {
+        eprintln!(
+            "[trace] warning: could not start the watcher recovery scan; \
+             files written while subscriptions were being established will \
+             wait for the next reconcile"
+        );
+    }
+}
+
 fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     let dominated_kinds = matches!(
         event.kind,
@@ -2329,11 +2373,22 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         }
 
         if !path.is_file() {
+            // Only for events that can actually introduce a directory. Any
+            // `Modify` would include `Modify(Metadata)`, which a recursive
+            // chmod or a checkout fires once per directory — and each one
+            // would re-walk and re-subscribe that directory's whole subtree
+            // on the single watcher worker, turning a linear operation into
+            // quadratic work. inotify announces a new directory as `Create`
+            // and one moved in as `Modify(Name)`; nothing else can.
+            let introduces_dir = matches!(
+                event.kind,
+                EventKind::Create(_) | EventKind::Modify(notify::event::ModifyKind::Name(_))
+            );
             // `is_real_dir` rather than `is_dir`: the latter follows symlinks,
             // and a link to a directory is not something the walker descends
             // into, so subscribing to and indexing its target would pull in a
             // tree the index never contained — possibly outside `root`.
-            if PER_DIRECTORY_WATCHES && is_real_dir(path) {
+            if PER_DIRECTORY_WATCHES && introduces_dir && is_real_dir(path) {
                 // With non-recursive subscriptions notify will not extend the
                 // watch set for us, so a directory that just appeared — and
                 // anything already inside it — has to be picked up here.
@@ -2371,6 +2426,37 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
         },
         Err(_) => return,
     };
+
+    // The same two rules `walk_file_metadata` applies, and for the same
+    // reason: the walk is authoritative about what belongs in the index, so
+    // anything it rejects must not be added here. Without this a file that
+    // grew past the cap — or an ineligible extension in a directory a relaxed
+    // ignore rule just exposed — would be read whole and indexed, and the next
+    // reconcile would silently delete it again.
+    let eligible = !tgrep_core::walker::is_binary_extension(path)
+        && !state
+            .max_file_size
+            .is_some_and(|limit| current.size > limit);
+    if !eligible {
+        // It may have been eligible when it was last indexed — a file can grow
+        // past the cap. Drop what we hold so the index matches the walk rather
+        // than keeping a stale copy of the smaller version until the reconcile.
+        if state
+            .file_stamps
+            .write()
+            .unwrap()
+            .remove(rel_path)
+            .is_some()
+        {
+            eprintln!("[trace] reindex: dropped {rel_path} (no longer eligible)");
+            state.index.write().unwrap().live.delete_file(rel_path);
+            if let Ok(mut cache) = state.cache.write() {
+                cache.pop(rel_path);
+            }
+        }
+        return;
+    }
+
     if state.file_stamps.read().unwrap().get(rel_path) == Some(&current) {
         return;
     }
@@ -3185,13 +3271,13 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             state.no_require_git,
         );
         let found = matcher.is_some();
-        // These subscriptions are the repository's first, so "newly watched"
-        // is every directory in it. No recovery scan: the startup stale check
-        // runs right after this and does a full walk-versus-index diff, which
-        // is a strict superset of what a recovery scan would find — and doing
-        // it here would stat the entire tree while holding the gate, on the
-        // path a warm start exists to keep fast.
-        let _ = publish_ignore_matcher(state, root, matcher);
+        // "Newly watched" here is every directory in the repository, and the
+        // build's walk ran before any of them were subscribed. Deferred rather
+        // than skipped: the scan waits out `indexing` and then costs one
+        // `metadata` call per file, since the stamps this build just wrote
+        // describe the index exactly.
+        let newly_watched = publish_ignore_matcher(state, root, matcher);
+        spawn_recovery_scan(state, root, newly_watched);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -3284,11 +3370,13 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             state.no_require_git,
         );
         let has_matcher = matcher.is_some();
-        // Same reasoning as the bootstrap publish: this is the cold-start
-        // build, so "newly watched" is the whole tree, `indexing` keeps the
-        // watcher off the index for the rest of the build, and the stale check
-        // that follows reconciles anything written during it.
-        let _ = publish_ignore_matcher(state, root, matcher);
+        // Subscriptions are taken here, partway through the build, so files
+        // written to a directory the walk has already passed are in neither
+        // the build's results nor any event. The scan waits for the build to
+        // finish before looking, because until then the stamps describe
+        // nothing and every file would read as changed.
+        let newly_watched = publish_ignore_matcher(state, root, matcher);
+        spawn_recovery_scan(state, root, newly_watched);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1804,6 +1804,33 @@ impl WatchRegistry {
     /// else, and giving up on the entire tree is exactly the failure mode this
     /// registration exists to avoid.
     fn add_all<'a>(&mut self, desired: impl IntoIterator<Item = &'a PathBuf>) -> Vec<PathBuf> {
+        self.subscribe(desired, false)
+    }
+
+    /// Subscribe to every directory in `dirs`, re-issuing the subscription even
+    /// for ones already recorded as watched.
+    ///
+    /// For directories that have just appeared, where membership in `watched`
+    /// proves nothing. The kernel drops an inotify watch by itself when its
+    /// directory is deleted or moved away, and nothing tells us the descriptor
+    /// is gone — so a path recreated at the same location would look
+    /// subscribed while receiving no events at all. [`Self::add_all`] would
+    /// skip it, and so would every later [`Self::sync`], since the path is in
+    /// `desired` *and* in `watched`: the entry stays poisoned until the server
+    /// restarts. Re-adding is cheap and idempotent (`inotify_add_watch`
+    /// returns the existing descriptor), so the doubt is worth paying for.
+    ///
+    /// Returns only the directories that were not previously recorded, so a
+    /// caller's notion of "newly watched" keeps its meaning.
+    fn resubscribe_all<'a>(&mut self, dirs: impl IntoIterator<Item = &'a PathBuf>) -> Vec<PathBuf> {
+        self.subscribe(dirs, true)
+    }
+
+    fn subscribe<'a>(
+        &mut self,
+        desired: impl IntoIterator<Item = &'a PathBuf>,
+        force: bool,
+    ) -> Vec<PathBuf> {
         let mut added = Vec::new();
         let mut failures = 0;
         // Iterating `desired` and testing membership is deliberate: a
@@ -1811,15 +1838,24 @@ impl WatchRegistry {
         // this runs per newly created directory on repositories where that set
         // is tens of thousands of entries.
         for dir in desired {
-            if self.watched.contains(dir) {
+            let known = self.watched.contains(dir);
+            if known && !force {
                 continue;
             }
             match self.watcher.watch(dir, RecursiveMode::NonRecursive) {
                 Ok(()) => {
-                    self.watched.insert(dir.clone());
-                    added.push(dir.clone());
+                    if !known {
+                        self.watched.insert(dir.clone());
+                        added.push(dir.clone());
+                    }
                 }
                 Err(e) => {
+                    // A forced re-add that fails means the directory is gone
+                    // again; drop the entry so a later attempt can retry it
+                    // rather than trusting a descriptor that does not exist.
+                    if known {
+                        self.watched.remove(dir);
+                    }
                     // One line per call, not per directory: exhausting the
                     // inotify budget fails thousands of these at once.
                     if failures == 0 {
@@ -1837,6 +1873,25 @@ impl WatchRegistry {
             eprintln!("[trace] warning: {failures} directories could not be watched");
         }
         added
+    }
+
+    /// Drop a path that no longer exists from the subscription set.
+    ///
+    /// The kernel has already released the descriptor if the directory was
+    /// deleted; the `unwatch` is for the moved-away case, where it is still
+    /// live and now pointing outside the tree. What matters either way is
+    /// clearing `watched`, so that if the path comes back, it is treated as
+    /// the new directory it is instead of an already-subscribed one.
+    ///
+    /// Cheap by design: one hash lookup per removal event, because deleting a
+    /// tree delivers one event per directory in it and anything proportional
+    /// to the whole watched set would turn that into quadratic work.
+    /// Descendants left behind by a move are pruned by the next
+    /// [`Self::sync`], which no longer finds them under the root.
+    fn forget(&mut self, path: &Path) {
+        if self.watched.remove(path) {
+            let _ = self.watcher.unwatch(path);
+        }
     }
 
     /// Bring the subscription set in line with `desired`, subscribing to
@@ -2054,7 +2109,12 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
             // matters at scale — a monorepo can hold tens of thousands of
             // watched directories, and materialising a union for every newly
             // created directory would be quadratic over a checkout.
-            registry.add_all(level.iter());
+            //
+            // Forced, because these directories have just appeared: a path
+            // recreated where a watched one used to be is still recorded as
+            // watched, but the kernel dropped its descriptor when the original
+            // went away.
+            registry.resubscribe_all(level.iter());
         }
 
         // The registry lock is released before any `read_dir`, so a large
@@ -2236,6 +2296,18 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         let is_remove = matches!(event.kind, EventKind::Remove(_)) || !path.exists();
 
         if is_remove {
+            // A watched directory that disappears takes its descriptor with
+            // it, but not its entry in the registry. Clearing that entry is
+            // what lets the path be subscribed again if it comes back — and
+            // keeps `watched` from accumulating dead paths between syncs.
+            // Done for every removed path rather than only known directories,
+            // since by now there is nothing left to ask what it was; a path
+            // that was never watched is a single failed hash lookup.
+            if PER_DIRECTORY_WATCHES
+                && let Some(registry) = state.watch_registry.lock().unwrap().as_mut()
+            {
+                registry.forget(path);
+            }
             // notify can deliver Remove events for transient/unknown paths
             // (e.g. a build tool's temp file). Suppress the noisy log line
             // for those, but still apply the delete unconditionally — if
@@ -4233,6 +4305,52 @@ mod tests {
         let (added, removed) = registry.sync(&[c.clone()].into_iter().collect());
         assert_eq!((added.len(), removed), (0, 2));
         assert_eq!(registry.watched, [c].into_iter().collect());
+    }
+
+    #[test]
+    fn a_recreated_directory_is_subscribed_again_rather_than_assumed_watched() {
+        // The kernel releases an inotify watch by itself when its directory is
+        // deleted or moved away, and says nothing about it. A path recreated at
+        // the same location therefore *looks* subscribed while receiving no
+        // events — and because it is in `desired` as well as in `watched`, no
+        // later `sync` can tell the difference either. The entry stays poisoned
+        // for the life of the process, so the directory silently stops being
+        // watched forever.
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        std::fs::create_dir(&a).unwrap();
+
+        let watcher = notify::recommended_watcher(|_: notify::Result<Event>| {}).unwrap();
+        let mut registry = WatchRegistry {
+            watcher,
+            watched: std::collections::HashSet::new(),
+        };
+        assert_eq!(registry.add_all(std::slice::from_ref(&a)).len(), 1);
+
+        // What the removal event does. Without it the entry below survives.
+        registry.forget(&a);
+        assert!(
+            !registry.watched.contains(&a),
+            "a removed directory must not be left recorded as watched"
+        );
+        assert_eq!(
+            registry.add_all(std::slice::from_ref(&a)).len(),
+            1,
+            "a directory recreated after removal must be subscribed again"
+        );
+
+        // And the belt-and-braces half: even with the entry still present —
+        // a move away delivers no event for the descendants it takes with it —
+        // a directory that has just appeared gets its subscription re-issued.
+        // Already-known paths are not reported as new, so the recovery scan
+        // does not treat the whole subtree as freshly watched.
+        assert!(
+            registry
+                .resubscribe_all(std::slice::from_ref(&a))
+                .is_empty(),
+            "re-issuing a subscription must not report an existing path as new"
+        );
+        assert!(registry.watched.contains(&a));
     }
 
     #[cfg(unix)]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -296,6 +296,12 @@ struct ServerState {
     index_total: std::sync::atomic::AtomicU64,
     /// True when file watching is enabled for this server.
     watch_enabled: bool,
+    /// The live watcher and the directories it is subscribed to.
+    ///
+    /// Held here rather than by `run` because the subscription set is not
+    /// fixed: publishing a new ignore matcher renarrows it, and a directory
+    /// created after startup has to be subscribed as it appears.
+    watch_registry: Mutex<Option<WatchRegistry>>,
     /// Directories to exclude from indexing.
     exclude_dirs: Vec<String>,
     /// Disable all source-control ignore files for every server discovery path.
@@ -570,6 +576,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
         watch_enabled: !no_watch,
+        watch_registry: Mutex::new(None),
         exclude_dirs: exclude_dirs.to_vec(),
         no_ignore,
         no_require_git,
@@ -656,14 +663,13 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     }
 
     // Start file watcher (unless --no-watch)
-    let _watcher = if no_watch {
+    if no_watch {
         eprintln!("[trace] file watcher disabled (--no-watch)");
-        None
     } else {
         let watcher_state = Arc::clone(&state);
         let watcher_root = root.clone();
-        start_file_watcher(watcher_state, &watcher_root, watcher_queue_cap)
-    };
+        start_file_watcher(watcher_state, &watcher_root, watcher_queue_cap);
+    }
 
     // Set up graceful shutdown
     let shutdown_index_dir = index_dir.clone();
@@ -744,14 +750,23 @@ fn build_stale_matcher(
     matcher
 }
 
-/// Commit matcher and index semantics together while the stale refresh holds
-/// `snapshot_gate`. `None` is a legitimate matcher when no rules exist.
-fn commit_stale_matcher(
+/// Publish a new ignore matcher and bring everything that depends on it up to
+/// date. `None` is a legitimate matcher when no rules exist.
+///
+/// Callers on the stale path hold `snapshot_gate` for write, which is what
+/// makes the matcher swap and the index decisions around it atomic from the
+/// watcher's point of view.
+fn publish_ignore_matcher(
     state: &ServerState,
+    root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
 ) {
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
+    // New rules mean a different set of directories worth hearing about:
+    // a tightened rule releases the subscriptions under it, and a relaxed
+    // one takes subscriptions for the tree it used to hide.
+    sync_watch_registrations(state, root);
 }
 
 fn handle_connection(stream: TcpStream, state: &ServerState) -> Result<()> {
@@ -1482,11 +1497,7 @@ fn handle_reload(id: Option<serde_json::Value>, state: &ServerState) -> String {
     }
 }
 
-fn start_file_watcher(
-    state: Arc<ServerState>,
-    root: &Path,
-    queue_cap: usize,
-) -> Option<RecommendedWatcher> {
+fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) -> bool {
     use std::sync::mpsc::{RecvTimeoutError, TrySendError};
 
     let root_path = root.to_path_buf();
@@ -1525,19 +1536,46 @@ fn start_file_watcher(
         Ok(w) => w,
         Err(e) => {
             eprintln!("[trace] warning: failed to start file watcher: {e}");
-            return None;
+            return false;
         }
     };
 
-    if let Err(e) = watcher.watch(root, RecursiveMode::Recursive) {
+    // The root is always subscribed. On a whole-subtree backend that single
+    // recursive subscription is the entire watch set; on a per-directory
+    // backend it is the anchor, and `sync_watch_registrations` below adds the
+    // descendants the ignore rules allow.
+    let root_mode = if PER_DIRECTORY_WATCHES {
+        RecursiveMode::NonRecursive
+    } else {
+        RecursiveMode::Recursive
+    };
+    if let Err(e) = watcher.watch(root, root_mode) {
         eprintln!("[trace] warning: failed to watch directory: {e}");
-        return None;
+        return false;
+    }
+
+    *state.watch_registry.lock().unwrap() = Some(WatchRegistry {
+        watcher,
+        watched: std::iter::once(root.to_path_buf()).collect(),
+    });
+
+    // Subscribing to the descendants needs the ignore matcher, and on a warm
+    // start it is still being built on another thread. Skipping the sync here
+    // costs nothing: events are dropped while `gitignore_pending` is set, and
+    // the publish that clears it runs this same sync. Subscribing first and
+    // narrowing afterwards would mean briefly holding exactly the watches this
+    // is meant to avoid — on a repo big enough to exhaust the inotify budget,
+    // long enough to fail.
+    if state.gitignore_pending.load(Ordering::SeqCst) {
+        eprintln!("[trace] watcher subscriptions deferred until the ignore matcher is ready");
+    } else {
+        sync_watch_registrations(&state, root);
     }
 
     let worker_state = Arc::clone(&state);
     let worker_root = root_path;
     let worker_index_dir = state.index_dir.clone();
-    std::thread::Builder::new()
+    if std::thread::Builder::new()
         .name("tgrep-watcher".into())
         .spawn(move || {
             loop {
@@ -1579,14 +1617,19 @@ fn start_file_watcher(
                 }
             }
         })
-        .ok()?;
+        .is_err()
+    {
+        eprintln!("[trace] warning: failed to start the watcher worker thread");
+        *state.watch_registry.lock().unwrap() = None;
+        return false;
+    }
 
     state
         .watcher_active
         .store(true, std::sync::atomic::Ordering::Relaxed);
     eprintln!("[trace] file watcher started");
 
-    Some(watcher)
+    true
 }
 
 /// Decide whether the file watcher should skip a path entirely.
@@ -1618,6 +1661,30 @@ fn should_skip_watcher_path(
     exclude_dirs: &[String],
     gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
 ) -> bool {
+    should_skip_watcher_entry(rel_path, exclude_dirs, gitignore, false)
+}
+
+/// [`should_skip_watcher_path`] for a path known to be a directory.
+///
+/// Two rules read differently for a directory. `--exclude` names apply to the
+/// final segment as well, because the walker drops the whole subtree when the
+/// entry it is looking at *is* the excluded directory. And the gitignore
+/// matcher is told it is matching a directory, so a directory-only rule like
+/// `build/` matches — as a file path, `build` does not.
+fn should_skip_watcher_dir(
+    rel_path: &str,
+    exclude_dirs: &[String],
+    gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
+) -> bool {
+    should_skip_watcher_entry(rel_path, exclude_dirs, gitignore, true)
+}
+
+fn should_skip_watcher_entry(
+    rel_path: &str,
+    exclude_dirs: &[String],
+    gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
+    is_dir: bool,
+) -> bool {
     // Single streaming pass over path components — no Vec allocation
     // on the hot watcher path. The hidden-component check applies to
     // every segment (including the basename); the exclude_dirs check
@@ -1632,23 +1699,21 @@ fn should_skip_watcher_path(
         if seg.starts_with('.') {
             return true;
         }
-        // Ancestor (i.e. not the last segment) — apply exclude_dirs.
-        if segments.peek().is_some()
-            && !exclude_dirs.is_empty()
-            && exclude_dirs.iter().any(|d| d == seg)
-        {
+        // An ancestor is always a directory; the final segment is one only
+        // when the caller says so.
+        let segment_is_dir = segments.peek().is_some() || is_dir;
+        if segment_is_dir && !exclude_dirs.is_empty() && exclude_dirs.iter().any(|d| d == seg) {
             return true;
         }
     }
 
     // Gitignore check (if a matcher is available).
     if let Some(gi) = gitignore {
-        // We don't know whether the path is a dir or a file here — for
-        // the watcher's purposes we treat all events as "file" matches.
-        // Notify usually fires per-file events anyway, and gitignore
-        // rules that target dirs would have already skipped the dir's
-        // contents via `matched_path_or_any_parents`.
-        if gi.is_ignored(Path::new(rel_path), false) {
+        // For a file event we don't know whether the path is a dir, so we
+        // treat it as a file. Notify usually fires per-file events anyway,
+        // and gitignore rules that target dirs would have already skipped
+        // the dir's contents via `matched_path_or_any_parents`.
+        if gi.is_ignored(Path::new(rel_path), is_dir) {
             return true;
         }
     }
@@ -1674,6 +1739,238 @@ fn is_ignore_rules_file(root: &Path, path: &Path) -> bool {
         Some(tgrep_core::gitignore::GITIGNORE_FILENAME)
             | Some(tgrep_core::gitignore::DOT_IGNORE_FILENAME)
     ) || path == root.join(tgrep_core::gitignore::P4IGNORE_FILENAME)
+}
+
+/// Whether this platform's `notify` backend takes one OS subscription per
+/// directory rather than a single recursive one for the whole tree.
+///
+/// inotify has no recursive mode. `RecursiveMode::Recursive` makes notify walk
+/// the tree itself and spend one watch descriptor per directory, so every
+/// ignored directory costs a descriptor from the per-user
+/// `fs.inotify.max_user_watches` budget purely to deliver events we then throw
+/// away. Worse, notify's registration loop propagates the first failure, so a
+/// repo whose ignored build output exhausts the budget makes `watch()` return
+/// an error and the server loses its watcher entirely.
+///
+/// ReadDirectoryChangesW (Windows) and FSEvents (macOS) subscribe once for the
+/// whole subtree, so there is no per-directory registration to withhold. On
+/// those platforms filtering on delivery is the only lever available, and
+/// [`should_skip_watcher_path`] remains it.
+///
+/// Deliberately limited to the backends we can exercise in CI. kqueue and
+/// `PollWatcher` are per-path too, but nothing here builds or tests them.
+const PER_DIRECTORY_WATCHES: bool = cfg!(any(target_os = "linux", target_os = "android"));
+
+/// The watcher plus the set of directories it is currently subscribed to.
+///
+/// Only meaningful when [`PER_DIRECTORY_WATCHES`] is true; elsewhere `watched`
+/// holds just the root, which is subscribed recursively.
+struct WatchRegistry {
+    watcher: RecommendedWatcher,
+    watched: std::collections::HashSet<PathBuf>,
+}
+
+impl WatchRegistry {
+    /// Bring the subscription set in line with `desired`, subscribing to
+    /// directories that are newly relevant and dropping ones that are not.
+    ///
+    /// Returns `(added, removed)`. A single directory that cannot be
+    /// subscribed is reported and skipped rather than failing the sync: the
+    /// watcher is still useful for everything else, and giving up on the whole
+    /// tree is exactly the failure mode this registration exists to avoid.
+    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (usize, usize) {
+        let stale: Vec<PathBuf> = self.watched.difference(desired).cloned().collect();
+        let mut removed = 0;
+        for dir in stale {
+            // Best effort. inotify drops a descriptor by itself when the
+            // directory is deleted, so "not found" is an expected outcome
+            // here, not an error worth reporting.
+            let _ = self.watcher.unwatch(&dir);
+            self.watched.remove(&dir);
+            removed += 1;
+        }
+
+        let missing: Vec<PathBuf> = desired.difference(&self.watched).cloned().collect();
+        let mut added = 0;
+        let mut failures = 0;
+        for dir in missing {
+            match self.watcher.watch(&dir, RecursiveMode::NonRecursive) {
+                Ok(()) => {
+                    self.watched.insert(dir);
+                    added += 1;
+                }
+                Err(e) => {
+                    // One line per sync, not per directory: exhausting the
+                    // inotify budget fails thousands of these at once.
+                    if failures == 0 {
+                        eprintln!(
+                            "[trace] warning: could not watch {}: {e} \
+                             (continuing with the directories that succeeded)",
+                            dir.display()
+                        );
+                    }
+                    failures += 1;
+                }
+            }
+        }
+        if failures > 1 {
+            eprintln!("[trace] warning: {failures} directories could not be watched");
+        }
+        (added, removed)
+    }
+}
+
+/// Every directory at or below `start` whose contents the watcher needs to
+/// hear about.
+///
+/// A per-directory subscription reports the files directly inside it, so the
+/// set is "`start`, plus every descendant directory the indexer would walk
+/// into". Ignored directories are pruned along with their subtrees, which is
+/// the whole point: the tree under `target/` or `node_modules/` is usually
+/// most of the directories in a repo.
+///
+/// `root` is the repository root and is only used to build the relative paths
+/// the ignore rules are written against; `start` is where the walk begins.
+/// They differ when a subtree that appeared at runtime is being subscribed,
+/// and conflating them would match every rule at the wrong anchor.
+///
+/// `start` itself is always included — callers are responsible for not asking
+/// about a directory that is ignored.
+///
+/// Symlinked directories are not descended into, matching the walker (the
+/// `ignore` crate does not follow links by default). That also keeps a
+/// symlink cycle from turning this into an infinite walk.
+fn watchable_dirs(
+    root: &Path,
+    start: &Path,
+    exclude_dirs: &[String],
+    gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
+) -> std::collections::HashSet<PathBuf> {
+    let mut found = std::collections::HashSet::new();
+    found.insert(start.to_path_buf());
+
+    let mut stack = vec![start.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            // An unreadable directory is not a reason to abandon the rest of
+            // the tree; the periodic reconcile is what catches what we miss.
+            continue;
+        };
+        for entry in entries.flatten() {
+            if !entry.file_type().is_ok_and(|t| t.is_dir()) {
+                continue;
+            }
+            let path = entry.path();
+            let Ok(rel) = path.strip_prefix(root) else {
+                continue;
+            };
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            if should_skip_watcher_dir(&rel, exclude_dirs, gitignore) {
+                continue;
+            }
+            stack.push(path.clone());
+            found.insert(path);
+        }
+    }
+    found
+}
+
+/// Recompute the watcher's subscriptions against the ignore rules in force.
+///
+/// Called when the watcher starts and every time the ignore matcher is
+/// published, so relaxing a rule subscribes to the tree it used to hide and
+/// tightening one drops it.
+fn sync_watch_registrations(state: &ServerState, root: &Path) {
+    if !PER_DIRECTORY_WATCHES {
+        return;
+    }
+    let mut registry = state.watch_registry.lock().unwrap();
+    let Some(registry) = registry.as_mut() else {
+        // The watcher has not started yet. It syncs once as it comes up, so
+        // there is nothing to do and nothing to remember.
+        return;
+    };
+
+    let start = Instant::now();
+    let desired = {
+        let gitignore = state.gitignore.read().unwrap();
+        watchable_dirs(root, root, &state.exclude_dirs, gitignore.as_ref())
+    };
+    let total = desired.len();
+    let (added, removed) = registry.sync(&desired);
+    if added > 0 || removed > 0 {
+        eprintln!(
+            "[trace] watcher subscriptions: {total} directories \
+             (+{added}, -{removed}) in {:.1}ms",
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+}
+
+/// Subscribe to a directory that has just appeared, and to anything already
+/// inside it.
+///
+/// Non-recursive subscriptions are not extended by notify — it only auto-adds
+/// watches beneath a watch that was registered as recursive — so a new
+/// directory has to be picked up here or its contents are invisible.
+///
+/// Files that landed between the directory's creation and its subscription
+/// would be missed by definition, so the same pass indexes what it finds.
+/// The caller must already hold `snapshot_gate`.
+fn watch_new_subtree(state: &ServerState, root: &Path, dir: &Path) {
+    let Ok(rel_dir) = dir.strip_prefix(root) else {
+        return;
+    };
+    let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+
+    let desired = {
+        let gitignore = state.gitignore.read().unwrap();
+        // The event that brought us here was filtered with file semantics, so
+        // a `build/`-style rule that only ever matches directories has not
+        // been applied to this path yet. Re-check before subscribing to it.
+        if !rel_dir.is_empty()
+            && should_skip_watcher_dir(&rel_dir, &state.exclude_dirs, gitignore.as_ref())
+        {
+            return;
+        }
+        watchable_dirs(root, dir, &state.exclude_dirs, gitignore.as_ref())
+    };
+
+    {
+        let mut registry = state.watch_registry.lock().unwrap();
+        let Some(registry) = registry.as_mut() else {
+            return;
+        };
+        // A union, not a replacement: `desired` covers only this subtree, and
+        // `sync` would read anything outside it as newly stale and unsubscribe
+        // from the entire rest of the repository.
+        let union: std::collections::HashSet<PathBuf> =
+            registry.watched.union(&desired).cloned().collect();
+        registry.sync(&union);
+    }
+
+    for subdir in &desired {
+        let Ok(entries) = std::fs::read_dir(subdir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if !entry.file_type().is_ok_and(|t| t.is_file()) {
+                continue;
+            }
+            let path = entry.path();
+            let Ok(rel) = path.strip_prefix(root) else {
+                continue;
+            };
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            let skip = {
+                let gitignore = state.gitignore.read().unwrap();
+                should_skip_watcher_path(&rel, &state.exclude_dirs, gitignore.as_ref())
+            };
+            if !skip {
+                reindex_file(state, &path, &rel);
+            }
+        }
+    }
 }
 
 fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
@@ -1713,8 +2010,6 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 }
 
 fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
-    use tgrep_core::meta::FileStamp;
-
     let dominated_kinds = matches!(
         event.kind,
         EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
@@ -1810,65 +2105,82 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         }
 
         if !path.is_file() {
-            continue;
-        }
-
-        // Compute the file's current stamp and skip if it matches what we
-        // last indexed. notify on Windows in particular fires Modify events
-        // for atime/attribute updates, opens, etc. — re-indexing on those
-        // would re-read large files, churn the live overlay, and produce a
-        // misleading "modified" trace for files that didn't actually change.
-        let current = match std::fs::metadata(path) {
-            Ok(m) => FileStamp {
-                mtime: m
-                    .modified()
-                    .ok()
-                    .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0),
-                size: m.len(),
-            },
-            Err(_) => continue,
-        };
-        if state.file_stamps.read().unwrap().get(&rel_path) == Some(&current) {
-            continue;
-        }
-
-        // Read contents and extract trigrams OUTSIDE the index write lock
-        // so a concurrent search (which needs a read lock) is not blocked
-        // on our file I/O and trigram parsing. Windows' SRWLock is
-        // writer-preferring: a single waiting writer here would otherwise
-        // stall every subsequent search request.
-        let data = match std::fs::read(path) {
-            Ok(d) => d,
-            Err(_) => continue,
-        };
-        let text = tgrep_core::encoding::decode_for_index(&data);
-        let is_binary = tgrep_core::trigram::is_binary(&text);
-        let per_tri = if is_binary {
-            None
-        } else {
-            Some(tgrep_core::live::LiveIndex::compute_trigram_masks(&text))
-        };
-
-        eprintln!("[trace] reindex: modified {rel_path}");
-        // gate acquired at the function level — the commit + stamp
-        // update is processed atomically with respect to flush/auto-save.
-        {
-            let mut index = state.index.write().unwrap();
-            match per_tri {
-                Some(per_tri) => index.live.commit_upsert(&rel_path, per_tri),
-                None => index.live.delete_file(&rel_path),
+            if PER_DIRECTORY_WATCHES && path.is_dir() {
+                // With non-recursive subscriptions notify will not extend the
+                // watch set for us, so a directory that just appeared — and
+                // anything already inside it — has to be picked up here.
+                watch_new_subtree(state, root, path);
             }
+            continue;
         }
-        state
-            .file_stamps
-            .write()
-            .unwrap()
-            .insert(rel_path.clone(), current);
-        if let Ok(mut cache) = state.cache.write() {
-            cache.pop(&rel_path);
+
+        reindex_file(state, path, &rel_path);
+    }
+}
+
+/// Read a file and merge it into the live index, unless its stamp says the
+/// content we already indexed is current.
+///
+/// The caller must hold `snapshot_gate`: the read, the commit, and the stamp
+/// update have to be atomic with respect to a flush or auto-save.
+fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
+    use tgrep_core::meta::FileStamp;
+
+    // Compute the file's current stamp and skip if it matches what we
+    // last indexed. notify on Windows in particular fires Modify events
+    // for atime/attribute updates, opens, etc. — re-indexing on those
+    // would re-read large files, churn the live overlay, and produce a
+    // misleading "modified" trace for files that didn't actually change.
+    let current = match std::fs::metadata(path) {
+        Ok(m) => FileStamp {
+            mtime: m
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            size: m.len(),
+        },
+        Err(_) => return,
+    };
+    if state.file_stamps.read().unwrap().get(rel_path) == Some(&current) {
+        return;
+    }
+
+    // Read contents and extract trigrams OUTSIDE the index write lock
+    // so a concurrent search (which needs a read lock) is not blocked
+    // on our file I/O and trigram parsing. Windows' SRWLock is
+    // writer-preferring: a single waiting writer here would otherwise
+    // stall every subsequent search request.
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let text = tgrep_core::encoding::decode_for_index(&data);
+    let is_binary = tgrep_core::trigram::is_binary(&text);
+    let per_tri = if is_binary {
+        None
+    } else {
+        Some(tgrep_core::live::LiveIndex::compute_trigram_masks(&text))
+    };
+
+    eprintln!("[trace] reindex: modified {rel_path}");
+    // Gate held by the caller — the commit + stamp update is processed
+    // atomically with respect to flush/auto-save.
+    {
+        let mut index = state.index.write().unwrap();
+        match per_tri {
+            Some(per_tri) => index.live.commit_upsert(rel_path, per_tri),
+            None => index.live.delete_file(rel_path),
         }
+    }
+    state
+        .file_stamps
+        .write()
+        .unwrap()
+        .insert(rel_path.to_string(), current);
+    if let Ok(mut cache) = state.cache.write() {
+        cache.pop(rel_path);
     }
 }
 
@@ -2369,7 +2681,7 @@ fn background_refresh_stale(
     // this function holds `snapshot_gate` for write across its whole body, and
     // the only reader of `state.gitignore` takes the read side first, so no
     // event can observe the matcher before this function returns either way.
-    commit_stale_matcher(state, build_stale_matcher(state, root, &walk));
+    publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -2607,8 +2919,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             state.no_require_git,
         );
         let found = matcher.is_some();
-        *state.gitignore.write().unwrap() = matcher;
-        state.gitignore_pending.store(false, Ordering::SeqCst);
+        publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -2701,8 +3012,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             state.no_require_git,
         );
         let has_matcher = matcher.is_some();
-        *state.gitignore.write().unwrap() = matcher;
-        state.gitignore_pending.store(false, Ordering::SeqCst);
+        publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -3455,6 +3765,7 @@ mod tests {
             index_progress: std::sync::atomic::AtomicU64::new(0),
             index_total: std::sync::atomic::AtomicU64::new(0),
             watch_enabled: true,
+            watch_registry: Mutex::new(None),
             exclude_dirs: Vec::new(),
             no_ignore: false,
             no_require_git: false,
@@ -3674,6 +3985,160 @@ mod tests {
             &no_exclude,
             Some(&gi)
         ));
+    }
+
+    #[test]
+    fn watchable_dirs_prunes_ignored_and_hidden_subtrees() {
+        // The point of the subscription set: an ignored directory costs one
+        // inotify watch descriptor per directory inside it, so pruning has to
+        // happen before the subtree is walked, not after its events arrive.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        std::fs::write(root.join(".gitignore"), "build/\n").unwrap();
+
+        for dir in [
+            "src",
+            "src/nested",
+            "build",
+            "build/a",
+            "build/a/deep",
+            ".git/objects",
+            "vendor",
+            "vendor/pkg",
+        ] {
+            std::fs::create_dir_all(root.join(dir)).unwrap();
+        }
+
+        let gi = tgrep_core::gitignore::build_matcher(root).expect("matcher should build");
+        let exclude = vec!["vendor".to_string()];
+        let dirs = watchable_dirs(root, root, &exclude, Some(&gi));
+
+        let rel: std::collections::HashSet<String> = dirs
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        // The root itself is always watched, plus the directories the indexer
+        // would descend into.
+        assert!(rel.contains(""), "root must always be watched: {rel:?}");
+        assert!(rel.contains("src"));
+        assert!(rel.contains("src/nested"));
+
+        // A gitignored directory and everything beneath it.
+        assert!(
+            !rel.contains("build"),
+            "gitignored dir was watched: {rel:?}"
+        );
+        assert!(!rel.contains("build/a"));
+        assert!(!rel.contains("build/a/deep"));
+
+        // Hidden directories, which the walker skips too.
+        assert!(!rel.contains(".git"));
+        assert!(!rel.contains(".git/objects"));
+
+        // `--exclude` names prune the directory itself, not just its children.
+        assert!(!rel.contains("vendor"), "excluded dir was watched: {rel:?}");
+        assert!(!rel.contains("vendor/pkg"));
+    }
+
+    #[test]
+    fn watchable_dirs_without_a_matcher_keeps_everything_visible() {
+        // `--no-ignore` publishes no matcher. The subscription set must then
+        // be the whole tree minus hidden paths, matching what the walk indexes;
+        // silently narrowing it would drop events for files that ARE indexed.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("build/a")).unwrap();
+        std::fs::create_dir_all(root.join(".hidden")).unwrap();
+
+        let dirs = watchable_dirs(root, root, &[], None);
+        let rel: std::collections::HashSet<String> = dirs
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        assert!(rel.contains("build"));
+        assert!(rel.contains("build/a"));
+        assert!(!rel.contains(".hidden"));
+    }
+
+    #[test]
+    fn watchable_dirs_anchors_rules_at_the_root_not_the_start_directory() {
+        // A subtree that appears at runtime is walked from itself, but the
+        // ignore rules are written against paths relative to the repository
+        // root. Walking with the subtree as the anchor would test "nested"
+        // against a rule meant for "src/nested" and prune the wrong things.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        std::fs::write(root.join(".gitignore"), "src/fresh/skipped/\n/keep/\n").unwrap();
+
+        for dir in ["src/fresh/skipped", "src/fresh/keep", "src/fresh/kept"] {
+            std::fs::create_dir_all(root.join(dir)).unwrap();
+        }
+
+        let gi = tgrep_core::gitignore::build_matcher(root).expect("matcher should build");
+        let dirs = watchable_dirs(root, &root.join("src/fresh"), &[], Some(&gi));
+        let rel: std::collections::HashSet<String> = dirs
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        assert!(
+            rel.contains("src/fresh"),
+            "start dir must be watched: {rel:?}"
+        );
+        assert!(rel.contains("src/fresh/kept"));
+        assert!(
+            !rel.contains("src/fresh/skipped"),
+            "a root-anchored rule was not applied: {rel:?}"
+        );
+        // `keep/` is anchored at the root, so it must NOT prune
+        // `src/fresh/keep` just because the walk started at `src/fresh`.
+        assert!(
+            rel.contains("src/fresh/keep"),
+            "a root-anchored rule was applied at the wrong depth: {rel:?}"
+        );
+    }
+
+    #[test]
+    fn skip_watcher_dir_applies_directory_semantics() {
+        // A directory-only gitignore rule (`build/`) does not match the path
+        // `build` when it is tested as a file, which is why the subscription
+        // set needs its own dir-aware entry point.
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        std::fs::write(tmp.path().join(".gitignore"), "build/\n").unwrap();
+        let gi = tgrep_core::gitignore::build_matcher(tmp.path()).expect("matcher should build");
+
+        assert!(should_skip_watcher_dir("build", &[], Some(&gi)));
+        assert!(!should_skip_watcher_path("build", &[], Some(&gi)));
+
+        // `--exclude` prunes the named directory itself...
+        let exclude = vec!["target".to_string()];
+        assert!(should_skip_watcher_dir("target", &exclude, None));
+        assert!(should_skip_watcher_dir("src/target", &exclude, None));
+        // ...but a *file* of that name is still indexed, so it must not be
+        // skipped. This is the invariant `should_skip_watcher_path` already
+        // held, and sharing an implementation must not have changed it.
+        assert!(!should_skip_watcher_path("target", &exclude, None));
+        assert!(!should_skip_watcher_path("src/target", &exclude, None));
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -5448,13 +5448,21 @@ mod tests {
         };
         defer_events_during_build(&state, &small);
         assert_eq!(
-            state.deferred_events.lock().unwrap().as_ref().unwrap().len(),
+            state
+                .deferred_events
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .len(),
             1
         );
 
         let flood = Event {
             kind: EventKind::Create(notify::event::CreateKind::Any),
-            paths: (0..200_001).map(|i| root.join(format!("f{i}.rs"))).collect(),
+            paths: (0..100_000)
+                .map(|i| root.join(format!("f{i}.rs")))
+                .collect(),
             attrs: Default::default(),
         };
         defer_events_during_build(&state, &flood);

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1771,36 +1771,31 @@ struct WatchRegistry {
 }
 
 impl WatchRegistry {
-    /// Bring the subscription set in line with `desired`, subscribing to
-    /// directories that are newly relevant and dropping ones that are not.
+    /// Subscribe to every directory in `desired` that is not already
+    /// subscribed, leaving existing subscriptions alone.
     ///
-    /// Returns `(added, removed)`. A single directory that cannot be
-    /// subscribed is reported and skipped rather than failing the sync: the
-    /// watcher is still useful for everything else, and giving up on the whole
-    /// tree is exactly the failure mode this registration exists to avoid.
-    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (usize, usize) {
-        let stale: Vec<PathBuf> = self.watched.difference(desired).cloned().collect();
-        let mut removed = 0;
-        for dir in stale {
-            // Best effort. inotify drops a descriptor by itself when the
-            // directory is deleted, so "not found" is an expected outcome
-            // here, not an error worth reporting.
-            let _ = self.watcher.unwatch(&dir);
-            self.watched.remove(&dir);
-            removed += 1;
-        }
-
-        let missing: Vec<PathBuf> = desired.difference(&self.watched).cloned().collect();
+    /// Returns the number added. A single directory that cannot be subscribed
+    /// is reported and skipped rather than failing the whole call: the watcher
+    /// is still useful for everything else, and giving up on the entire tree is
+    /// exactly the failure mode this registration exists to avoid.
+    fn add_all(&mut self, desired: &std::collections::HashSet<PathBuf>) -> usize {
         let mut added = 0;
         let mut failures = 0;
-        for dir in missing {
-            match self.watcher.watch(&dir, RecursiveMode::NonRecursive) {
+        // Iterating `desired` and testing membership is deliberate: a
+        // `difference` would be proportional to the whole watched set, and
+        // this runs per newly created directory on repositories where that set
+        // is tens of thousands of entries.
+        for dir in desired {
+            if self.watched.contains(dir) {
+                continue;
+            }
+            match self.watcher.watch(dir, RecursiveMode::NonRecursive) {
                 Ok(()) => {
-                    self.watched.insert(dir);
+                    self.watched.insert(dir.clone());
                     added += 1;
                 }
                 Err(e) => {
-                    // One line per sync, not per directory: exhausting the
+                    // One line per call, not per directory: exhausting the
                     // inotify budget fails thousands of these at once.
                     if failures == 0 {
                         eprintln!(
@@ -1816,7 +1811,28 @@ impl WatchRegistry {
         if failures > 1 {
             eprintln!("[trace] warning: {failures} directories could not be watched");
         }
-        (added, removed)
+        added
+    }
+
+    /// Bring the subscription set in line with `desired`, subscribing to
+    /// directories that are newly relevant and dropping ones that are not.
+    ///
+    /// Returns `(added, removed)`. Only for a set that describes the whole
+    /// tree — anything absent from `desired` is unsubscribed. To subscribe to
+    /// a subtree without disturbing the rest, use [`Self::add_all`].
+    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (usize, usize) {
+        let stale: Vec<PathBuf> = self.watched.difference(desired).cloned().collect();
+        let mut removed = 0;
+        for dir in stale {
+            // Best effort. inotify drops a descriptor by itself when the
+            // directory is deleted, so "not found" is an expected outcome
+            // here, not an error worth reporting.
+            let _ = self.watcher.unwatch(&dir);
+            self.watched.remove(&dir);
+            removed += 1;
+        }
+
+        (self.add_all(desired), removed)
     }
 }
 
@@ -1941,12 +1957,13 @@ fn watch_new_subtree(state: &ServerState, root: &Path, dir: &Path) {
         let Some(registry) = registry.as_mut() else {
             return;
         };
-        // A union, not a replacement: `desired` covers only this subtree, and
-        // `sync` would read anything outside it as newly stale and unsubscribe
-        // from the entire rest of the repository.
-        let union: std::collections::HashSet<PathBuf> =
-            registry.watched.union(&desired).cloned().collect();
-        registry.sync(&union);
+        // Additive, not a sync: `desired` covers only this subtree, and `sync`
+        // would read everything outside it as stale and unsubscribe from the
+        // entire rest of the repository. Doing this without materialising a
+        // union also matters at scale — a monorepo can hold tens of thousands
+        // of watched directories, and copying that set for every newly created
+        // directory would be quadratic over a checkout or a build.
+        registry.add_all(&desired);
     }
 
     for subdir in &desired {
@@ -3985,6 +4002,46 @@ mod tests {
             &no_exclude,
             Some(&gi)
         ));
+    }
+
+    #[test]
+    fn watch_registry_add_all_is_additive_but_sync_prunes() {
+        // These two must not be confused. `watch_new_subtree` learns only
+        // about the subtree that just appeared, so if it went through `sync`
+        // every directory outside that subtree would look stale and the server
+        // would unsubscribe from the entire rest of the repository — turning a
+        // new folder into a silent, total loss of file watching.
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        let c = tmp.path().join("c");
+        for dir in [&a, &b, &c] {
+            std::fs::create_dir(dir).unwrap();
+        }
+
+        let watcher = notify::recommended_watcher(|_: notify::Result<Event>| {}).unwrap();
+        let mut registry = WatchRegistry {
+            watcher,
+            watched: std::collections::HashSet::new(),
+        };
+
+        let added = registry.add_all(&[a.clone(), b.clone()].into_iter().collect());
+        assert_eq!(added, 2);
+
+        // Adding a subtree leaves existing subscriptions untouched, and
+        // re-adding one already present is a no-op rather than a duplicate.
+        let added = registry.add_all(&[b.clone(), c.clone()].into_iter().collect());
+        assert_eq!(added, 1, "b was already watched and must not be re-added");
+        assert_eq!(
+            registry.watched,
+            [a.clone(), b.clone(), c.clone()].into_iter().collect(),
+            "add_all dropped a subscription outside the set it was given"
+        );
+
+        // `sync`, by contrast, is authoritative over the whole tree.
+        let (added, removed) = registry.sync(&[c.clone()].into_iter().collect());
+        assert_eq!((added, removed), (0, 2));
+        assert_eq!(registry.watched, [c].into_iter().collect());
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -756,17 +756,24 @@ fn build_stale_matcher(
 /// Callers on the stale path hold `snapshot_gate` for write, which is what
 /// makes the matcher swap and the index decisions around it atomic from the
 /// watcher's point of view.
+///
+/// Returns the directories that were newly subscribed to as a result. Those
+/// were unwatched while the caller's walk ran, so anything written to them in
+/// that window produced no event and appears in no walk result. Callers pass
+/// the list to [`reindex_files_in`] once `state.file_stamps` describes the
+/// index they just published.
+#[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
     root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
-) {
+) -> Vec<PathBuf> {
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
     // New rules mean a different set of directories worth hearing about:
     // a tightened rule releases the subscriptions under it, and a relaxed
     // one takes subscriptions for the tree it used to hide.
-    sync_watch_registrations(state, root);
+    sync_watch_registrations(state, root)
 }
 
 fn handle_connection(stream: TcpStream, state: &ServerState) -> Result<()> {
@@ -1569,7 +1576,13 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
     if state.gitignore_pending.load(Ordering::SeqCst) {
         eprintln!("[trace] watcher subscriptions deferred until the ignore matcher is ready");
     } else {
-        sync_watch_registrations(&state, root);
+        // The newly watched directories are deliberately not rechecked here.
+        // This is every directory in the repository, the index was built or
+        // opened moments ago, and the stale check that follows startup
+        // reconciles the same drift while holding `snapshot_gate` — which this
+        // path does not hold and must not take, since the watcher has to be
+        // receiving events before that check runs.
+        let _ = sync_watch_registrations(&state, root);
     }
 
     let worker_state = Arc::clone(&state);
@@ -1761,6 +1774,17 @@ fn is_ignore_rules_file(root: &Path, path: &Path) -> bool {
 /// `PollWatcher` are per-path too, but nothing here builds or tests them.
 const PER_DIRECTORY_WATCHES: bool = cfg!(any(target_os = "linux", target_os = "android"));
 
+/// Whether `path` is a directory in its own right rather than a symlink to one.
+///
+/// [`Path::is_dir`] follows links, so it answers "does this lead to a
+/// directory", which is the wrong question here: the walker does not follow
+/// symlinks, so a symlinked directory is not part of the indexed tree. Treating
+/// one as a directory would subscribe to and index its target — possibly a tree
+/// outside `root` entirely, and possibly a cycle.
+fn is_real_dir(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir())
+}
+
 /// The watcher plus the set of directories it is currently subscribed to.
 ///
 /// Only meaningful when [`PER_DIRECTORY_WATCHES`] is true; elsewhere `watched`
@@ -1774,12 +1798,13 @@ impl WatchRegistry {
     /// Subscribe to every directory in `desired` that is not already
     /// subscribed, leaving existing subscriptions alone.
     ///
-    /// Returns the number added. A single directory that cannot be subscribed
-    /// is reported and skipped rather than failing the whole call: the watcher
-    /// is still useful for everything else, and giving up on the entire tree is
-    /// exactly the failure mode this registration exists to avoid.
-    fn add_all(&mut self, desired: &std::collections::HashSet<PathBuf>) -> usize {
-        let mut added = 0;
+    /// Returns the directories that were newly subscribed to. A single
+    /// directory that cannot be subscribed is reported and skipped rather than
+    /// failing the whole call: the watcher is still useful for everything
+    /// else, and giving up on the entire tree is exactly the failure mode this
+    /// registration exists to avoid.
+    fn add_all<'a>(&mut self, desired: impl IntoIterator<Item = &'a PathBuf>) -> Vec<PathBuf> {
+        let mut added = Vec::new();
         let mut failures = 0;
         // Iterating `desired` and testing membership is deliberate: a
         // `difference` would be proportional to the whole watched set, and
@@ -1792,7 +1817,7 @@ impl WatchRegistry {
             match self.watcher.watch(dir, RecursiveMode::NonRecursive) {
                 Ok(()) => {
                     self.watched.insert(dir.clone());
-                    added += 1;
+                    added.push(dir.clone());
                 }
                 Err(e) => {
                     // One line per call, not per directory: exhausting the
@@ -1820,7 +1845,7 @@ impl WatchRegistry {
     /// Returns `(added, removed)`. Only for a set that describes the whole
     /// tree — anything absent from `desired` is unsubscribed. To subscribe to
     /// a subtree without disturbing the rest, use [`Self::add_all`].
-    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (usize, usize) {
+    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (Vec<PathBuf>, usize) {
         let stale: Vec<PathBuf> = self.watched.difference(desired).cloned().collect();
         let mut removed = 0;
         for dir in stale {
@@ -1896,15 +1921,21 @@ fn watchable_dirs(
 /// Called when the watcher starts and every time the ignore matcher is
 /// published, so relaxing a rule subscribes to the tree it used to hide and
 /// tightening one drops it.
-fn sync_watch_registrations(state: &ServerState, root: &Path) {
+///
+/// Returns the directories that were newly subscribed to. Until a directory is
+/// subscribed it cannot report anything, so a file written to one of these
+/// between the caller's walk and this call is in neither the walk's results nor
+/// any event. The caller is expected to hand the list to
+/// [`reindex_files_in`] once its own bookkeeping is settled.
+fn sync_watch_registrations(state: &ServerState, root: &Path) -> Vec<PathBuf> {
     if !PER_DIRECTORY_WATCHES {
-        return;
+        return Vec::new();
     }
     let mut registry = state.watch_registry.lock().unwrap();
     let Some(registry) = registry.as_mut() else {
         // The watcher has not started yet. It syncs once as it comes up, so
         // there is nothing to do and nothing to remember.
-        return;
+        return Vec::new();
     };
 
     let start = Instant::now();
@@ -1914,60 +1945,34 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) {
     };
     let total = desired.len();
     let (added, removed) = registry.sync(&desired);
-    if added > 0 || removed > 0 {
+    if !added.is_empty() || removed > 0 {
         eprintln!(
             "[trace] watcher subscriptions: {total} directories \
-             (+{added}, -{removed}) in {:.1}ms",
+             (+{}, -{removed}) in {:.1}ms",
+            added.len(),
             start.elapsed().as_secs_f64() * 1000.0
         );
     }
+    added
 }
 
-/// Subscribe to a directory that has just appeared, and to anything already
-/// inside it.
+/// Re-check the files directly inside `dirs`, indexing the ones that changed.
 ///
-/// Non-recursive subscriptions are not extended by notify — it only auto-adds
-/// watches beneath a watch that was registered as recursive — so a new
-/// directory has to be picked up here or its contents are invisible.
+/// Used to close the gap between a walk and the subscriptions that follow it:
+/// [`reindex_file`] compares stamps first, so for a tree that did not change
+/// under us this costs one `metadata` call per file and indexes nothing.
 ///
-/// Files that landed between the directory's creation and its subscription
-/// would be missed by definition, so the same pass indexes what it finds.
-/// The caller must already hold `snapshot_gate`.
-fn watch_new_subtree(state: &ServerState, root: &Path, dir: &Path) {
-    let Ok(rel_dir) = dir.strip_prefix(root) else {
+/// Callers must already hold `snapshot_gate`, and `state.file_stamps` must
+/// already describe the index as published — a merge that replaces the stamps
+/// afterwards would both discard what this records and make every file here
+/// look changed.
+fn reindex_files_in(state: &ServerState, root: &Path, dirs: &[PathBuf]) {
+    if dirs.is_empty() {
         return;
-    };
-    let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
-
-    let desired = {
-        let gitignore = state.gitignore.read().unwrap();
-        // The event that brought us here was filtered with file semantics, so
-        // a `build/`-style rule that only ever matches directories has not
-        // been applied to this path yet. Re-check before subscribing to it.
-        if !rel_dir.is_empty()
-            && should_skip_watcher_dir(&rel_dir, &state.exclude_dirs, gitignore.as_ref())
-        {
-            return;
-        }
-        watchable_dirs(root, dir, &state.exclude_dirs, gitignore.as_ref())
-    };
-
-    {
-        let mut registry = state.watch_registry.lock().unwrap();
-        let Some(registry) = registry.as_mut() else {
-            return;
-        };
-        // Additive, not a sync: `desired` covers only this subtree, and `sync`
-        // would read everything outside it as stale and unsubscribe from the
-        // entire rest of the repository. Doing this without materialising a
-        // union also matters at scale — a monorepo can hold tens of thousands
-        // of watched directories, and copying that set for every newly created
-        // directory would be quadratic over a checkout or a build.
-        registry.add_all(&desired);
     }
-
-    for subdir in &desired {
-        let Ok(entries) = std::fs::read_dir(subdir) else {
+    let start = Instant::now();
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
             continue;
         };
         for entry in entries.flatten() {
@@ -1987,6 +1992,136 @@ fn watch_new_subtree(state: &ServerState, root: &Path, dir: &Path) {
                 reindex_file(state, &path, &rel);
             }
         }
+    }
+    eprintln!(
+        "[trace] watcher: rechecked {} newly watched directories in {:.1}ms",
+        dirs.len(),
+        start.elapsed().as_secs_f64() * 1000.0
+    );
+}
+
+/// Subscribe to a directory that has just appeared, and to anything already
+/// inside it.
+///
+/// Non-recursive subscriptions are not extended by notify — it only auto-adds
+/// watches beneath a watch that was registered as recursive — so a new
+/// directory has to be picked up here or its contents are invisible.
+///
+/// Files that landed between the directory's creation and its subscription
+/// would be missed by definition, so the same pass indexes what it finds.
+/// The caller must already hold `snapshot_gate`.
+///
+/// The descent subscribes to each level *before* reading it. Reading first
+/// leaves a window in which a child created in between is in neither place:
+/// not in what this pass enumerates, and not yet able to report itself. That
+/// window is small but it is exactly the one a checkout or a build fills, and
+/// anything lost in it stays invisible until the hourly reconcile.
+fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
+    // `is_dir` follows symlinks; the walker does not. Refuse a symlinked
+    // directory here so we never subscribe to, or index, a tree the indexer
+    // would not have walked into.
+    if !is_real_dir(dir) {
+        return;
+    }
+    let Ok(rel_dir) = dir.strip_prefix(root) else {
+        return;
+    };
+    let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+    // The event that brought us here was filtered with file semantics, so a
+    // `build/`-style rule that only ever matches directories has not been
+    // applied to this path yet. Re-check before subscribing to it.
+    if !rel_dir.is_empty() {
+        let gitignore = state.gitignore.read().unwrap();
+        if should_skip_watcher_dir(&rel_dir, &state.exclude_dirs, gitignore.as_ref()) {
+            return;
+        }
+    }
+
+    let mut level = vec![dir.to_path_buf()];
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    let mut files: Vec<(PathBuf, String)> = Vec::new();
+    let mut found_ignore_rules = false;
+
+    while !level.is_empty() {
+        {
+            let mut registry = state.watch_registry.lock().unwrap();
+            let Some(registry) = registry.as_mut() else {
+                return;
+            };
+            // Additive, not a sync: this covers only the new subtree, and
+            // `sync` would read everything outside it as stale and unsubscribe
+            // from the entire rest of the repository. Staying additive also
+            // matters at scale — a monorepo can hold tens of thousands of
+            // watched directories, and materialising a union for every newly
+            // created directory would be quadratic over a checkout.
+            registry.add_all(level.iter());
+        }
+
+        // The registry lock is released before any `read_dir`, so a large
+        // subtree does not hold it across the I/O for a whole level.
+        let mut next = Vec::new();
+        for subdir in level.drain(..) {
+            if !seen.insert(subdir.clone()) {
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&subdir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                let path = entry.path();
+                let Ok(rel) = path.strip_prefix(root) else {
+                    continue;
+                };
+                let rel = rel.to_string_lossy().replace('\\', "/");
+                // `DirEntry::file_type` does not follow symlinks, so a
+                // symlinked directory is neither descended into nor indexed.
+                if file_type.is_dir() {
+                    let skip = {
+                        let gitignore = state.gitignore.read().unwrap();
+                        should_skip_watcher_dir(&rel, &state.exclude_dirs, gitignore.as_ref())
+                    };
+                    if !skip {
+                        next.push(path);
+                    }
+                } else if file_type.is_file() {
+                    // A subtree that arrives whole — a clone, a `mv`, a branch
+                    // switch — can carry its own ignore rules. Those files are
+                    // dot-prefixed, so the scan below would silently drop them
+                    // and index the rest of the subtree against rules that do
+                    // not know about them.
+                    if !state.no_ignore && is_ignore_rules_file(root, &path) {
+                        found_ignore_rules = true;
+                        continue;
+                    }
+                    let skip = {
+                        let gitignore = state.gitignore.read().unwrap();
+                        should_skip_watcher_path(&rel, &state.exclude_dirs, gitignore.as_ref())
+                    };
+                    if !skip {
+                        files.push((path, rel));
+                    }
+                }
+            }
+        }
+        level = next;
+    }
+
+    if found_ignore_rules {
+        // Indexing now would apply the wrong rules to the whole subtree, and
+        // anything wrongly indexed would stay until something touched it
+        // again. The refresh rewalks and republishes, which covers these files
+        // correctly; it runs on its own thread and takes `snapshot_gate`
+        // there, so scheduling it while we hold the gate is safe.
+        state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+        schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+        return;
+    }
+
+    for (path, rel) in &files {
+        reindex_file(state, path, rel);
     }
 }
 
@@ -2122,7 +2257,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         }
 
         if !path.is_file() {
-            if PER_DIRECTORY_WATCHES && path.is_dir() {
+            // `is_real_dir` rather than `is_dir`: the latter follows symlinks,
+            // and a link to a directory is not something the walker descends
+            // into, so subscribing to and indexing its target would pull in a
+            // tree the index never contained — possibly outside `root`.
+            if PER_DIRECTORY_WATCHES && is_real_dir(path) {
                 // With non-recursive subscriptions notify will not extend the
                 // watch set for us, so a directory that just appeared — and
                 // anything already inside it — has to be picked up here.
@@ -2655,19 +2794,57 @@ fn stamps_for_indexed(
         .collect()
 }
 
+/// Rebuild the ignore matcher and reconcile the index against the filesystem.
+///
+/// Returns whether the index can be trusted afterwards. A `false` means the
+/// walk or the merge failed and the stamps are not describing the index.
 fn background_refresh_stale(
     state: &Arc<ServerState>,
     root: &Path,
     index_dir: &Path,
     compare_index_membership: bool,
 ) -> bool {
+    let _refresh = state.stale_refresh_lock.lock().unwrap();
+    // Keep watcher/auto-save mutations out for the complete walk → matcher →
+    // merge → recovery cycle. Search queries do not take this gate and remain
+    // available. Held here rather than inside so the recovery scan below is
+    // still covered by it.
+    let _gate = state.snapshot_gate.write().unwrap();
+
+    let mut newly_watched = Vec::new();
+    let ok = refresh_stale_locked(
+        state,
+        root,
+        index_dir,
+        compare_index_membership,
+        &mut newly_watched,
+    );
+
+    // Directories that were not subscribed while the walk ran could not report
+    // a write, and the walk may have passed them before it happened, so a file
+    // created in that window is in neither place. Recheck them now that the
+    // subscriptions exist.
+    //
+    // Only on success, and only here at the end: a failed walk or merge leaves
+    // `file_stamps` describing something other than the published index, and
+    // `stream_merge_stale_changes` replaces the stamps wholesale, so scanning
+    // any earlier would both be discarded and re-read every changed file.
+    if ok {
+        reindex_files_in(state, root, &newly_watched);
+    }
+    ok
+}
+
+fn refresh_stale_locked(
+    state: &Arc<ServerState>,
+    root: &Path,
+    index_dir: &Path,
+    compare_index_membership: bool,
+    newly_watched: &mut Vec<PathBuf>,
+) -> bool {
     use tgrep_core::meta;
     use tgrep_core::walker;
 
-    let _refresh = state.stale_refresh_lock.lock().unwrap();
-    // Keep watcher/auto-save mutations out for the complete walk → matcher →
-    // merge cycle. Search queries do not take this gate and remain available.
-    let _gate = state.snapshot_gate.write().unwrap();
     let start = Instant::now();
     eprintln!("[trace] stale check: comparing index against filesystem...");
 
@@ -2695,10 +2872,10 @@ fn background_refresh_stale(
     // with a delete, would be enough.
     //
     // Committing here rather than at each exit is invisible to the watcher:
-    // this function holds `snapshot_gate` for write across its whole body, and
+    // the caller holds `snapshot_gate` for write across this whole body, and
     // the only reader of `state.gitignore` takes the read side first, so no
     // event can observe the matcher before this function returns either way.
-    publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
+    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -2936,7 +3113,13 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             state.no_require_git,
         );
         let found = matcher.is_some();
-        publish_ignore_matcher(state, root, matcher);
+        // These subscriptions are the repository's first, so "newly watched"
+        // is every directory in it. No recovery scan: the startup stale check
+        // runs right after this and does a full walk-versus-index diff, which
+        // is a strict superset of what a recovery scan would find — and doing
+        // it here would stat the entire tree while holding the gate, on the
+        // path a warm start exists to keep fast.
+        let _ = publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -3029,7 +3212,11 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             state.no_require_git,
         );
         let has_matcher = matcher.is_some();
-        publish_ignore_matcher(state, root, matcher);
+        // Same reasoning as the bootstrap publish: this is the cold-start
+        // build, so "newly watched" is the whole tree, `indexing` keeps the
+        // watcher off the index for the rest of the build, and the stale check
+        // that follows reconciles anything written during it.
+        let _ = publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -4025,13 +4212,17 @@ mod tests {
             watched: std::collections::HashSet::new(),
         };
 
-        let added = registry.add_all(&[a.clone(), b.clone()].into_iter().collect());
-        assert_eq!(added, 2);
+        let added = registry.add_all(&[a.clone(), b.clone()]);
+        assert_eq!(added.len(), 2);
 
         // Adding a subtree leaves existing subscriptions untouched, and
         // re-adding one already present is a no-op rather than a duplicate.
-        let added = registry.add_all(&[b.clone(), c.clone()].into_iter().collect());
-        assert_eq!(added, 1, "b was already watched and must not be re-added");
+        let added = registry.add_all(&[b.clone(), c.clone()]);
+        assert_eq!(
+            added,
+            vec![c.clone()],
+            "b was already watched and must not be re-added"
+        );
         assert_eq!(
             registry.watched,
             [a.clone(), b.clone(), c.clone()].into_iter().collect(),
@@ -4040,8 +4231,33 @@ mod tests {
 
         // `sync`, by contrast, is authoritative over the whole tree.
         let (added, removed) = registry.sync(&[c.clone()].into_iter().collect());
-        assert_eq!((added, removed), (0, 2));
+        assert_eq!((added.len(), removed), (0, 2));
         assert_eq!(registry.watched, [c].into_iter().collect());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn is_real_dir_rejects_a_symlink_to_a_directory() {
+        // `Path::is_dir` follows links, so it would report a symlinked
+        // directory as a directory and the watcher would subscribe to and
+        // index the link's target — a tree the walker never descends into, and
+        // one that can sit entirely outside the repository root.
+        let tmp = TempDir::new().unwrap();
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert!(is_real_dir(&real));
+        assert!(
+            link.is_dir(),
+            "precondition: is_dir follows the link, which is the trap"
+        );
+        assert!(!is_real_dir(&link));
+        assert!(!is_real_dir(&tmp.path().join("missing")));
+        let file = tmp.path().join("file.txt");
+        std::fs::write(&file, "x").unwrap();
+        assert!(!is_real_dir(&file));
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1656,9 +1656,24 @@ fn should_skip_watcher_path(
     false
 }
 
+/// Whether a changed path is an ignore-rules source, i.e. one whose contents
+/// feed the matcher published in `ServerState::gitignore`.
+///
+/// `.gitignore` and `.ignore` are matched by file name at any depth, because
+/// [`tgrep_core::gitignore::matcher_from_ignore_paths`] anchors nested files of
+/// both kinds. `.ignore` must be included even though it is git-agnostic —
+/// leaving it out meant a `.ignore` written while the server was live never
+/// refreshed the matcher, so the watcher kept indexing files the rule excluded.
+///
+/// `p4ignore.ini` stays root-scoped, mirroring the walker, which only reads the
+/// root-level file.
 fn is_ignore_rules_file(root: &Path, path: &Path) -> bool {
-    path.file_name().and_then(|name| name.to_str()) == Some(".gitignore")
-        || path == root.join(tgrep_core::gitignore::P4IGNORE_FILENAME)
+    let name = path.file_name().and_then(|name| name.to_str());
+    matches!(
+        name,
+        Some(tgrep_core::gitignore::GITIGNORE_FILENAME)
+            | Some(tgrep_core::gitignore::DOT_IGNORE_FILENAME)
+    ) || path == root.join(tgrep_core::gitignore::P4IGNORE_FILENAME)
 }
 
 fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
@@ -3671,6 +3686,14 @@ mod tests {
         assert!(is_ignore_rules_file(
             root,
             Path::new("workspace/p4ignore.ini")
+        ));
+        // `.ignore` is a first-class ignore source (and, unlike `.gitignore`,
+        // applies outside a git repo), so live edits to it must refresh the
+        // matcher too — at the root and nested.
+        assert!(is_ignore_rules_file(root, Path::new("workspace/.ignore")));
+        assert!(is_ignore_rules_file(
+            root,
+            Path::new("workspace/nested/.ignore")
         ));
         assert!(!is_ignore_rules_file(
             root,

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -290,6 +290,23 @@ struct ServerState {
     ignore_rules_dirty: std::sync::atomic::AtomicBool,
     /// Ensures a burst of ignore-file events uses at most one refresh worker.
     ignore_refresh_scheduled: std::sync::atomic::AtomicBool,
+    /// Paths the watcher saw while `indexing` was set, kept so they can be
+    /// replayed once the build publishes.
+    ///
+    /// Events that arrive during a build cannot be applied — the stamps do not
+    /// describe the index yet, so every path would read as changed — but they
+    /// are the only record that those paths moved. The build's own walk misses
+    /// anything written to a directory it has already passed, and on a
+    /// whole-subtree backend there is no per-directory recovery scan to fall
+    /// back on, so discarding them leaves the change invisible until the hourly
+    /// reconcile.
+    ///
+    /// `None` means the buffer overflowed and the paths were dropped; the
+    /// replay then falls back to a full stale refresh, which is slower but
+    /// complete. Bounded because a build can run for minutes on a large
+    /// repository and a checkout or a build tree churning underneath it is
+    /// unbounded.
+    deferred_events: Mutex<Option<std::collections::HashSet<PathBuf>>>,
     /// Progress: number of files indexed so far.
     index_progress: std::sync::atomic::AtomicU64,
     /// Total files discovered for indexing.
@@ -573,6 +590,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         gitignore_pending: std::sync::atomic::AtomicBool::new(!no_watch && !no_ignore),
         ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
         ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+        deferred_events: Mutex::new(Some(std::collections::HashSet::new())),
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
         watch_enabled: !no_watch,
@@ -757,24 +775,29 @@ fn build_stale_matcher(
 /// makes the matcher swap and the index decisions around it atomic from the
 /// watcher's point of view.
 ///
-/// Returns the directories that were newly subscribed to as a result, and the
-/// moment the walk behind that decision began. Those were unwatched while the
-/// caller's walk ran, so anything written to them in that window produced no
-/// event and appears in no walk result. Callers pass both to
-/// [`reindex_files_in`] once `state.file_stamps` describes the index they just
-/// published.
+/// Returns the directories that were newly subscribed to as a result. Those
+/// were unwatched while the caller's walk ran, so anything written to them in
+/// that window produced no event and appears in no walk result. Callers pass
+/// them to [`reindex_files_in`] once `state.file_stamps` describes the index
+/// they just published.
+///
+/// `since` is when the walk that produced `matcher` began, and is only passed
+/// through so the recovery scan can use it. It has to come from the caller: the
+/// subscription walk inside this function starts later, and an ignore file
+/// written between the two would predate a timestamp taken here and be read as
+/// already accounted for by rules that never saw it.
 #[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
     root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
-) -> (Vec<PathBuf>, SystemTime) {
+) -> Vec<PathBuf> {
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
     // New rules mean a different set of directories worth hearing about:
     // a tightened rule releases the subscriptions under it, and a relaxed
     // one takes subscriptions for the tree it used to hide.
-    sync_watch_registrations(state, root)
+    sync_watch_registrations(state, root).0
 }
 
 fn handle_connection(stream: TcpStream, state: &ServerState) -> Result<()> {
@@ -2424,6 +2447,103 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 
 /// Recheck newly watched directories on a background thread.
 ///
+/// Remember the paths in an event that arrived mid-build, for replay once the
+/// build publishes.
+///
+/// The event cannot be applied now: until `indexing` clears, `file_stamps` does
+/// not describe the index, so every path would compare as changed and the
+/// watcher would re-read the repository alongside the build already reading it.
+/// It cannot simply be dropped either — see [`ServerState::deferred_events`].
+///
+/// Capped, and the cap discards the whole set rather than truncating it: a
+/// partial set is indistinguishable from a complete one at replay time, and
+/// silently recovering nine tenths of a checkout is worse than knowing to fall
+/// back on a full refresh.
+fn defer_events_during_build(state: &ServerState, event: &Event) {
+    /// A checkout of the Linux kernel is ~90k files. Above this the fallback
+    /// refresh is cheaper than the replay would be anyway.
+    const MAX_DEFERRED: usize = 100_000;
+
+    let Ok(mut deferred) = state.deferred_events.lock() else {
+        return;
+    };
+    let Some(paths) = deferred.as_mut() else {
+        return;
+    };
+    if paths.len().saturating_add(event.paths.len()) > MAX_DEFERRED {
+        *deferred = None;
+        eprintln!(
+            "[trace] warning: too many file changes during the initial index build to replay \
+             individually; a full reconcile will run instead"
+        );
+        return;
+    }
+    paths.extend(event.paths.iter().cloned());
+}
+
+/// Apply the events that arrived during the build, now that it has published.
+///
+/// Replayed as synthetic create events rather than handled directly so they go
+/// through exactly the filtering an ordinary event gets — ignore rules, the
+/// exclude list, the index directory, new-subtree subscription. `Create(Any)`
+/// is the right kind for all of them: `handle_fs_event` decides removal from
+/// whether the path still exists, and modifications and creations take the same
+/// route, so one kind covers arrivals, edits and deletions alike.
+///
+/// The caller must *not* hold `snapshot_gate`; `handle_fs_event` takes it.
+fn replay_deferred_events(state: &Arc<ServerState>, root: &Path) {
+    let deferred = match state.deferred_events.lock() {
+        // Leaves `Some(empty)` behind, so anything deferred by a later build
+        // (a reconcile sets `indexing` again) is collected from scratch.
+        Ok(mut guard) => guard.replace(std::collections::HashSet::new()),
+        Err(_) => return,
+    };
+    let Some(paths) = deferred else {
+        // Overflowed. A stale refresh rewalks the tree and diffs it against the
+        // index, which covers every path the replay would have, and it is what
+        // already runs when ignore rules change mid-build.
+        eprintln!("[trace] watcher: reconciling after too many changes during the initial build");
+        let state = Arc::clone(state);
+        let root = root.to_path_buf();
+        if thread::Builder::new()
+            .name("tgrep-deferred-reconcile".into())
+            .spawn(move || {
+                if !background_refresh_stale(&state, &root, &state.index_dir, true) {
+                    eprintln!(
+                        "[trace] warning: the post-build reconcile did not complete; changes made \
+                         during the build wait for the next one"
+                    );
+                }
+            })
+            .is_err()
+        {
+            eprintln!("[trace] warning: could not start the post-build reconcile");
+        }
+        return;
+    };
+    if paths.is_empty() {
+        return;
+    }
+
+    let start = Instant::now();
+    let count = paths.len();
+    for path in paths {
+        handle_fs_event(
+            state,
+            root,
+            &Event {
+                kind: EventKind::Create(notify::event::CreateKind::Any),
+                paths: vec![path],
+                attrs: Default::default(),
+            },
+        );
+    }
+    eprintln!(
+        "[trace] watcher: replayed {count} change(s) deferred during the initial build in {:.1}ms",
+        start.elapsed().as_secs_f64() * 1000.0
+    );
+}
+
 /// For the publish sites that cannot scan inline. Until a directory is
 /// subscribed it cannot report a write, and the walk that decided to subscribe
 /// to it may have passed it before that write happened, so a file landing in
@@ -2436,16 +2556,16 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 ///
 /// Waits out `indexing` first. During a build the stamps do not describe the
 /// index yet, so every file would look changed and the scan would re-read the
-/// whole repository alongside the build that is already doing it.
+/// whole repository alongside the build that is already doing it. That wait is
+/// also what makes this the right place to replay the events the build made the
+/// watcher discard, which is why it runs even on a backend that has nothing
+/// per-directory to recover.
 fn spawn_recovery_scan(
     state: &Arc<ServerState>,
     root: &Path,
     dirs: Vec<PathBuf>,
     since: SystemTime,
 ) {
-    if dirs.is_empty() || !PER_DIRECTORY_WATCHES {
-        return;
-    }
     let state = Arc::clone(state);
     let root = root.to_path_buf();
     let spawned = thread::Builder::new()
@@ -2453,6 +2573,15 @@ fn spawn_recovery_scan(
         .spawn(move || {
             while state.indexing.load(Ordering::SeqCst) {
                 thread::sleep(Duration::from_millis(200));
+            }
+            // Before the gate, not under it: this takes `snapshot_gate` for
+            // read itself, and std's `RwLock` may deadlock on a recursive read
+            // if a writer queues up in between.
+            replay_deferred_events(&state, &root);
+
+            let dirs = recovery_scan_dirs(&state, &root, dirs);
+            if dirs.is_empty() {
+                return;
             }
             // Read, not write: this does exactly what `handle_fs_event` does,
             // and that runs under the read side. Taking it at all is what
@@ -2468,6 +2597,30 @@ fn spawn_recovery_scan(
              wait for the next reconcile"
         );
     }
+}
+
+/// The directories a recovery scan should recheck, given the ones a
+/// subscription sync reported as newly watched.
+///
+/// The root is added because it is never in that list: it is subscribed as the
+/// watcher starts, before any matcher exists, so every later sync sees it as
+/// already watched. Nothing else covers it — a file written to the top level
+/// while a build walk was deeper in the tree produced no event the build could
+/// use and no event the watcher would keep — and it costs one directory
+/// listing.
+///
+/// Empty on a whole-subtree backend, where there are no per-directory
+/// subscriptions to have raced and `reindex_files_in`'s pickup of unwatched
+/// subdirectories would take exactly the per-directory watches that backend
+/// exists to avoid.
+fn recovery_scan_dirs(state: &ServerState, root: &Path, mut dirs: Vec<PathBuf>) -> Vec<PathBuf> {
+    if !PER_DIRECTORY_WATCHES || !state.watch_enabled {
+        return Vec::new();
+    }
+    if !dirs.iter().any(|d| d == root) {
+        dirs.push(root.to_path_buf());
+    }
+    dirs
 }
 
 fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
@@ -2494,8 +2647,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     }
 
     // Skip ordinary file events while the initial background index build is in
-    // progress. The indexer will pick up those files itself.
+    // progress. The indexer will pick up those files itself — but only for the
+    // parts of the tree it has not reached yet, so remember these and replay
+    // them once it publishes.
     if state.indexing.load(Ordering::SeqCst) {
+        defer_events_during_build(state, event);
         return;
     }
 
@@ -2610,26 +2766,110 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     }
 }
 
+/// Drop everything the index holds for a path.
+///
+/// The delete is not conditional on a stamp entry. `ServerState` accepts an
+/// empty stamp map when `filestamps.json` is missing or unreadable, and the
+/// reader can still hold the path in that state, so keying the delete on the
+/// stamp alone would leave content the walk now rejects searchable. The stamp
+/// removal is best-effort; the index and cache deletes always happen.
+///
+/// The cost of that is a tombstone in the overlay for paths that were never
+/// indexed — `live::delete_file` records one either way — and this runs for
+/// every ineligible file a recovery scan walks past, which at startup is every
+/// binary asset in the repository. An existing tombstone is therefore taken as
+/// proof there is nothing left to do, which bounds that to one per distinct
+/// path. The trace line, which is the part that would be actively misleading,
+/// stays conditional on there having been something to drop.
+///
+/// The caller must already hold `snapshot_gate`.
+fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
+    let had_stamp = state
+        .file_stamps
+        .write()
+        .unwrap()
+        .remove(rel_path)
+        .is_some();
+    {
+        let index = state.index.read().unwrap();
+        if index.live.has_path(rel_path) || had_stamp {
+            eprintln!("[trace] reindex: dropped {rel_path} ({reason})");
+        } else if index.live.is_deleted(rel_path) {
+            // Already tombstoned, so there is nothing to record and no reason
+            // to dirty the overlay again. This is the repeat case: a recovery
+            // scan or a chatty editor can bring the same rejected path back
+            // here any number of times.
+            return;
+        }
+    }
+    state.index.write().unwrap().live.delete_file(rel_path);
+    if let Ok(mut cache) = state.cache.write() {
+        cache.pop(rel_path);
+    }
+}
+
+/// Open a file without following a final symlink, so the handle is the path
+/// itself rather than wherever it points.
+///
+/// Every later question — is this a regular file, how big is it, what is in it
+/// — is then answered from the one handle, which is what makes the eligibility
+/// decision and the read describe the same object. Checking the path and then
+/// reading it separately leaves a window in which a tree being rewritten under
+/// us (a checkout, a build, `git mv`) can swap a regular file for a link, and
+/// the read would follow it out of the served root.
+fn open_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // Fails outright on a symlink, which is the answer we want.
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // Opens the reparse point rather than its target. Unlike O_NOFOLLOW
+        // this succeeds, so the caller's `is_file` check on the handle's
+        // metadata is what rejects it — a reparse point is not a regular file.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        std::fs::File::open(path)
+    }
+}
+
 /// Read a file and merge it into the live index, unless its stamp says the
 /// content we already indexed is current.
 ///
 /// The caller must hold `snapshot_gate`: the read, the commit, and the stamp
 /// update have to be atomic with respect to a flush or auto-save.
 fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
+    use std::io::Read;
     use tgrep_core::meta::FileStamp;
 
-    // Compute the file's current stamp and skip if it matches what we
-    // last indexed. notify on Windows in particular fires Modify events
-    // for atime/attribute updates, opens, etc. — re-indexing on those
-    // would re-read large files, churn the live overlay, and produce a
-    // misleading "modified" trace for files that didn't actually change.
-    //
-    // `symlink_metadata` describes the link itself; `metadata` would describe
-    // its target. See the eligibility check below for why that distinction
-    // matters here.
-    let meta = match std::fs::symlink_metadata(path) {
-        Ok(m) => m,
-        Err(_) => return,
+    // One handle for the whole decision. Opened without following a final
+    // symlink, and every fact below — type, size, mtime, bytes — read back off
+    // it, so nothing that happens to the path in the meantime can make the
+    // content we index disagree with the metadata we judged it by.
+    let file = match open_no_follow(path) {
+        Ok(f) => f,
+        Err(_) => {
+            // Includes the ELOOP that a symlink gets on unix. It may still be
+            // a path we indexed before it became one, so fall through to the
+            // drop rather than returning.
+            drop_indexed_file(state, rel_path, "no longer eligible");
+            return;
+        }
+    };
+    let Ok(meta) = file.metadata() else {
+        return;
     };
     let current = FileStamp {
         mtime: meta
@@ -2648,13 +2888,14 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // — would be read whole and indexed, and the next reconcile would silently
     // delete it again.
     //
-    // `is_file` on the link's own metadata is the third rule, and the one with
-    // teeth: the walker runs with `follow_links(false)`, where a symlink is
-    // neither file nor dir and is skipped outright. Following one here would
-    // read the target and index its bytes under the link's path — and the
-    // target need not be under `root` at all, so a link committed to a branch
-    // (or dropped in by a build) is enough to pull `~/.ssh/id_rsa` into an
-    // index whose whole contract is that it covers the served tree.
+    // `is_file` is the third rule, and the one with teeth: the walker runs with
+    // `follow_links(false)`, where a symlink is neither file nor dir and is
+    // skipped outright. Indexing through one would put the target's bytes under
+    // the link's path — and the target need not be under `root` at all, so a
+    // link committed to a branch (or dropped in by a build) is enough to pull
+    // `~/.ssh/id_rsa` into an index whose whole contract is that it covers the
+    // served tree. On unix the open above has already failed for a link; this
+    // is what rejects one on Windows, where the reparse point opens fine.
     let eligible = meta.is_file()
         && !tgrep_core::walker::is_binary_extension(path)
         && !state
@@ -2665,36 +2906,7 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
         // past the cap, and a real file can be replaced by a link to one. Drop
         // what we hold so the index matches the walk rather than keeping a
         // stale copy of the smaller version until the reconcile.
-        //
-        // The stamp is not the only evidence that something is indexed. A file
-        // the watcher added since the last flush lives in the live overlay,
-        // and a stamp map that was replaced wholesale — by a stale merge, or
-        // by a load that failed and left it empty — no longer mentions it, so
-        // testing the stamp alone would skip the drop and keep serving content
-        // the walk rejects. `has_path` covers the overlay; an entry that is
-        // only in the persisted reader with no stamp to match is beyond what
-        // can be checked cheaply here (the reader has no path index) and is
-        // left to the reconcile's membership diff.
-        //
-        // Both are checked before deleting rather than deleting unconditionally
-        // the way the removal branch does: removals are rare, but this runs for
-        // every ineligible file a recovery scan walks past, and `delete_file`
-        // records a tombstone and dirties the overlay even when the path was
-        // never indexed.
-        let had_stamp = state
-            .file_stamps
-            .write()
-            .unwrap()
-            .remove(rel_path)
-            .is_some();
-        let in_overlay = state.index.read().unwrap().live.has_path(rel_path);
-        if had_stamp || in_overlay {
-            eprintln!("[trace] reindex: dropped {rel_path} (no longer eligible)");
-            state.index.write().unwrap().live.delete_file(rel_path);
-            if let Ok(mut cache) = state.cache.write() {
-                cache.pop(rel_path);
-            }
-        }
+        drop_indexed_file(state, rel_path, "no longer eligible");
         return;
     }
 
@@ -2707,10 +2919,14 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // on our file I/O and trigram parsing. Windows' SRWLock is
     // writer-preferring: a single waiting writer here would otherwise
     // stall every subsequent search request.
-    let data = match std::fs::read(path) {
-        Ok(d) => d,
-        Err(_) => return,
-    };
+    //
+    // From the handle, not the path: re-opening here is what would let a
+    // symlink take the place of the file we just approved.
+    let mut file = file;
+    let mut data = Vec::with_capacity(current.size.min(1 << 20) as usize);
+    if file.read_to_end(&mut data).is_err() {
+        return;
+    }
     let text = tgrep_core::encoding::decode_for_index(&data);
     let is_binary = tgrep_core::trigram::is_binary(&text);
     let per_tri = if is_binary {
@@ -3278,10 +3494,9 @@ fn refresh_stale_locked(
     // the caller holds `snapshot_gate` for write across this whole body, and
     // the only reader of `state.gitignore` takes the read side first, so no
     // event can observe the matcher before this function returns either way.
-    // The caller anchored the recovery window at its own walk, which starts
-    // earlier than the subscription sync inside this call, so the timestamp
-    // that comes back here is the looser of the two and is dropped.
-    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk)).0;
+    // The caller's walk started before this publish; its timestamp is what the
+    // recovery scan needs, so the one the subscription sync derives is dropped.
+    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -3435,6 +3650,13 @@ fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
 /// caller to fall back.
 fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path) -> bool {
     let start = Instant::now();
+    // Anchors the recovery window at the start of the build's traversal, which
+    // is the point from which writes could be missed: nothing under `root` is
+    // subscribed yet, and the walk below has not reached most of it. Taking it
+    // after the build — or letting the later subscription sync derive its own —
+    // would exclude everything written while the build ran, which is precisely
+    // the window that needs recovering.
+    let since = SystemTime::now();
     eprintln!("[trace] bootstrapping index with the external merge sort (memory-bounded)...");
 
     // Dropped once the build is done so the sampled peak (on platforms without
@@ -3510,6 +3732,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
              the watcher may reindex on spurious events"
         ),
     }
+    let mut newly_watched = Vec::new();
     if state.watch_enabled && !state.no_ignore {
         let t_gi = Instant::now();
         let matcher = tgrep_core::walker::build_gitignore_matcher_from_files(
@@ -3524,14 +3747,19 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         // than skipped: the scan waits out `indexing` and then costs one
         // `metadata` call per file, since the stamps this build just wrote
         // describe the index exactly.
-        let (newly_watched, since) = publish_ignore_matcher(state, root, matcher);
-        spawn_recovery_scan(state, root, newly_watched, since);
+        newly_watched = publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
             t_gi.elapsed().as_secs_f64() * 1000.0,
             if found { "" } else { " (no rules found)" }
         );
+    }
+    // Outside that block, because it also drains the events the watcher had to
+    // discard while this build ran, and those pile up whether or not there are
+    // ignore rules to publish.
+    if state.watch_enabled {
+        spawn_recovery_scan(state, root, newly_watched, since);
     }
 
     state.indexing.store(false, Ordering::SeqCst);
@@ -3596,6 +3824,11 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
 
     // Phase 1: Walk file paths (no content reads)
     let t_walk = Instant::now();
+    // The recovery window opens with this traversal, not with the subscriptions
+    // it later feeds: a nested `.ignore` written after the walk read its parent
+    // directory but before the matcher is published is invisible to both, and a
+    // timestamp taken any later would date it as already accounted for.
+    let since = SystemTime::now();
     let walk = walker::walk_dir(
         root,
         &WalkOptions {
@@ -3609,6 +3842,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         },
     );
 
+    let mut newly_watched = Vec::new();
     if state.watch_enabled && !state.no_ignore {
         let start = Instant::now();
         let matcher = walker::build_gitignore_matcher_from_files(
@@ -3623,8 +3857,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         // the build's results nor any event. The scan waits for the build to
         // finish before looking, because until then the stamps describe
         // nothing and every file would read as changed.
-        let (newly_watched, since) = publish_ignore_matcher(state, root, matcher);
-        spawn_recovery_scan(state, root, newly_watched, since);
+        newly_watched = publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -3633,6 +3866,11 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             walk.ignore_files.len(),
             if has_matcher { "" } else { ", no rules found" }
         );
+    }
+    // Outside that block: the scan also drains the events discarded while this
+    // build ran, which accumulate with or without ignore rules.
+    if state.watch_enabled {
+        spawn_recovery_scan(state, root, newly_watched, since);
     }
 
     // Filter out already-indexed files
@@ -4387,6 +4625,7 @@ mod tests {
             gitignore_pending: std::sync::atomic::AtomicBool::new(true),
             ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
             ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+            deferred_events: Mutex::new(Some(std::collections::HashSet::new())),
             index_progress: std::sync::atomic::AtomicU64::new(0),
             index_total: std::sync::atomic::AtomicU64::new(0),
             watch_enabled: true,
@@ -5151,6 +5390,131 @@ mod tests {
         assert!(
             state.gitignore.read().unwrap().is_some(),
             "the matcher the walk did find must still be published"
+        );
+    }
+
+    /// The metadata the eligibility check uses and the bytes that get indexed
+    /// have to describe the same object, which means one handle.
+    #[test]
+    fn open_no_follow_reads_a_regular_file() {
+        use std::io::Read;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("plain.rs");
+        std::fs::write(&path, "fn main() {}\n").unwrap();
+
+        let file = open_no_follow(&path).expect("a regular file opens");
+        let meta = file.metadata().expect("metadata off the handle");
+        assert!(meta.is_file());
+        assert_eq!(meta.len(), 13);
+
+        let mut data = String::new();
+        (&file).read_to_string(&mut data).unwrap();
+        assert_eq!(data, "fn main() {}\n");
+    }
+
+    /// A symlink must not open as its target, or a link committed to a branch
+    /// would pull a file from outside the served root into the index.
+    #[cfg(unix)]
+    #[test]
+    fn open_no_follow_refuses_a_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("secret.txt");
+        std::fs::write(&target, "sensitive\n").unwrap();
+        let link = tmp.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert!(
+            open_no_follow(&link).is_err(),
+            "O_NOFOLLOW must reject the link rather than open its target"
+        );
+    }
+
+    /// A burst big enough to be worth replaying individually is not worth
+    /// replaying individually. The buffer gives up as a whole, because a
+    /// truncated set looks exactly like a complete one at replay time.
+    #[cfg(unix)]
+    #[test]
+    fn deferring_more_changes_than_the_cap_gives_up_on_the_whole_set() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+
+        let small = Event {
+            kind: EventKind::Create(notify::event::CreateKind::Any),
+            paths: vec![root.join("a.rs")],
+            attrs: Default::default(),
+        };
+        defer_events_during_build(&state, &small);
+        assert_eq!(
+            state.deferred_events.lock().unwrap().as_ref().unwrap().len(),
+            1
+        );
+
+        let flood = Event {
+            kind: EventKind::Create(notify::event::CreateKind::Any),
+            paths: (0..200_001).map(|i| root.join(format!("f{i}.rs"))).collect(),
+            attrs: Default::default(),
+        };
+        defer_events_during_build(&state, &flood);
+        assert!(
+            state.deferred_events.lock().unwrap().is_none(),
+            "an overflowing burst must mark the buffer unusable, not truncate it"
+        );
+
+        // And stays given up on, rather than resuming a partial record.
+        defer_events_during_build(&state, &small);
+        assert!(state.deferred_events.lock().unwrap().is_none());
+    }
+
+    /// Events seen while a build ran are not applied then, but they are the
+    /// only record that those paths moved: the build's walk misses anything
+    /// written to a directory it already passed.
+    #[cfg(unix)]
+    #[test]
+    fn changes_deferred_during_a_build_are_applied_once_it_publishes() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        // As it is once a build publishes: no rules to wait for, nothing
+        // indexing.
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let path = root.join("late.rs");
+        std::fs::write(&path, "fn written_during_the_build() {}\n").unwrap();
+
+        state.indexing.store(true, Ordering::SeqCst);
+        handle_fs_event(
+            &state,
+            &root,
+            &Event {
+                kind: EventKind::Create(notify::event::CreateKind::Any),
+                paths: vec![path.clone()],
+                attrs: Default::default(),
+            },
+        );
+        assert!(
+            !state.index.read().unwrap().live.has_path("late.rs"),
+            "an event during a build must not touch the index"
+        );
+
+        state.indexing.store(false, Ordering::SeqCst);
+        replay_deferred_events(&state, &root);
+
+        assert!(
+            state.index.read().unwrap().live.has_path("late.rs"),
+            "the deferred change must be applied once the build is done"
+        );
+        assert!(
+            state
+                .deferred_events
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|p| p.is_empty()),
+            "the buffer must be drained, and left usable for the next build"
         );
     }
 

--- a/tgrep-cli/tests/watcher_dot_ignore.rs
+++ b/tgrep-cli/tests/watcher_dot_ignore.rs
@@ -101,6 +101,48 @@ fn wait_for_match(port: u16, pattern: &str, timeout: Duration) -> bool {
     }
 }
 
+/// Poll until `pattern` stops being searchable, returning whether it went away.
+fn wait_for_no_match(port: u16, pattern: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        if search_matches(port, pattern) == 0 {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn build_index(root: &Path, index_dir: &Path) {
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+}
+
+fn spawn_server(root: &Path, index_dir: &Path) -> ServerGuard {
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    ServerGuard { child }
+}
+
 #[test]
 fn watcher_honors_dot_ignore_and_still_indexes_new_files() {
     let dir = TempDir::new().unwrap();
@@ -117,29 +159,8 @@ fn watcher_honors_dot_ignore_and_still_indexes_new_files() {
     )
     .unwrap();
 
-    let status = Command::new(tgrep_bin())
-        .args([
-            "index",
-            root.to_str().unwrap(),
-            "--index-path",
-            index_dir.to_str().unwrap(),
-        ])
-        .status()
-        .expect("failed to run tgrep index");
-    assert!(status.success(), "initial index build failed");
-
-    let child = Command::new(tgrep_bin())
-        .args([
-            "serve",
-            "--index-path",
-            index_dir.to_str().unwrap(),
-            root.to_str().unwrap(),
-        ])
-        .stderr(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .spawn()
-        .expect("failed to start tgrep serve");
-    let _server = ServerGuard { child };
+    build_index(root, &index_dir);
+    let _server = spawn_server(root, &index_dir);
 
     let port = wait_for_port(&index_dir);
 
@@ -174,5 +195,73 @@ fn watcher_honors_dot_ignore_and_still_indexes_new_files() {
         search_matches(port, "dot_ignored_leak_marker"),
         0,
         "watcher indexed a file under a directory excluded by .ignore"
+    );
+}
+
+/// A `.ignore` written *after* the server is live must refresh the ignore
+/// rules, exactly as a `.gitignore` write does.
+///
+/// The startup matcher is built from the walk that the initial index used, so
+/// a `.ignore` that already exists is honored for free — which is what the
+/// test above covers. Rules that appear later only take effect if the watcher
+/// recognizes the `.ignore` write as an ignore-rules change and schedules the
+/// refresh; when it does not, the stale matcher stays published and the
+/// already-indexed content under the newly excluded directory stays
+/// searchable indefinitely (the periodic reconcile is on an hourly timer).
+///
+/// The fixture seeds the ignored file *before* indexing, so the assertion is a
+/// transition — searchable, then not — rather than a fixed sleep racing the
+/// refresh.
+#[test]
+fn late_dot_ignore_refreshes_the_watchers_ignore_rules() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    // No `.git` here either: `.ignore` is not git-gated, so this pins the
+    // refresh path for the one ignore source that works outside a repo.
+    fs::create_dir_all(root.join("secret")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("secret").join("creds.txt"),
+        "late_ignored_leak_marker\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    build_index(root, &index_dir);
+    let _server = spawn_server(root, &index_dir);
+
+    let port = wait_for_port(&index_dir);
+
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source file to be searchable"
+    );
+    // Positive control: with no `.ignore` yet, the seeded file under `secret/`
+    // is legitimately indexed. Without this the assertion below could pass
+    // simply because the file was never indexed in the first place.
+    assert!(
+        wait_for_match(port, "late_ignored_leak_marker", Duration::from_secs(30)),
+        "expected the file under secret/ to be indexed before any .ignore exists"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    fs::write(root.join(".ignore"), "secret/\n").unwrap();
+
+    assert!(
+        wait_for_no_match(port, "late_ignored_leak_marker", Duration::from_secs(60)),
+        "a .ignore written while the server was live never refreshed the ignore \
+         rules; content under the newly excluded directory is still searchable"
+    );
+
+    // The refresh must not take the rest of the index with it.
+    assert!(
+        search_matches(port, "normal_source_marker") > 0,
+        "the ignore-rules refresh dropped a file that is not ignored"
     );
 }

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -306,3 +306,84 @@ fn watcher_indexes_files_in_directories_created_after_startup() {
         "watcher indexed a file in a directory created under a gitignored path"
     );
 }
+
+/// A subtree that arrives already populated can carry its own ignore rules.
+///
+/// A clone, a `git mv`, a branch switch or an unpacked archive all land this
+/// way: the directory and everything under it appear in one step, so there is
+/// no moment at which the `.gitignore` inside it is seen on its own. The
+/// recovery pass skips dot-prefixed files, so without explicitly looking for
+/// ignore rules it would index the subtree against rules that never mentioned
+/// it — and the wrongly indexed files would stay until something touched them
+/// again or the hourly reconcile came round.
+#[test]
+fn watcher_honors_ignore_rules_inside_a_subtree_that_arrives_whole() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source file to be searchable"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    // Staged under a dot-prefixed name so the watcher ignores it while it is
+    // being built, and on the same filesystem so the move below is atomic.
+    let staging = root.join(".staging");
+    fs::create_dir_all(&staging).unwrap();
+    fs::write(staging.join(".gitignore"), "secret.txt\n").unwrap();
+    fs::write(staging.join("secret.txt"), "moved_subtree_secret_marker\n").unwrap();
+    fs::write(
+        staging.join("keep.rs"),
+        "fn keep() { let moved_subtree_keep_marker = 3; }\n",
+    )
+    .unwrap();
+
+    fs::rename(&staging, root.join("vendor")).unwrap();
+
+    assert!(
+        wait_for_match(port, "moved_subtree_keep_marker", Duration::from_secs(60)),
+        "watcher never indexed the non-ignored file in a subtree that arrived whole"
+    );
+    assert_eq!(
+        search_matches(port, "moved_subtree_secret_marker"),
+        0,
+        "watcher indexed a file excluded by a .gitignore that arrived inside \
+         the same subtree, so the subtree was indexed against stale rules"
+    );
+}

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -1,0 +1,308 @@
+//! The watcher must not take OS subscriptions for trees it is going to ignore.
+//!
+//! On Linux `notify` has no recursive inotify mode: `RecursiveMode::Recursive`
+//! walks the tree and spends one watch descriptor per directory. Ignored build
+//! output is usually most of the directories in a repository, so subscribing to
+//! it burns the per-user `fs.inotify.max_user_watches` budget on events that
+//! are then discarded — and because notify propagates the first registration
+//! failure, a repo large enough to exhaust that budget loses its watcher
+//! entirely.
+//!
+//! This is observable: the kernel reports a process's inotify watches in
+//! `/proc/<pid>/fdinfo/<fd>`, one `inotify wd:` line per watch. The test below
+//! counts them for a live server and pins that the ignored subtree is absent,
+//! while asserting the watcher still works — a watcher that registered nothing
+//! at all would trivially satisfy the count.
+//!
+//! Windows (ReadDirectoryChangesW) and macOS (FSEvents) subscribe once for the
+//! whole subtree, so there is no per-directory registration to withhold and
+//! nothing here applies; the count assertion is Linux-only for that reason.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Directories inside the ignored tree. Large enough that a recursive
+/// subscription is unmistakable in the watch count, small enough to create
+/// quickly.
+#[cfg(target_os = "linux")]
+const IGNORED_DIRS: usize = 60;
+/// Directories inside the indexed tree.
+#[cfg(target_os = "linux")]
+const SOURCE_DIRS: usize = 4;
+
+fn tgrep_bin() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin("tgrep")
+}
+
+struct ServerGuard {
+    child: Child,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn send_request(port: u16, request: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    writeln!(stream, "{request}")?;
+    stream.flush()?;
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader.read_line(&mut response)?;
+    Ok(response)
+}
+
+fn search_matches(port: u16, pattern: &str) -> u64 {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "search",
+        "id": 1,
+        "params": { "pattern": pattern }
+    })
+    .to_string();
+    let response = send_request(port, &request).expect("search request failed");
+    let value: serde_json::Value = serde_json::from_str(&response).expect("invalid JSON response");
+    value
+        .pointer("/result/num_matches")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| panic!("missing num_matches in response: {response}"))
+}
+
+fn wait_for_match(port: u16, pattern: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        if search_matches(port, pattern) > 0 {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Read `(pid, port)` once the server is accepting connections.
+fn wait_for_server(index_dir: &Path) -> (u32, u16) {
+    let serve_json = index_dir.join("serve.json");
+    let start = Instant::now();
+    loop {
+        assert!(
+            start.elapsed() <= Duration::from_secs(60),
+            "tgrep serve did not start within 60 seconds"
+        );
+        if let Ok(data) = fs::read_to_string(&serve_json)
+            && let Ok(info) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(p) = info.get("port").and_then(|v| v.as_u64())
+            && let Some(pid) = info.get("pid").and_then(|v| v.as_u64())
+            && TcpStream::connect(format!("127.0.0.1:{p}")).is_ok()
+        {
+            return (pid as u32, p as u16);
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Total inotify watch descriptors held by `pid`.
+///
+/// Each inotify file descriptor's `fdinfo` lists one `inotify wd:` line per
+/// watch, so summing them across the process's descriptors gives the number of
+/// directories it is subscribed to.
+#[cfg(target_os = "linux")]
+fn inotify_watch_count(pid: u32) -> usize {
+    let dir = format!("/proc/{pid}/fdinfo");
+    let Ok(entries) = fs::read_dir(&dir) else {
+        panic!("could not read {dir}; /proc must be mounted for this test");
+    };
+    let mut total = 0;
+    for entry in entries.flatten() {
+        // Descriptors come and go while we read; a vanished one is not a
+        // failure, it simply holds no watches we can count.
+        if let Ok(contents) = fs::read_to_string(entry.path()) {
+            total += contents
+                .lines()
+                .filter(|line| line.starts_with("inotify wd:"))
+                .count();
+        }
+    }
+    total
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn watcher_does_not_subscribe_to_gitignored_directories() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    // A real (if empty) `.git` entry: `.gitignore` rules only apply inside a
+    // repository, so without it the fixture would measure the wrong thing.
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+
+    for i in 0..IGNORED_DIRS {
+        let sub = root.join("build").join(format!("out{i}"));
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(sub.join("artifact.txt"), "ignored_build_output\n").unwrap();
+    }
+    for i in 0..SOURCE_DIRS {
+        let sub = root.join("src").join(format!("pkg{i}"));
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(
+            sub.join("lib.rs"),
+            format!("fn seeded{i}() {{ let normal_source_marker = {i}; }}\n"),
+        )
+        .unwrap();
+    }
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (pid, port) = wait_for_server(&index_dir);
+
+    // Positive control, and a wait for the watcher to be live: subscriptions
+    // are deferred until the ignore matcher is published, so counting before
+    // that would pass for the wrong reason.
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source files to be searchable"
+    );
+    fs::write(
+        root.join("src").join("added.rs"),
+        "fn added() { let watcher_added_marker = 1; }\n",
+    )
+    .unwrap();
+    assert!(
+        wait_for_match(port, "watcher_added_marker", Duration::from_secs(30)),
+        "watcher never indexed a newly created ordinary file, so the watch \
+         count below would be meaningless"
+    );
+
+    let watches = inotify_watch_count(pid);
+
+    // The tree the watcher legitimately needs is the root, `src`, `src/pkg*`,
+    // and `.git` is hidden so it is not watched either. Allow generous slack
+    // for anything else in the process holding an inotify fd, but stay far
+    // below the ~66 a recursive subscription over this fixture would take.
+    let allowed = SOURCE_DIRS + 8;
+    assert!(
+        watches <= allowed,
+        "watcher holds {watches} inotify watches for a tree whose only \
+         non-ignored directories are the root plus {SOURCE_DIRS} under src/; \
+         it is subscribing to the {IGNORED_DIRS} gitignored directories under \
+         build/ (expected at most {allowed})"
+    );
+}
+
+/// New directories still have to be picked up.
+///
+/// Non-recursive subscriptions are not extended by notify, so a directory
+/// created after startup is invisible unless the watcher subscribes to it as
+/// it appears. This runs everywhere: on a whole-subtree backend it simply
+/// re-confirms the existing behaviour, which is the point — the two paths must
+/// agree.
+#[test]
+fn watcher_indexes_files_in_directories_created_after_startup() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source file to be searchable"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    // A whole new subtree, several levels deep, written in one go. The files
+    // land immediately after their directories, which is exactly the race the
+    // subscription pass has to close.
+    let nested = root.join("src").join("fresh").join("deeper");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(
+        nested.join("new.rs"),
+        "fn fresh() { let nested_new_dir_marker = 2; }\n",
+    )
+    .unwrap();
+
+    assert!(
+        wait_for_match(port, "nested_new_dir_marker", Duration::from_secs(30)),
+        "watcher never indexed a file created in a directory that did not \
+         exist when the server started"
+    );
+
+    // ...and a directory created inside the ignored tree stays ignored.
+    let ignored = root.join("build").join("fresh");
+    fs::create_dir_all(&ignored).unwrap();
+    fs::write(ignored.join("out.txt"), "new_ignored_dir_marker\n").unwrap();
+    thread::sleep(Duration::from_secs(3));
+    assert_eq!(
+        search_matches(port, "new_ignored_dir_marker"),
+        0,
+        "watcher indexed a file in a directory created under a gitignored path"
+    );
+}

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -387,3 +387,86 @@ fn watcher_honors_ignore_rules_inside_a_subtree_that_arrives_whole() {
          the same subtree, so the subtree was indexed against stale rules"
     );
 }
+
+/// A directory removed and recreated at the same path must still be watched.
+///
+/// The kernel drops an inotify watch when its directory goes away and does not
+/// say so, leaving the path recorded as watched with no descriptor behind it.
+/// Nothing later can tell that entry from a live one — it is in the desired set
+/// *and* in the watched set — so without explicitly clearing it on removal the
+/// directory stops being watched for the life of the process.
+///
+/// `rm -rf build && mkdir build`, a branch switch, and a `git clean` all do
+/// exactly this.
+#[test]
+fn watcher_rewatches_a_directory_that_is_removed_and_recreated() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir_all(root.join("src").join("gen")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src").join("gen").join("old.rs"),
+        "fn old() { let pre_delete_marker = 2; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "pre_delete_marker", Duration::from_secs(30)),
+        "expected the seeded file in src/gen to be searchable"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    let gen_dir = root.join("src").join("gen");
+    fs::remove_dir_all(&gen_dir).unwrap();
+    thread::sleep(Duration::from_secs(2));
+    fs::create_dir_all(&gen_dir).unwrap();
+
+    // Deliberately after the recreation has been processed. A file written in
+    // the same breath would be picked up by the subscription pass's own scan
+    // and would say nothing about whether the watch itself was re-established.
+    thread::sleep(Duration::from_secs(3));
+    fs::write(
+        gen_dir.join("new.rs"),
+        "fn regenerated() { let post_recreate_marker = 3; }\n",
+    )
+    .unwrap();
+
+    assert!(
+        wait_for_match(port, "post_recreate_marker", Duration::from_secs(30)),
+        "watcher never saw a file written to a directory that was removed and \
+         recreated, so its subscription was not re-established"
+    );
+}

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -92,6 +92,25 @@ fn wait_for_match(port: u16, pattern: &str, timeout: Duration) -> bool {
     }
 }
 
+/// Wait until `pattern` stops matching.
+///
+/// For content that has to be *dropped* from the index. The barrier the other
+/// assertions use — a second file appearing — only proves that some later event
+/// was processed, which on a backend that coalesces or reorders events (macOS)
+/// says nothing about the drop.
+fn wait_for_no_match(port: u16, pattern: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        if search_matches(port, pattern) == 0 {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
 /// Read `(pid, port)` once the server is accepting connections.
 fn wait_for_server(index_dir: &Path) -> (u32, u16) {
     let serve_json = index_dir.join("serve.json");
@@ -497,6 +516,12 @@ fn watcher_applies_the_same_file_eligibility_rules_as_the_walker() {
         "fn seeded() { let seeded_source_marker = 1; }\n",
     )
     .unwrap();
+    // Small enough to be indexed now, and grown past the cap below.
+    fs::write(
+        root.join("src").join("grows.rs"),
+        "fn grows() { let outgrew_the_cap_marker = 5; }\n",
+    )
+    .unwrap();
 
     let status = Command::new(tgrep_bin())
         .args([
@@ -543,6 +568,11 @@ fn watcher_applies_the_same_file_eligibility_rules_as_the_walker() {
     let mut oversized = String::from("fn big() { let oversized_file_marker = 3; }\n");
     oversized.push_str(&"// padding\n".repeat(400));
     fs::write(src.join("huge.rs"), oversized).unwrap();
+    // Already in the index, and now over the cap: what was indexed has to go,
+    // not just stop being updated.
+    let mut grown = String::from("fn grows() { let outgrew_the_cap_marker = 5; }\n");
+    grown.push_str(&"// padding\n".repeat(400));
+    fs::write(src.join("grows.rs"), grown).unwrap();
     fs::write(
         src.join("extra.rs"),
         "fn extra() { let eligible_file_marker = 4; }\n",
@@ -564,5 +594,98 @@ fn watcher_applies_the_same_file_eligibility_rules_as_the_walker() {
         search_matches(port, "oversized_file_marker"),
         0,
         "the watcher indexed a file larger than --max-filesize"
+    );
+    assert!(
+        wait_for_no_match(port, "outgrew_the_cap_marker", Duration::from_secs(30)),
+        "a file that grew past --max-filesize kept its indexed content"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn watcher_does_not_index_through_symlinks() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    // Deliberately outside the served root: this stands in for anything a
+    // symlink committed to a branch could point at.
+    let outside = TempDir::new().unwrap();
+    let secret = outside.path().join("secret.txt");
+    fs::write(&secret, "fn leak() { let outside_root_marker = 1; }\n").unwrap();
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let seeded_source_marker = 1; }\n",
+    )
+    .unwrap();
+    // Indexed as a real file first, then replaced by a link below.
+    fs::write(
+        root.join("src").join("swapped.rs"),
+        "fn swapped() { let replaced_by_symlink_marker = 2; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "seeded_source_marker", Duration::from_secs(30)),
+        "expected the seeded file to be searchable"
+    );
+    assert_eq!(
+        search_matches(port, "replaced_by_symlink_marker"),
+        1,
+        "expected the file that is about to be replaced to start out indexed"
+    );
+
+    let src = root.join("src");
+    std::os::unix::fs::symlink(&secret, src.join("link.rs")).unwrap();
+    fs::remove_file(src.join("swapped.rs")).unwrap();
+    std::os::unix::fs::symlink(&secret, src.join("swapped.rs")).unwrap();
+    fs::write(
+        src.join("extra.rs"),
+        "fn extra() { let eligible_file_marker = 3; }\n",
+    )
+    .unwrap();
+
+    assert!(
+        wait_for_match(port, "eligible_file_marker", Duration::from_secs(30)),
+        "the eligible file written alongside the symlinks was never indexed, \
+         so this test cannot say anything about the symlinks"
+    );
+
+    assert!(
+        wait_for_no_match(port, "replaced_by_symlink_marker", Duration::from_secs(30)),
+        "a real file replaced by a symlink kept its old content in the index"
+    );
+    assert_eq!(
+        search_matches(port, "outside_root_marker"),
+        0,
+        "the watcher followed a symlink and indexed content from outside the served root"
     );
 }

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -470,3 +470,99 @@ fn watcher_rewatches_a_directory_that_is_removed_and_recreated() {
          recreated, so its subscription was not re-established"
     );
 }
+
+/// The walk decides what belongs in the index; the watcher must agree with it.
+///
+/// `should_skip_watcher_path` only filters by location — excludes, ignore
+/// rules, hidden paths. It says nothing about the two rules the walker applies
+/// per file: binary extensions are skipped, and so is anything over
+/// `--max-filesize`. A file arriving through the watcher therefore used to be
+/// indexed even when a walk of the very same tree would have rejected it, so
+/// the index disagreed with itself depending on whether a file was present at
+/// startup or written afterwards — and the next reconcile silently deleted it.
+///
+/// Both rejections are asserted alongside an eligible file written at the same
+/// moment. Without that control the test would pass just as happily against a
+/// watcher that had stopped indexing anything at all.
+#[test]
+fn watcher_applies_the_same_file_eligibility_rules_as_the_walker() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let seeded_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--max-filesize",
+            "2K",
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--max-filesize",
+            "2K",
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "seeded_source_marker", Duration::from_secs(30)),
+        "expected the seeded file to be searchable"
+    );
+
+    let src = root.join("src");
+    // Text content, so nothing but the extension can keep it out.
+    fs::write(
+        src.join("asset.png"),
+        "fn decoy() { let binary_extension_marker = 2; }\n",
+    )
+    .unwrap();
+    // Same marker, pushed past the 2K cap by padding.
+    let mut oversized = String::from("fn big() { let oversized_file_marker = 3; }\n");
+    oversized.push_str(&"// padding\n".repeat(400));
+    fs::write(src.join("huge.rs"), oversized).unwrap();
+    fs::write(
+        src.join("extra.rs"),
+        "fn extra() { let eligible_file_marker = 4; }\n",
+    )
+    .unwrap();
+
+    assert!(
+        wait_for_match(port, "eligible_file_marker", Duration::from_secs(30)),
+        "the eligible file written next to the rejected ones was never indexed, \
+         so this test cannot say anything about the rejections"
+    );
+
+    assert_eq!(
+        search_matches(port, "binary_extension_marker"),
+        0,
+        "the watcher indexed a file whose extension the walker rejects"
+    );
+    assert_eq!(
+        search_matches(port, "oversized_file_marker"),
+        0,
+        "the watcher indexed a file larger than --max-filesize"
+    );
+}

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -158,7 +158,11 @@ impl Default for WalkOptions {
 }
 
 /// Check if a file extension indicates a binary format.
-fn is_binary_extension(path: &Path) -> bool {
+///
+/// Public so the watcher can apply the same rule the walk does. A file the
+/// walk rejected here must not be inserted into the index by an incremental
+/// update, or the two disagree about what the index contains.
+pub fn is_binary_extension(path: &Path) -> bool {
     path.extension()
         .and_then(|e| e.to_str())
         .is_some_and(|ext| {


### PR DESCRIPTION
Reverts only the mid-build event deferral to confirm the new test fails without it. Will be deleted.