### PR TITLE
CONTROL (do not merge): ignore-source digest removed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/tgrep-cli/Cargo.toml
+++ b/tgrep-cli/Cargo.toml
@@ -31,7 +31,7 @@ memmap2 = "0.9"
 memchr = "2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_System_ProcessStatus", "Win32_System_SystemInformation", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32_System_ProcessStatus", "Win32_System_SystemInformation", "Win32_System_Threading"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use fs2::FileExt;
 use lru::LruCache;
@@ -757,17 +757,18 @@ fn build_stale_matcher(
 /// makes the matcher swap and the index decisions around it atomic from the
 /// watcher's point of view.
 ///
-/// Returns the directories that were newly subscribed to as a result. Those
-/// were unwatched while the caller's walk ran, so anything written to them in
-/// that window produced no event and appears in no walk result. Callers pass
-/// the list to [`reindex_files_in`] once `state.file_stamps` describes the
-/// index they just published.
+/// Returns the directories that were newly subscribed to as a result, and the
+/// moment the walk behind that decision began. Those were unwatched while the
+/// caller's walk ran, so anything written to them in that window produced no
+/// event and appears in no walk result. Callers pass both to
+/// [`reindex_files_in`] once `state.file_stamps` describes the index they just
+/// published.
 #[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
     root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
-) -> Vec<PathBuf> {
+) -> (Vec<PathBuf>, SystemTime) {
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
     // New rules mean a different set of directories worth hearing about:
@@ -1582,8 +1583,8 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
         // subscriptions at all. Its walk is then already over by the time we
         // subscribe here, and nothing else revisits the tree until the hourly
         // reconcile — so the recovery scan is not optional on this path.
-        let newly_watched = sync_watch_registrations(&state, root);
-        spawn_recovery_scan(&state, root, newly_watched);
+        let (newly_watched, since) = sync_watch_registrations(&state, root);
+        spawn_recovery_scan(&state, root, newly_watched, since);
     }
 
     let worker_state = Arc::clone(&state);
@@ -1876,6 +1877,16 @@ impl WatchRegistry {
         added
     }
 
+    /// Whether `path` is already subscribed.
+    ///
+    /// For deciding whether a directory found during a recovery scan is one the
+    /// sync already knew about or one that appeared after it — the latter has
+    /// to be picked up explicitly, since a non-recursive subscription on its
+    /// parent says nothing about it.
+    fn is_watched(&self, path: &Path) -> bool {
+        self.watched.contains(path)
+    }
+
     /// Drop a path that no longer exists from the subscription set.
     ///
     /// The kernel has already released the descriptor if the directory was
@@ -1978,20 +1989,26 @@ fn watchable_dirs(
 /// published, so relaxing a rule subscribes to the tree it used to hide and
 /// tightening one drops it.
 ///
-/// Returns the directories that were newly subscribed to. Until a directory is
-/// subscribed it cannot report anything, so a file written to one of these
-/// between the caller's walk and this call is in neither the walk's results nor
-/// any event. The caller is expected to hand the list to
-/// [`reindex_files_in`] once its own bookkeeping is settled.
-fn sync_watch_registrations(state: &ServerState, root: &Path) -> Vec<PathBuf> {
+/// Returns the directories that were newly subscribed to, and the moment the
+/// walk behind that decision began. Until a directory is subscribed it cannot
+/// report anything, so a file written to one of these between the walk and the
+/// subscription is in neither the walk's results nor any event. The caller is
+/// expected to hand both to [`reindex_files_in`] once its own bookkeeping is
+/// settled; the timestamp bounds that window, which is what lets the scan tell
+/// an ignore-rules file that landed inside it from the thousands that were
+/// already there and are already reflected in the matcher.
+fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, SystemTime) {
+    // Before the early returns as well as the walk: a caller that gets no
+    // directories back still gets a usable bound.
+    let since = SystemTime::now();
     if !PER_DIRECTORY_WATCHES {
-        return Vec::new();
+        return (Vec::new(), since);
     }
     let mut registry = state.watch_registry.lock().unwrap();
     let Some(registry) = registry.as_mut() else {
         // The watcher has not started yet. It syncs once as it comes up, so
         // there is nothing to do and nothing to remember.
-        return Vec::new();
+        return (Vec::new(), since);
     };
 
     let start = Instant::now();
@@ -2009,37 +2026,113 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> Vec<PathBuf> {
             start.elapsed().as_secs_f64() * 1000.0
         );
     }
-    added
+    (added, since)
 }
 
-/// Re-check the files directly inside `dirs`, indexing the ones that changed.
+/// Re-check the files directly inside `dirs`, indexing the ones that changed,
+/// dropping the ones that are gone, and subscribing to subdirectories that
+/// appeared while the subscriptions were being established.
 ///
 /// Used to close the gap between a walk and the subscriptions that follow it:
 /// [`reindex_file`] compares stamps first, so for a tree that did not change
 /// under us this costs one `metadata` call per file and indexes nothing.
 ///
+/// `since` is when the walk behind `dirs` began — the start of the window this
+/// is closing. It is only consulted for ignore-rules files, where "did this
+/// arrive after the matcher was decided" cannot be answered from the stamps:
+/// the dot-prefixed ones are hidden, so they are never indexed and never have
+/// one.
+///
 /// Callers must already hold `snapshot_gate`, and `state.file_stamps` must
 /// already describe the index as published — a merge that replaces the stamps
 /// afterwards would both discard what this records and make every file here
 /// look changed.
-fn reindex_files_in(state: &ServerState, root: &Path, dirs: &[PathBuf]) {
+fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], since: SystemTime) {
     if dirs.is_empty() {
         return;
     }
     let start = Instant::now();
+    // Directories whose listing succeeded, and the files those listings
+    // contained, for the removal sweep at the end. Only files are recorded:
+    // stamps describe files, so directory names would just be dead weight on a
+    // set that at startup spans the whole repository.
+    let mut swept: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut present: std::collections::HashSet<String> = std::collections::HashSet::new();
+
     for dir in dirs {
-        let Ok(entries) = std::fs::read_dir(dir) else {
+        let Ok(rel_dir) = dir.strip_prefix(root) else {
             continue;
         };
+        let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            // No listing means no evidence, and the sweep below must not treat
+            // silence as absence.
+            continue;
+        };
+        let mut subdirs: Vec<PathBuf> = Vec::new();
         for entry in entries.flatten() {
-            if !entry.file_type().is_ok_and(|t| t.is_file()) {
-                continue;
-            }
             let path = entry.path();
             let Ok(rel) = path.strip_prefix(root) else {
                 continue;
             };
             let rel = rel.to_string_lossy().replace('\\', "/");
+            let Ok(file_type) = entry.file_type() else {
+                // Unclassifiable, so nothing can be concluded about it —
+                // least of all that it is gone.
+                present.insert(rel);
+                continue;
+            };
+            // `DirEntry::file_type` does not follow symlinks, so a symlinked
+            // file or directory is neither indexed nor descended into, which
+            // is what the walker does with `follow_links(false)`.
+            if file_type.is_dir() {
+                subdirs.push(path);
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            present.insert(rel.clone());
+
+            // An ignore-rules file that landed in this window was not seen by
+            // the walk that built the matcher in force, so every other file in
+            // this scan is being judged by rules that do not know about it.
+            // Indexing them now would apply the wrong rules and leave whatever
+            // was wrongly indexed until something touched it again.
+            //
+            // The mtime test is what keeps this quiet: a repository has an
+            // ignore file in every other directory and the startup scan walks
+            // past all of them, but they predate the walk and are already
+            // accounted for. Only one written inside the window can have been
+            // missed — and a spurious match (a `touch` in the same
+            // millisecond) costs an idempotent refresh, not correctness.
+            //
+            // Bounded at both ends, not just the near one. On a network mount
+            // whose server clock runs ahead of ours, every recently touched
+            // file carries a future mtime and would pass a one-sided test — on
+            // every scan, including the one at the end of the refresh this
+            // schedules, which walks the whole repository and then arms the
+            // next. Treating a future mtime as skew rather than as an arrival
+            // gives up the fix on such a mount and keeps the loop closed.
+            if !state.no_ignore
+                && is_ignore_rules_file(root, &path)
+                && entry
+                    .metadata()
+                    .and_then(|m| m.modified())
+                    .is_ok_and(|m| m >= since && m <= SystemTime::now())
+            {
+                // Abandon the scan: the refresh rewalks and republishes, which
+                // covers these directories properly, and anything indexed
+                // between here and there would be judged by the stale rules.
+                state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+                schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+                eprintln!(
+                    "[trace] watcher: ignore rules changed during recovery ({rel}); \
+                     deferring to a refresh"
+                );
+                return;
+            }
+
             let skip = {
                 let gitignore = state.gitignore.read().unwrap();
                 should_skip_watcher_path(&rel, &state.exclude_dirs, gitignore.as_ref())
@@ -2048,12 +2141,108 @@ fn reindex_files_in(state: &ServerState, root: &Path, dirs: &[PathBuf]) {
                 reindex_file(state, &path, &rel);
             }
         }
+        swept.insert(rel_dir);
+
+        // A directory created in the same window is in neither `dirs` (the
+        // walk did not see it) nor any event (its parent's subscription is
+        // non-recursive, so notify does not extend to it), and would stay
+        // invisible until the hourly reconcile.
+        //
+        // Only the ones not already subscribed: at startup `dirs` is every
+        // directory in the repository and each one is a subdirectory of
+        // another, so descending into all of them would re-walk the tree once
+        // per level. The membership test reduces that to a hash lookup apiece.
+        if !subdirs.is_empty() {
+            let unwatched: Vec<PathBuf> = {
+                let mut registry = state.watch_registry.lock().unwrap();
+                match registry.as_mut() {
+                    // Filtered under the lock but subscribed outside it:
+                    // `watch_new_subtree` takes the same lock, and it is not
+                    // reentrant.
+                    Some(registry) => subdirs
+                        .into_iter()
+                        .filter(|p| !registry.is_watched(p))
+                        .collect(),
+                    None => Vec::new(),
+                }
+            };
+            for subdir in &unwatched {
+                watch_new_subtree(state, root, subdir);
+            }
+        }
     }
+
+    sweep_removed_files(state, &swept, &present);
+
     eprintln!(
         "[trace] watcher: rechecked {} newly watched directories in {:.1}ms",
         dirs.len(),
         start.elapsed().as_secs_f64() * 1000.0
     );
+}
+
+/// Drop index entries for files that were deleted while subscriptions were
+/// being established.
+///
+/// The counterpart to the indexing pass in [`reindex_files_in`]: a file removed
+/// in that window produced no event either, and unlike a modified one nothing
+/// later brings it back to the watcher's attention, so it keeps answering
+/// searches until the hourly reconcile.
+///
+/// `swept` holds the relative directories whose listing succeeded — a failed
+/// `read_dir` proves nothing and must not be read as an empty directory — and
+/// `present` every file those listings contained, regardless of ignore rules or
+/// eligibility. Filtering `present` would delete entries for files that are
+/// still on disk and were indexed under a laxer configuration.
+///
+/// The caller must already hold `snapshot_gate`.
+fn sweep_removed_files(
+    state: &ServerState,
+    swept: &std::collections::HashSet<String>,
+    present: &std::collections::HashSet<String>,
+) {
+    if swept.is_empty() {
+        return;
+    }
+    // One pass over the stamps rather than a lookup per swept directory: at
+    // startup both sides of this span the whole repository, and anything
+    // proportional to their product would not finish.
+    let gone: Vec<String> = {
+        let stamps = state.file_stamps.read().unwrap();
+        stamps
+            .keys()
+            .filter(|rel| {
+                let parent = rel.rsplit_once('/').map_or("", |(dir, _)| dir);
+                swept.contains(parent) && !present.contains(rel.as_str())
+            })
+            .cloned()
+            .collect()
+    };
+    if gone.is_empty() {
+        return;
+    }
+    eprintln!(
+        "[trace] watcher: dropped {} file(s) removed while subscriptions were \
+         being established",
+        gone.len()
+    );
+    {
+        let mut index = state.index.write().unwrap();
+        for rel in &gone {
+            index.live.delete_file(rel);
+        }
+    }
+    {
+        let mut stamps = state.file_stamps.write().unwrap();
+        for rel in &gone {
+            stamps.remove(rel);
+        }
+    }
+    if let Ok(mut cache) = state.cache.write() {
+        for rel in &gone {
+            cache.pop(rel);
+        }
+    }
 }
 
 /// Subscribe to a directory that has just appeared, and to anything already
@@ -2098,7 +2287,7 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
     let mut files: Vec<(PathBuf, String)> = Vec::new();
     let mut found_ignore_rules = false;
 
-    while !level.is_empty() {
+    'descend: while !level.is_empty() {
         {
             let mut registry = state.watch_registry.lock().unwrap();
             let Some(registry) = registry.as_mut() else {
@@ -2153,9 +2342,20 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
                     // dot-prefixed, so the scan below would silently drop them
                     // and index the rest of the subtree against rules that do
                     // not know about them.
+                    //
+                    // Abandon the descent immediately rather than finishing it.
+                    // Everything gathered from here on is discarded by the
+                    // refresh anyway, and the rules that are about to be
+                    // published are the ones that decide whether these
+                    // directories should be watched at all — continuing would
+                    // subscribe to every level of, say, a `node_modules/` that
+                    // was just moved into place, which on Linux is a watch
+                    // descriptor apiece and the exhaustion this pass exists to
+                    // avoid. The refresh's `sync` would prune them, but only
+                    // after they had already been taken.
                     if !state.no_ignore && is_ignore_rules_file(root, &path) {
                         found_ignore_rules = true;
-                        continue;
+                        break 'descend;
                     }
                     let skip = {
                         let gitignore = state.gitignore.read().unwrap();
@@ -2237,7 +2437,12 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 /// Waits out `indexing` first. During a build the stamps do not describe the
 /// index yet, so every file would look changed and the scan would re-read the
 /// whole repository alongside the build that is already doing it.
-fn spawn_recovery_scan(state: &Arc<ServerState>, root: &Path, dirs: Vec<PathBuf>) {
+fn spawn_recovery_scan(
+    state: &Arc<ServerState>,
+    root: &Path,
+    dirs: Vec<PathBuf>,
+    since: SystemTime,
+) {
     if dirs.is_empty() || !PER_DIRECTORY_WATCHES {
         return;
     }
@@ -2254,7 +2459,7 @@ fn spawn_recovery_scan(state: &Arc<ServerState>, root: &Path, dirs: Vec<PathBuf>
             // keeps the stamp check and the index update from interleaving
             // with a flush.
             let _gate = state.snapshot_gate.read().unwrap();
-            reindex_files_in(&state, &root, &dirs);
+            reindex_files_in(&state, &root, &dirs, since);
         });
     if spawned.is_err() {
         eprintln!(
@@ -2372,6 +2577,10 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
             continue;
         }
 
+        // `is_file` follows symlinks, so a link to a file lands in
+        // `reindex_file` below rather than here — deliberately: that is where
+        // it is recognised as ineligible and any content indexed under that
+        // path before it became a link is dropped.
         if !path.is_file() {
             // Only for events that can actually introduce a directory. Any
             // `Modify` would include `Modify(Metadata)`, which a recursive
@@ -2414,40 +2623,72 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // for atime/attribute updates, opens, etc. — re-indexing on those
     // would re-read large files, churn the live overlay, and produce a
     // misleading "modified" trace for files that didn't actually change.
-    let current = match std::fs::metadata(path) {
-        Ok(m) => FileStamp {
-            mtime: m
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
-            size: m.len(),
-        },
+    //
+    // `symlink_metadata` describes the link itself; `metadata` would describe
+    // its target. See the eligibility check below for why that distinction
+    // matters here.
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
         Err(_) => return,
     };
+    let current = FileStamp {
+        mtime: meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        size: meta.len(),
+    };
 
-    // The same two rules `walk_file_metadata` applies, and for the same
-    // reason: the walk is authoritative about what belongs in the index, so
-    // anything it rejects must not be added here. Without this a file that
-    // grew past the cap — or an ineligible extension in a directory a relaxed
-    // ignore rule just exposed — would be read whole and indexed, and the next
-    // reconcile would silently delete it again.
-    let eligible = !tgrep_core::walker::is_binary_extension(path)
+    // The rules `walk_file_metadata` applies, and for the same reason: the walk
+    // is authoritative about what belongs in the index, so anything it rejects
+    // must not be added here. Without this a file that grew past the cap — or
+    // an ineligible extension in a directory a relaxed ignore rule just exposed
+    // — would be read whole and indexed, and the next reconcile would silently
+    // delete it again.
+    //
+    // `is_file` on the link's own metadata is the third rule, and the one with
+    // teeth: the walker runs with `follow_links(false)`, where a symlink is
+    // neither file nor dir and is skipped outright. Following one here would
+    // read the target and index its bytes under the link's path — and the
+    // target need not be under `root` at all, so a link committed to a branch
+    // (or dropped in by a build) is enough to pull `~/.ssh/id_rsa` into an
+    // index whose whole contract is that it covers the served tree.
+    let eligible = meta.is_file()
+        && !tgrep_core::walker::is_binary_extension(path)
         && !state
             .max_file_size
             .is_some_and(|limit| current.size > limit);
     if !eligible {
         // It may have been eligible when it was last indexed — a file can grow
-        // past the cap. Drop what we hold so the index matches the walk rather
-        // than keeping a stale copy of the smaller version until the reconcile.
-        if state
+        // past the cap, and a real file can be replaced by a link to one. Drop
+        // what we hold so the index matches the walk rather than keeping a
+        // stale copy of the smaller version until the reconcile.
+        //
+        // The stamp is not the only evidence that something is indexed. A file
+        // the watcher added since the last flush lives in the live overlay,
+        // and a stamp map that was replaced wholesale — by a stale merge, or
+        // by a load that failed and left it empty — no longer mentions it, so
+        // testing the stamp alone would skip the drop and keep serving content
+        // the walk rejects. `has_path` covers the overlay; an entry that is
+        // only in the persisted reader with no stamp to match is beyond what
+        // can be checked cheaply here (the reader has no path index) and is
+        // left to the reconcile's membership diff.
+        //
+        // Both are checked before deleting rather than deleting unconditionally
+        // the way the removal branch does: removals are rare, but this runs for
+        // every ineligible file a recovery scan walks past, and `delete_file`
+        // records a tombstone and dirties the overlay even when the path was
+        // never indexed.
+        let had_stamp = state
             .file_stamps
             .write()
             .unwrap()
             .remove(rel_path)
-            .is_some()
-        {
+            .is_some();
+        let in_overlay = state.index.read().unwrap().live.has_path(rel_path);
+        if had_stamp || in_overlay {
             eprintln!("[trace] reindex: dropped {rel_path} (no longer eligible)");
             state.index.write().unwrap().live.delete_file(rel_path);
             if let Ok(mut cache) = state.cache.write() {
@@ -2970,6 +3211,10 @@ fn background_refresh_stale(
     let _gate = state.snapshot_gate.write().unwrap();
 
     let mut newly_watched = Vec::new();
+    // Before the walk, not after the subscriptions: this bounds the window the
+    // recovery scan is closing, and the window opens the moment the traversal
+    // that decided what to subscribe to begins.
+    let since = SystemTime::now();
     let ok = refresh_stale_locked(
         state,
         root,
@@ -2988,7 +3233,7 @@ fn background_refresh_stale(
     // `stream_merge_stale_changes` replaces the stamps wholesale, so scanning
     // any earlier would both be discarded and re-read every changed file.
     if ok {
-        reindex_files_in(state, root, &newly_watched);
+        reindex_files_in(state, root, &newly_watched, since);
     }
     ok
 }
@@ -3033,7 +3278,10 @@ fn refresh_stale_locked(
     // the caller holds `snapshot_gate` for write across this whole body, and
     // the only reader of `state.gitignore` takes the read side first, so no
     // event can observe the matcher before this function returns either way.
-    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
+    // The caller anchored the recovery window at its own walk, which starts
+    // earlier than the subscription sync inside this call, so the timestamp
+    // that comes back here is the looser of the two and is dropped.
+    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk)).0;
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -3276,8 +3524,8 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         // than skipped: the scan waits out `indexing` and then costs one
         // `metadata` call per file, since the stamps this build just wrote
         // describe the index exactly.
-        let newly_watched = publish_ignore_matcher(state, root, matcher);
-        spawn_recovery_scan(state, root, newly_watched);
+        let (newly_watched, since) = publish_ignore_matcher(state, root, matcher);
+        spawn_recovery_scan(state, root, newly_watched, since);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -3375,8 +3623,8 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         // the build's results nor any event. The scan waits for the build to
         // finish before looking, because until then the stamps describe
         // nothing and every file would read as changed.
-        let newly_watched = publish_ignore_matcher(state, root, matcher);
-        spawn_recovery_scan(state, root, newly_watched);
+        let (newly_watched, since) = publish_ignore_matcher(state, root, matcher);
+        spawn_recovery_scan(state, root, newly_watched, since);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -3583,6 +3831,19 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // the newly published reader; no event is lost.
     let gate = state.snapshot_gate.write().unwrap();
     state.flushing.store(true, Ordering::SeqCst);
+
+    // Publish the stamps *before* clearing `indexing`, not after the flush.
+    // The recovery scan started at publish time waits for `indexing` to clear
+    // and then blocks on this gate, so it runs the instant the gate drops. If
+    // the stamps were still unpublished at that point every file it walked
+    // would compare as changed and it would re-read the entire repository —
+    // the exact work the wait exists to avoid — and the assignment would then
+    // overwrite the stamps it had just recorded for anything that really did
+    // change during the build, losing them until the next reconcile.
+    //
+    // Done even if the flush below fails: the live overlay already reflects
+    // what was just indexed, and the stamps describe that.
+    *state.file_stamps.write().unwrap() = stamps;
     state.indexing.store(false, Ordering::SeqCst);
 
     // Final flush to disk for the bulk build. Use the same streaming
@@ -3592,16 +3853,16 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // intermediate incremental flushes published `complete = false` so a
     // mid-build kill would resume rather than be treated as finished.
     eprintln!("[trace] persisting final index to disk...");
-    let pruned = flush_append_only_overlay_locked(state, index_dir, true, Some(&stamps));
+    let pruned = {
+        // A read guard rather than a clone: these maps hold an entry per file
+        // in the repo. Nothing reachable from the flush takes this lock, and
+        // every other writer is behind the publish gate we hold.
+        let stamps = state.file_stamps.read().unwrap();
+        flush_append_only_overlay_locked(state, index_dir, true, Some(&stamps))
+    };
     drop(gate);
 
     state.flushing.store(false, Ordering::SeqCst);
-
-    // Refresh the in-memory file_stamps so the file watcher can recognize
-    // unchanged files and skip spurious notify events (e.g. atime/attribute
-    // updates on Windows). Done even if the flush failed — the live overlay
-    // already reflects what we just indexed, and the stamps describe that.
-    *state.file_stamps.write().unwrap() = stamps;
 
     // Reclaim memory held by the indexing-time live overlay — but only when
     // the flush actually completed and `prune_persisted_entries` ran. If the

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1576,13 +1576,14 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
     if state.gitignore_pending.load(Ordering::SeqCst) {
         eprintln!("[trace] watcher subscriptions deferred until the ignore matcher is ready");
     } else {
-        // The newly watched directories are deliberately not rechecked here.
-        // This is every directory in the repository, the index was built or
-        // opened moments ago, and the stale check that follows startup
-        // reconciles the same drift while holding `snapshot_gate` — which this
-        // path does not hold and must not take, since the watcher has to be
-        // receiving events before that check runs.
-        let _ = sync_watch_registrations(&state, root);
+        // This can be the first subscription pass the repository ever gets:
+        // the stale check runs on a thread spawned before this function, so it
+        // can publish while `watch_registry` is still `None` and take no
+        // subscriptions at all. Its walk is then already over by the time we
+        // subscribe here, and nothing else revisits the tree until the hourly
+        // reconcile — so the recovery scan is not optional on this path.
+        let newly_watched = sync_watch_registrations(&state, root);
+        spawn_recovery_scan(&state, root, newly_watched);
     }
 
     let worker_state = Arc::clone(&state);
@@ -2221,6 +2222,49 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
     });
 }
 
+/// Recheck newly watched directories on a background thread.
+///
+/// For the publish sites that cannot scan inline. Until a directory is
+/// subscribed it cannot report a write, and the walk that decided to subscribe
+/// to it may have passed it before that write happened, so a file landing in
+/// that window is in neither place and would wait for the hourly reconcile.
+///
+/// Spawned because at startup this is every directory in the repository and
+/// the callers are on paths that must not block: `start_file_watcher` has to
+/// get its worker running, and an index build must not stop to stat the tree
+/// it is already reading.
+///
+/// Waits out `indexing` first. During a build the stamps do not describe the
+/// index yet, so every file would look changed and the scan would re-read the
+/// whole repository alongside the build that is already doing it.
+fn spawn_recovery_scan(state: &Arc<ServerState>, root: &Path, dirs: Vec<PathBuf>) {
+    if dirs.is_empty() || !PER_DIRECTORY_WATCHES {
+        return;
+    }
+    let state = Arc::clone(state);
+    let root = root.to_path_buf();
+    let spawned = thread::Builder::new()
+        .name("tgrep-watch-recovery".into())
+        .spawn(move || {
+            while state.indexing.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_millis(200));
+            }
+            // Read, not write: this does exactly what `handle_fs_event` does,
+            // and that runs under the read side. Taking it at all is what
+            // keeps the stamp check and the index update from interleaving
+            // with a flush.
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_files_in(&state, &root, &dirs);
+        });
+    if spawned.is_err() {
+        eprintln!(
+            "[trace] warning: could not start the watcher recovery scan; \
+             files written while subscriptions were being established will \
+             wait for the next reconcile"
+        );
+    }
+}
+
 fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     let dominated_kinds = matches!(
         event.kind,
@@ -2329,11 +2373,22 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         }
 
         if !path.is_file() {
+            // Only for events that can actually introduce a directory. Any
+            // `Modify` would include `Modify(Metadata)`, which a recursive
+            // chmod or a checkout fires once per directory — and each one
+            // would re-walk and re-subscribe that directory's whole subtree
+            // on the single watcher worker, turning a linear operation into
+            // quadratic work. inotify announces a new directory as `Create`
+            // and one moved in as `Modify(Name)`; nothing else can.
+            let introduces_dir = matches!(
+                event.kind,
+                EventKind::Create(_) | EventKind::Modify(notify::event::ModifyKind::Name(_))
+            );
             // `is_real_dir` rather than `is_dir`: the latter follows symlinks,
             // and a link to a directory is not something the walker descends
             // into, so subscribing to and indexing its target would pull in a
             // tree the index never contained — possibly outside `root`.
-            if PER_DIRECTORY_WATCHES && is_real_dir(path) {
+            if PER_DIRECTORY_WATCHES && introduces_dir && is_real_dir(path) {
                 // With non-recursive subscriptions notify will not extend the
                 // watch set for us, so a directory that just appeared — and
                 // anything already inside it — has to be picked up here.
@@ -2371,6 +2426,37 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
         },
         Err(_) => return,
     };
+
+    // The same two rules `walk_file_metadata` applies, and for the same
+    // reason: the walk is authoritative about what belongs in the index, so
+    // anything it rejects must not be added here. Without this a file that
+    // grew past the cap — or an ineligible extension in a directory a relaxed
+    // ignore rule just exposed — would be read whole and indexed, and the next
+    // reconcile would silently delete it again.
+    let eligible = !tgrep_core::walker::is_binary_extension(path)
+        && !state
+            .max_file_size
+            .is_some_and(|limit| current.size > limit);
+    if !eligible {
+        // It may have been eligible when it was last indexed — a file can grow
+        // past the cap. Drop what we hold so the index matches the walk rather
+        // than keeping a stale copy of the smaller version until the reconcile.
+        if state
+            .file_stamps
+            .write()
+            .unwrap()
+            .remove(rel_path)
+            .is_some()
+        {
+            eprintln!("[trace] reindex: dropped {rel_path} (no longer eligible)");
+            state.index.write().unwrap().live.delete_file(rel_path);
+            if let Ok(mut cache) = state.cache.write() {
+                cache.pop(rel_path);
+            }
+        }
+        return;
+    }
+
     if state.file_stamps.read().unwrap().get(rel_path) == Some(&current) {
         return;
     }
@@ -3185,13 +3271,13 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             state.no_require_git,
         );
         let found = matcher.is_some();
-        // These subscriptions are the repository's first, so "newly watched"
-        // is every directory in it. No recovery scan: the startup stale check
-        // runs right after this and does a full walk-versus-index diff, which
-        // is a strict superset of what a recovery scan would find — and doing
-        // it here would stat the entire tree while holding the gate, on the
-        // path a warm start exists to keep fast.
-        let _ = publish_ignore_matcher(state, root, matcher);
+        // "Newly watched" here is every directory in the repository, and the
+        // build's walk ran before any of them were subscribed. Deferred rather
+        // than skipped: the scan waits out `indexing` and then costs one
+        // `metadata` call per file, since the stamps this build just wrote
+        // describe the index exactly.
+        let newly_watched = publish_ignore_matcher(state, root, matcher);
+        spawn_recovery_scan(state, root, newly_watched);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -3284,11 +3370,13 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             state.no_require_git,
         );
         let has_matcher = matcher.is_some();
-        // Same reasoning as the bootstrap publish: this is the cold-start
-        // build, so "newly watched" is the whole tree, `indexing` keeps the
-        // watcher off the index for the rest of the build, and the stale check
-        // that follows reconciles anything written during it.
-        let _ = publish_ignore_matcher(state, root, matcher);
+        // Subscriptions are taken here, partway through the build, so files
+        // written to a directory the walk has already passed are in neither
+        // the build's results nor any event. The scan waits for the build to
+        // finish before looking, because until then the stamps describe
+        // nothing and every file would read as changed.
+        let newly_watched = publish_ignore_matcher(state, root, matcher);
+        spawn_recovery_scan(state, root, newly_watched);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2369,27 +2369,39 @@ fn sweep_removed_files(
     if gone.is_empty() {
         return;
     }
-    eprintln!(
-        "[trace] watcher: dropped {} file(s) removed while subscriptions were \
-         being established",
-        gone.len()
-    );
-    {
-        let mut index = state.index.write().unwrap();
-        for rel in &gone {
-            index.live.delete_file(rel);
+    // Per candidate, under the same lock `reindex_file` takes, and re-checked
+    // against the filesystem rather than against the listing that produced
+    // `gone`. That listing is from earlier in the scan; a file recreated since
+    // then has already had its create event consumed by the watcher, so
+    // deleting it here on the strength of a stale observation would lose it
+    // until the next reconcile — and there is nothing left to replay.
+    //
+    // The lock is what makes the recheck mean anything: without it the file
+    // could be reindexed between the check and the delete, which is the same
+    // bug one instruction later.
+    let mut dropped = 0usize;
+    for rel in &gone {
+        let _reindex = match state.reindex_lock.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        // No-follow: a path that came back as a symlink is still not something
+        // the index should hold, so it stays swept.
+        if std::fs::symlink_metadata(state.root.join(rel)).is_ok_and(|m| m.file_type().is_file()) {
+            continue;
         }
-    }
-    {
-        let mut stamps = state.file_stamps.write().unwrap();
-        for rel in &gone {
-            stamps.remove(rel);
-        }
-    }
-    if let Ok(mut cache) = state.cache.write() {
-        for rel in &gone {
+        state.index.write().unwrap().live.delete_file(rel);
+        state.file_stamps.write().unwrap().remove(rel);
+        if let Ok(mut cache) = state.cache.write() {
             cache.pop(rel);
         }
+        dropped += 1;
+    }
+    if dropped > 0 {
+        eprintln!(
+            "[trace] watcher: dropped {dropped} file(s) removed while subscriptions were \
+             being established"
+        );
     }
 }
 
@@ -3212,13 +3224,53 @@ fn relative_components(root: &Path, path: &Path) -> std::io::Result<Vec<std::ffi
     Ok(components)
 }
 
+/// The outcome of reading a file whose stat'd size has already been approved.
+enum CappedRead {
+    Data(Vec<u8>),
+    /// The file yielded more bytes than the cap allows, whatever its size said.
+    TooLarge,
+    Failed,
+}
+
+/// Reads a file's contents, never pulling in more than one byte past the cap.
+///
+/// The size that qualified this file was stat'd before the read, and appending
+/// between the two is exactly what a log or a build artifact does. An
+/// unbounded read would then hold the whole of it in memory and index it past
+/// the limit the user set. One byte over is enough to prove it no longer
+/// qualifies, and is all that is ever read beyond the limit.
+fn read_within_limit(file: &mut std::fs::File, limit: Option<u64>, capacity: usize) -> CappedRead {
+    use std::io::Read;
+
+    let mut data = Vec::with_capacity(capacity);
+    match limit {
+        Some(limit) => {
+            if file
+                .take(limit.saturating_add(1))
+                .read_to_end(&mut data)
+                .is_err()
+            {
+                return CappedRead::Failed;
+            }
+            if data.len() as u64 > limit {
+                return CappedRead::TooLarge;
+            }
+        }
+        None => {
+            if file.read_to_end(&mut data).is_err() {
+                return CappedRead::Failed;
+            }
+        }
+    }
+    CappedRead::Data(data)
+}
+
 /// Read a file and merge it into the live index, unless its stamp says the
 /// content we already indexed is current.
 ///
 /// The caller must hold `snapshot_gate`: the read, the commit, and the stamp
 /// update have to be atomic with respect to a flush or auto-save.
 fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
-    use std::io::Read;
     use tgrep_core::meta::FileStamp;
 
     // Against other indexers, not against searches. The gate above is held for
@@ -3310,10 +3362,18 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // From the handle, not the path: re-opening here is what would let a
     // symlink take the place of the file we just approved.
     let mut file = file;
-    let mut data = Vec::with_capacity(current.size.min(1 << 20) as usize);
-    if file.read_to_end(&mut data).is_err() {
-        return;
-    }
+    let data = match read_within_limit(
+        &mut file,
+        state.max_file_size,
+        current.size.min(1 << 20) as usize,
+    ) {
+        CappedRead::Data(data) => data,
+        CappedRead::TooLarge => {
+            drop_indexed_file(state, rel_path, "grew past the size limit while being read");
+            return;
+        }
+        CappedRead::Failed => return,
+    };
     let text = tgrep_core::encoding::decode_for_index(&data);
     let is_binary = tgrep_core::trigram::is_binary(&text);
     let per_tri = if is_binary {
@@ -6137,12 +6197,43 @@ mod tests {
             "an unenumerated directory must not tombstone the files under it"
         );
 
-        // And with the listing complete, the same absence is a deletion.
+        // And with the listing complete, the same absence is a deletion — once
+        // the file is actually gone, which the sweep now confirms itself.
+        std::fs::remove_file(&path).unwrap();
         let swept = std::collections::HashSet::from(["d".to_string()]);
         sweep_removed_files(&state, &swept, &present);
         assert!(
             state.index.read().unwrap().live.is_deleted("d/a.rs"),
             "a fully enumerated directory must sweep what it no longer contains"
+        );
+    }
+
+    /// The listing that decides what to sweep is from earlier in the scan. A
+    /// file recreated since then has already had its event consumed, so
+    /// deleting it on that stale evidence loses it until the next reconcile.
+    #[cfg(unix)]
+    #[test]
+    fn the_sweep_does_not_delete_a_file_that_came_back() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+
+        let path = root.join("d").join("a.rs");
+        std::fs::create_dir(root.join("d")).unwrap();
+        std::fs::write(&path, "fn a() {}\n").unwrap();
+        reindex_file(&state, &path, "d/a.rs");
+        assert!(state.index.read().unwrap().live.has_path("d/a.rs"));
+
+        // `d` enumerated cleanly and did not contain `a.rs` at the time — but
+        // it is back on disk by the time the sweep runs.
+        let swept = std::collections::HashSet::from(["d".to_string()]);
+        let present = std::collections::HashSet::new();
+        sweep_removed_files(&state, &swept, &present);
+
+        assert!(
+            !state.index.read().unwrap().live.is_deleted("d/a.rs"),
+            "a file that exists again must not be swept on a stale listing"
         );
     }
 
@@ -6185,6 +6276,70 @@ mod tests {
         assert!(
             state.index.read().unwrap().live.is_deleted("x.rs"),
             "content indexed before the path became a fifo must not stay searchable"
+        );
+    }
+
+    /// The size that qualifies a file is stat'd before its contents are read.
+    /// A file that grows in between must not be read into memory without
+    /// bound, nor indexed past the cap.
+    #[test]
+    fn a_read_stops_one_byte_past_the_cap() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("grew.txt");
+        std::fs::write(&path, "x".repeat(4096)).unwrap();
+
+        // Stat said 16 bytes; the file is 4096 by the time it is read.
+        let mut file = std::fs::File::open(&path).unwrap();
+        assert!(matches!(
+            read_within_limit(&mut file, Some(64), 16),
+            CappedRead::TooLarge
+        ));
+
+        let mut file = std::fs::File::open(&path).unwrap();
+        assert!(
+            matches!(read_within_limit(&mut file, None, 16), CappedRead::Data(d) if d.len() == 4096),
+            "no cap means no bound"
+        );
+
+        std::fs::write(&path, "small").unwrap();
+        let mut file = std::fs::File::open(&path).unwrap();
+        assert!(
+            matches!(read_within_limit(&mut file, Some(64), 5), CappedRead::Data(d) if d == b"small"),
+            "a file within the cap reads whole"
+        );
+
+        // Exactly at the cap is still within it.
+        std::fs::write(&path, "x".repeat(64)).unwrap();
+        let mut file = std::fs::File::open(&path).unwrap();
+        assert!(
+            matches!(read_within_limit(&mut file, Some(64), 64), CappedRead::Data(d) if d.len() == 64)
+        );
+    }
+
+    /// The whole point of the bound: a file past the cap loses what the index
+    /// held for it rather than keeping a stale, smaller copy.
+    #[cfg(unix)]
+    #[test]
+    fn a_file_that_outgrows_the_cap_loses_its_indexed_content() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let mut state = test_server_state(&root, &index_dir);
+        Arc::get_mut(&mut state).unwrap().max_file_size = Some(64);
+
+        let path = root.join("grows.rs");
+        std::fs::write(&path, "fn small_enough() {}\n").unwrap();
+        reindex_file(&state, &path, "grows.rs");
+        assert!(
+            state.index.read().unwrap().live.has_path("grows.rs"),
+            "a file under the cap should index normally"
+        );
+
+        std::fs::write(&path, "x".repeat(4096)).unwrap();
+        reindex_file(&state, &path, "grows.rs");
+        assert!(
+            state.index.read().unwrap().live.is_deleted("grows.rs"),
+            "content past the cap must not stay searchable"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1804,6 +1804,33 @@ impl WatchRegistry {
     /// else, and giving up on the entire tree is exactly the failure mode this
     /// registration exists to avoid.
     fn add_all<'a>(&mut self, desired: impl IntoIterator<Item = &'a PathBuf>) -> Vec<PathBuf> {
+        self.subscribe(desired, false)
+    }
+
+    /// Subscribe to every directory in `dirs`, re-issuing the subscription even
+    /// for ones already recorded as watched.
+    ///
+    /// For directories that have just appeared, where membership in `watched`
+    /// proves nothing. The kernel drops an inotify watch by itself when its
+    /// directory is deleted or moved away, and nothing tells us the descriptor
+    /// is gone — so a path recreated at the same location would look
+    /// subscribed while receiving no events at all. [`Self::add_all`] would
+    /// skip it, and so would every later [`Self::sync`], since the path is in
+    /// `desired` *and* in `watched`: the entry stays poisoned until the server
+    /// restarts. Re-adding is cheap and idempotent (`inotify_add_watch`
+    /// returns the existing descriptor), so the doubt is worth paying for.
+    ///
+    /// Returns only the directories that were not previously recorded, so a
+    /// caller's notion of "newly watched" keeps its meaning.
+    fn resubscribe_all<'a>(&mut self, dirs: impl IntoIterator<Item = &'a PathBuf>) -> Vec<PathBuf> {
+        self.subscribe(dirs, true)
+    }
+
+    fn subscribe<'a>(
+        &mut self,
+        desired: impl IntoIterator<Item = &'a PathBuf>,
+        force: bool,
+    ) -> Vec<PathBuf> {
         let mut added = Vec::new();
         let mut failures = 0;
         // Iterating `desired` and testing membership is deliberate: a
@@ -1811,15 +1838,24 @@ impl WatchRegistry {
         // this runs per newly created directory on repositories where that set
         // is tens of thousands of entries.
         for dir in desired {
-            if self.watched.contains(dir) {
+            let known = self.watched.contains(dir);
+            if known && !force {
                 continue;
             }
             match self.watcher.watch(dir, RecursiveMode::NonRecursive) {
                 Ok(()) => {
-                    self.watched.insert(dir.clone());
-                    added.push(dir.clone());
+                    if !known {
+                        self.watched.insert(dir.clone());
+                        added.push(dir.clone());
+                    }
                 }
                 Err(e) => {
+                    // A forced re-add that fails means the directory is gone
+                    // again; drop the entry so a later attempt can retry it
+                    // rather than trusting a descriptor that does not exist.
+                    if known {
+                        self.watched.remove(dir);
+                    }
                     // One line per call, not per directory: exhausting the
                     // inotify budget fails thousands of these at once.
                     if failures == 0 {
@@ -1837,6 +1873,25 @@ impl WatchRegistry {
             eprintln!("[trace] warning: {failures} directories could not be watched");
         }
         added
+    }
+
+    /// Drop a path that no longer exists from the subscription set.
+    ///
+    /// The kernel has already released the descriptor if the directory was
+    /// deleted; the `unwatch` is for the moved-away case, where it is still
+    /// live and now pointing outside the tree. What matters either way is
+    /// clearing `watched`, so that if the path comes back, it is treated as
+    /// the new directory it is instead of an already-subscribed one.
+    ///
+    /// Cheap by design: one hash lookup per removal event, because deleting a
+    /// tree delivers one event per directory in it and anything proportional
+    /// to the whole watched set would turn that into quadratic work.
+    /// Descendants left behind by a move are pruned by the next
+    /// [`Self::sync`], which no longer finds them under the root.
+    fn forget(&mut self, path: &Path) {
+        if self.watched.remove(path) {
+            let _ = self.watcher.unwatch(path);
+        }
     }
 
     /// Bring the subscription set in line with `desired`, subscribing to
@@ -2054,7 +2109,12 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
             // matters at scale — a monorepo can hold tens of thousands of
             // watched directories, and materialising a union for every newly
             // created directory would be quadratic over a checkout.
-            registry.add_all(level.iter());
+            //
+            // Forced, because these directories have just appeared: a path
+            // recreated where a watched one used to be is still recorded as
+            // watched, but the kernel dropped its descriptor when the original
+            // went away.
+            registry.resubscribe_all(level.iter());
         }
 
         // The registry lock is released before any `read_dir`, so a large
@@ -2236,6 +2296,18 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         let is_remove = matches!(event.kind, EventKind::Remove(_)) || !path.exists();
 
         if is_remove {
+            // A watched directory that disappears takes its descriptor with
+            // it, but not its entry in the registry. Clearing that entry is
+            // what lets the path be subscribed again if it comes back — and
+            // keeps `watched` from accumulating dead paths between syncs.
+            // Done for every removed path rather than only known directories,
+            // since by now there is nothing left to ask what it was; a path
+            // that was never watched is a single failed hash lookup.
+            if PER_DIRECTORY_WATCHES
+                && let Some(registry) = state.watch_registry.lock().unwrap().as_mut()
+            {
+                registry.forget(path);
+            }
             // notify can deliver Remove events for transient/unknown paths
             // (e.g. a build tool's temp file). Suppress the noisy log line
             // for those, but still apply the delete unconditionally — if
@@ -4233,6 +4305,52 @@ mod tests {
         let (added, removed) = registry.sync(&[c.clone()].into_iter().collect());
         assert_eq!((added.len(), removed), (0, 2));
         assert_eq!(registry.watched, [c].into_iter().collect());
+    }
+
+    #[test]
+    fn a_recreated_directory_is_subscribed_again_rather_than_assumed_watched() {
+        // The kernel releases an inotify watch by itself when its directory is
+        // deleted or moved away, and says nothing about it. A path recreated at
+        // the same location therefore *looks* subscribed while receiving no
+        // events — and because it is in `desired` as well as in `watched`, no
+        // later `sync` can tell the difference either. The entry stays poisoned
+        // for the life of the process, so the directory silently stops being
+        // watched forever.
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        std::fs::create_dir(&a).unwrap();
+
+        let watcher = notify::recommended_watcher(|_: notify::Result<Event>| {}).unwrap();
+        let mut registry = WatchRegistry {
+            watcher,
+            watched: std::collections::HashSet::new(),
+        };
+        assert_eq!(registry.add_all(std::slice::from_ref(&a)).len(), 1);
+
+        // What the removal event does. Without it the entry below survives.
+        registry.forget(&a);
+        assert!(
+            !registry.watched.contains(&a),
+            "a removed directory must not be left recorded as watched"
+        );
+        assert_eq!(
+            registry.add_all(std::slice::from_ref(&a)).len(),
+            1,
+            "a directory recreated after removal must be subscribed again"
+        );
+
+        // And the belt-and-braces half: even with the entry still present —
+        // a move away delivers no event for the descendants it takes with it —
+        // a directory that has just appeared gets its subscription re-issued.
+        // Already-known paths are not reported as new, so the recovery scan
+        // does not treat the whole subtree as freshly watched.
+        assert!(
+            registry
+                .resubscribe_all(std::slice::from_ref(&a))
+                .is_empty(),
+            "re-issuing a subscription must not report an existing path as new"
+        );
+        assert!(registry.watched.contains(&a));
     }
 
     #[cfg(unix)]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -6037,7 +6037,12 @@ mod tests {
         // for one is coalesced into it instead of spawning a real rewalk that
         // would race the assertions below.
         state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
-        reindex_files_in(&state, &root, &[root.clone()], SystemTime::UNIX_EPOCH);
+        reindex_files_in(
+            &state,
+            &root,
+            std::slice::from_ref(&root),
+            SystemTime::UNIX_EPOCH,
+        );
 
         assert!(
             state.ignore_rules_dirty.load(Ordering::SeqCst),

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -6104,12 +6104,17 @@ mod tests {
         );
     }
 
-    /// A directory whose listing was only partly enumerated has not proved
-    /// anything about the names it did not yield, so the sweep must not treat
-    /// them as deleted.
+    /// The invariant the incomplete-listing fix relies on: a directory that is
+    /// not in `swept` has proved nothing about the names under it, so the
+    /// sweep must leave them alone.
+    ///
+    /// The wiring above it — withholding a directory whose `read_dir` iterator
+    /// yielded an error — has no test of its own, because a per-entry
+    /// `readdir` failure cannot be induced portably. This pins the half that
+    /// makes withholding sufficient.
     #[cfg(unix)]
     #[test]
-    fn a_directory_that_was_not_fully_enumerated_is_not_swept() {
+    fn sweep_removed_files_only_deletes_from_directories_it_enumerated() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
         let index_dir = root.join(".tgrep");

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -296,6 +296,12 @@ struct ServerState {
     index_total: std::sync::atomic::AtomicU64,
     /// True when file watching is enabled for this server.
     watch_enabled: bool,
+    /// The live watcher and the directories it is subscribed to.
+    ///
+    /// Held here rather than by `run` because the subscription set is not
+    /// fixed: publishing a new ignore matcher renarrows it, and a directory
+    /// created after startup has to be subscribed as it appears.
+    watch_registry: Mutex<Option<WatchRegistry>>,
     /// Directories to exclude from indexing.
     exclude_dirs: Vec<String>,
     /// Disable all source-control ignore files for every server discovery path.
@@ -570,6 +576,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
         watch_enabled: !no_watch,
+        watch_registry: Mutex::new(None),
         exclude_dirs: exclude_dirs.to_vec(),
         no_ignore,
         no_require_git,
@@ -656,14 +663,13 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     }
 
     // Start file watcher (unless --no-watch)
-    let _watcher = if no_watch {
+    if no_watch {
         eprintln!("[trace] file watcher disabled (--no-watch)");
-        None
     } else {
         let watcher_state = Arc::clone(&state);
         let watcher_root = root.clone();
-        start_file_watcher(watcher_state, &watcher_root, watcher_queue_cap)
-    };
+        start_file_watcher(watcher_state, &watcher_root, watcher_queue_cap);
+    }
 
     // Set up graceful shutdown
     let shutdown_index_dir = index_dir.clone();
@@ -744,14 +750,23 @@ fn build_stale_matcher(
     matcher
 }
 
-/// Commit matcher and index semantics together while the stale refresh holds
-/// `snapshot_gate`. `None` is a legitimate matcher when no rules exist.
-fn commit_stale_matcher(
+/// Publish a new ignore matcher and bring everything that depends on it up to
+/// date. `None` is a legitimate matcher when no rules exist.
+///
+/// Callers on the stale path hold `snapshot_gate` for write, which is what
+/// makes the matcher swap and the index decisions around it atomic from the
+/// watcher's point of view.
+fn publish_ignore_matcher(
     state: &ServerState,
+    root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
 ) {
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
+    // New rules mean a different set of directories worth hearing about:
+    // a tightened rule releases the subscriptions under it, and a relaxed
+    // one takes subscriptions for the tree it used to hide.
+    sync_watch_registrations(state, root);
 }
 
 fn handle_connection(stream: TcpStream, state: &ServerState) -> Result<()> {
@@ -1482,11 +1497,7 @@ fn handle_reload(id: Option<serde_json::Value>, state: &ServerState) -> String {
     }
 }
 
-fn start_file_watcher(
-    state: Arc<ServerState>,
-    root: &Path,
-    queue_cap: usize,
-) -> Option<RecommendedWatcher> {
+fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) -> bool {
     use std::sync::mpsc::{RecvTimeoutError, TrySendError};
 
     let root_path = root.to_path_buf();
@@ -1525,19 +1536,46 @@ fn start_file_watcher(
         Ok(w) => w,
         Err(e) => {
             eprintln!("[trace] warning: failed to start file watcher: {e}");
-            return None;
+            return false;
         }
     };
 
-    if let Err(e) = watcher.watch(root, RecursiveMode::Recursive) {
+    // The root is always subscribed. On a whole-subtree backend that single
+    // recursive subscription is the entire watch set; on a per-directory
+    // backend it is the anchor, and `sync_watch_registrations` below adds the
+    // descendants the ignore rules allow.
+    let root_mode = if PER_DIRECTORY_WATCHES {
+        RecursiveMode::NonRecursive
+    } else {
+        RecursiveMode::Recursive
+    };
+    if let Err(e) = watcher.watch(root, root_mode) {
         eprintln!("[trace] warning: failed to watch directory: {e}");
-        return None;
+        return false;
+    }
+
+    *state.watch_registry.lock().unwrap() = Some(WatchRegistry {
+        watcher,
+        watched: std::iter::once(root.to_path_buf()).collect(),
+    });
+
+    // Subscribing to the descendants needs the ignore matcher, and on a warm
+    // start it is still being built on another thread. Skipping the sync here
+    // costs nothing: events are dropped while `gitignore_pending` is set, and
+    // the publish that clears it runs this same sync. Subscribing first and
+    // narrowing afterwards would mean briefly holding exactly the watches this
+    // is meant to avoid — on a repo big enough to exhaust the inotify budget,
+    // long enough to fail.
+    if state.gitignore_pending.load(Ordering::SeqCst) {
+        eprintln!("[trace] watcher subscriptions deferred until the ignore matcher is ready");
+    } else {
+        sync_watch_registrations(&state, root);
     }
 
     let worker_state = Arc::clone(&state);
     let worker_root = root_path;
     let worker_index_dir = state.index_dir.clone();
-    std::thread::Builder::new()
+    if std::thread::Builder::new()
         .name("tgrep-watcher".into())
         .spawn(move || {
             loop {
@@ -1579,14 +1617,19 @@ fn start_file_watcher(
                 }
             }
         })
-        .ok()?;
+        .is_err()
+    {
+        eprintln!("[trace] warning: failed to start the watcher worker thread");
+        *state.watch_registry.lock().unwrap() = None;
+        return false;
+    }
 
     state
         .watcher_active
         .store(true, std::sync::atomic::Ordering::Relaxed);
     eprintln!("[trace] file watcher started");
 
-    Some(watcher)
+    true
 }
 
 /// Decide whether the file watcher should skip a path entirely.
@@ -1618,6 +1661,30 @@ fn should_skip_watcher_path(
     exclude_dirs: &[String],
     gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
 ) -> bool {
+    should_skip_watcher_entry(rel_path, exclude_dirs, gitignore, false)
+}
+
+/// [`should_skip_watcher_path`] for a path known to be a directory.
+///
+/// Two rules read differently for a directory. `--exclude` names apply to the
+/// final segment as well, because the walker drops the whole subtree when the
+/// entry it is looking at *is* the excluded directory. And the gitignore
+/// matcher is told it is matching a directory, so a directory-only rule like
+/// `build/` matches — as a file path, `build` does not.
+fn should_skip_watcher_dir(
+    rel_path: &str,
+    exclude_dirs: &[String],
+    gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
+) -> bool {
+    should_skip_watcher_entry(rel_path, exclude_dirs, gitignore, true)
+}
+
+fn should_skip_watcher_entry(
+    rel_path: &str,
+    exclude_dirs: &[String],
+    gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
+    is_dir: bool,
+) -> bool {
     // Single streaming pass over path components — no Vec allocation
     // on the hot watcher path. The hidden-component check applies to
     // every segment (including the basename); the exclude_dirs check
@@ -1632,23 +1699,21 @@ fn should_skip_watcher_path(
         if seg.starts_with('.') {
             return true;
         }
-        // Ancestor (i.e. not the last segment) — apply exclude_dirs.
-        if segments.peek().is_some()
-            && !exclude_dirs.is_empty()
-            && exclude_dirs.iter().any(|d| d == seg)
-        {
+        // An ancestor is always a directory; the final segment is one only
+        // when the caller says so.
+        let segment_is_dir = segments.peek().is_some() || is_dir;
+        if segment_is_dir && !exclude_dirs.is_empty() && exclude_dirs.iter().any(|d| d == seg) {
             return true;
         }
     }
 
     // Gitignore check (if a matcher is available).
     if let Some(gi) = gitignore {
-        // We don't know whether the path is a dir or a file here — for
-        // the watcher's purposes we treat all events as "file" matches.
-        // Notify usually fires per-file events anyway, and gitignore
-        // rules that target dirs would have already skipped the dir's
-        // contents via `matched_path_or_any_parents`.
-        if gi.is_ignored(Path::new(rel_path), false) {
+        // For a file event we don't know whether the path is a dir, so we
+        // treat it as a file. Notify usually fires per-file events anyway,
+        // and gitignore rules that target dirs would have already skipped
+        // the dir's contents via `matched_path_or_any_parents`.
+        if gi.is_ignored(Path::new(rel_path), is_dir) {
             return true;
         }
     }
@@ -1674,6 +1739,238 @@ fn is_ignore_rules_file(root: &Path, path: &Path) -> bool {
         Some(tgrep_core::gitignore::GITIGNORE_FILENAME)
             | Some(tgrep_core::gitignore::DOT_IGNORE_FILENAME)
     ) || path == root.join(tgrep_core::gitignore::P4IGNORE_FILENAME)
+}
+
+/// Whether this platform's `notify` backend takes one OS subscription per
+/// directory rather than a single recursive one for the whole tree.
+///
+/// inotify has no recursive mode. `RecursiveMode::Recursive` makes notify walk
+/// the tree itself and spend one watch descriptor per directory, so every
+/// ignored directory costs a descriptor from the per-user
+/// `fs.inotify.max_user_watches` budget purely to deliver events we then throw
+/// away. Worse, notify's registration loop propagates the first failure, so a
+/// repo whose ignored build output exhausts the budget makes `watch()` return
+/// an error and the server loses its watcher entirely.
+///
+/// ReadDirectoryChangesW (Windows) and FSEvents (macOS) subscribe once for the
+/// whole subtree, so there is no per-directory registration to withhold. On
+/// those platforms filtering on delivery is the only lever available, and
+/// [`should_skip_watcher_path`] remains it.
+///
+/// Deliberately limited to the backends we can exercise in CI. kqueue and
+/// `PollWatcher` are per-path too, but nothing here builds or tests them.
+const PER_DIRECTORY_WATCHES: bool = cfg!(any(target_os = "linux", target_os = "android"));
+
+/// The watcher plus the set of directories it is currently subscribed to.
+///
+/// Only meaningful when [`PER_DIRECTORY_WATCHES`] is true; elsewhere `watched`
+/// holds just the root, which is subscribed recursively.
+struct WatchRegistry {
+    watcher: RecommendedWatcher,
+    watched: std::collections::HashSet<PathBuf>,
+}
+
+impl WatchRegistry {
+    /// Bring the subscription set in line with `desired`, subscribing to
+    /// directories that are newly relevant and dropping ones that are not.
+    ///
+    /// Returns `(added, removed)`. A single directory that cannot be
+    /// subscribed is reported and skipped rather than failing the sync: the
+    /// watcher is still useful for everything else, and giving up on the whole
+    /// tree is exactly the failure mode this registration exists to avoid.
+    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (usize, usize) {
+        let stale: Vec<PathBuf> = self.watched.difference(desired).cloned().collect();
+        let mut removed = 0;
+        for dir in stale {
+            // Best effort. inotify drops a descriptor by itself when the
+            // directory is deleted, so "not found" is an expected outcome
+            // here, not an error worth reporting.
+            let _ = self.watcher.unwatch(&dir);
+            self.watched.remove(&dir);
+            removed += 1;
+        }
+
+        let missing: Vec<PathBuf> = desired.difference(&self.watched).cloned().collect();
+        let mut added = 0;
+        let mut failures = 0;
+        for dir in missing {
+            match self.watcher.watch(&dir, RecursiveMode::NonRecursive) {
+                Ok(()) => {
+                    self.watched.insert(dir);
+                    added += 1;
+                }
+                Err(e) => {
+                    // One line per sync, not per directory: exhausting the
+                    // inotify budget fails thousands of these at once.
+                    if failures == 0 {
+                        eprintln!(
+                            "[trace] warning: could not watch {}: {e} \
+                             (continuing with the directories that succeeded)",
+                            dir.display()
+                        );
+                    }
+                    failures += 1;
+                }
+            }
+        }
+        if failures > 1 {
+            eprintln!("[trace] warning: {failures} directories could not be watched");
+        }
+        (added, removed)
+    }
+}
+
+/// Every directory at or below `start` whose contents the watcher needs to
+/// hear about.
+///
+/// A per-directory subscription reports the files directly inside it, so the
+/// set is "`start`, plus every descendant directory the indexer would walk
+/// into". Ignored directories are pruned along with their subtrees, which is
+/// the whole point: the tree under `target/` or `node_modules/` is usually
+/// most of the directories in a repo.
+///
+/// `root` is the repository root and is only used to build the relative paths
+/// the ignore rules are written against; `start` is where the walk begins.
+/// They differ when a subtree that appeared at runtime is being subscribed,
+/// and conflating them would match every rule at the wrong anchor.
+///
+/// `start` itself is always included — callers are responsible for not asking
+/// about a directory that is ignored.
+///
+/// Symlinked directories are not descended into, matching the walker (the
+/// `ignore` crate does not follow links by default). That also keeps a
+/// symlink cycle from turning this into an infinite walk.
+fn watchable_dirs(
+    root: &Path,
+    start: &Path,
+    exclude_dirs: &[String],
+    gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
+) -> std::collections::HashSet<PathBuf> {
+    let mut found = std::collections::HashSet::new();
+    found.insert(start.to_path_buf());
+
+    let mut stack = vec![start.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            // An unreadable directory is not a reason to abandon the rest of
+            // the tree; the periodic reconcile is what catches what we miss.
+            continue;
+        };
+        for entry in entries.flatten() {
+            if !entry.file_type().is_ok_and(|t| t.is_dir()) {
+                continue;
+            }
+            let path = entry.path();
+            let Ok(rel) = path.strip_prefix(root) else {
+                continue;
+            };
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            if should_skip_watcher_dir(&rel, exclude_dirs, gitignore) {
+                continue;
+            }
+            stack.push(path.clone());
+            found.insert(path);
+        }
+    }
+    found
+}
+
+/// Recompute the watcher's subscriptions against the ignore rules in force.
+///
+/// Called when the watcher starts and every time the ignore matcher is
+/// published, so relaxing a rule subscribes to the tree it used to hide and
+/// tightening one drops it.
+fn sync_watch_registrations(state: &ServerState, root: &Path) {
+    if !PER_DIRECTORY_WATCHES {
+        return;
+    }
+    let mut registry = state.watch_registry.lock().unwrap();
+    let Some(registry) = registry.as_mut() else {
+        // The watcher has not started yet. It syncs once as it comes up, so
+        // there is nothing to do and nothing to remember.
+        return;
+    };
+
+    let start = Instant::now();
+    let desired = {
+        let gitignore = state.gitignore.read().unwrap();
+        watchable_dirs(root, root, &state.exclude_dirs, gitignore.as_ref())
+    };
+    let total = desired.len();
+    let (added, removed) = registry.sync(&desired);
+    if added > 0 || removed > 0 {
+        eprintln!(
+            "[trace] watcher subscriptions: {total} directories \
+             (+{added}, -{removed}) in {:.1}ms",
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+}
+
+/// Subscribe to a directory that has just appeared, and to anything already
+/// inside it.
+///
+/// Non-recursive subscriptions are not extended by notify — it only auto-adds
+/// watches beneath a watch that was registered as recursive — so a new
+/// directory has to be picked up here or its contents are invisible.
+///
+/// Files that landed between the directory's creation and its subscription
+/// would be missed by definition, so the same pass indexes what it finds.
+/// The caller must already hold `snapshot_gate`.
+fn watch_new_subtree(state: &ServerState, root: &Path, dir: &Path) {
+    let Ok(rel_dir) = dir.strip_prefix(root) else {
+        return;
+    };
+    let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+
+    let desired = {
+        let gitignore = state.gitignore.read().unwrap();
+        // The event that brought us here was filtered with file semantics, so
+        // a `build/`-style rule that only ever matches directories has not
+        // been applied to this path yet. Re-check before subscribing to it.
+        if !rel_dir.is_empty()
+            && should_skip_watcher_dir(&rel_dir, &state.exclude_dirs, gitignore.as_ref())
+        {
+            return;
+        }
+        watchable_dirs(root, dir, &state.exclude_dirs, gitignore.as_ref())
+    };
+
+    {
+        let mut registry = state.watch_registry.lock().unwrap();
+        let Some(registry) = registry.as_mut() else {
+            return;
+        };
+        // A union, not a replacement: `desired` covers only this subtree, and
+        // `sync` would read anything outside it as newly stale and unsubscribe
+        // from the entire rest of the repository.
+        let union: std::collections::HashSet<PathBuf> =
+            registry.watched.union(&desired).cloned().collect();
+        registry.sync(&union);
+    }
+
+    for subdir in &desired {
+        let Ok(entries) = std::fs::read_dir(subdir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if !entry.file_type().is_ok_and(|t| t.is_file()) {
+                continue;
+            }
+            let path = entry.path();
+            let Ok(rel) = path.strip_prefix(root) else {
+                continue;
+            };
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            let skip = {
+                let gitignore = state.gitignore.read().unwrap();
+                should_skip_watcher_path(&rel, &state.exclude_dirs, gitignore.as_ref())
+            };
+            if !skip {
+                reindex_file(state, &path, &rel);
+            }
+        }
+    }
 }
 
 fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
@@ -1713,8 +2010,6 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 }
 
 fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
-    use tgrep_core::meta::FileStamp;
-
     let dominated_kinds = matches!(
         event.kind,
         EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
@@ -1810,65 +2105,82 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         }
 
         if !path.is_file() {
-            continue;
-        }
-
-        // Compute the file's current stamp and skip if it matches what we
-        // last indexed. notify on Windows in particular fires Modify events
-        // for atime/attribute updates, opens, etc. — re-indexing on those
-        // would re-read large files, churn the live overlay, and produce a
-        // misleading "modified" trace for files that didn't actually change.
-        let current = match std::fs::metadata(path) {
-            Ok(m) => FileStamp {
-                mtime: m
-                    .modified()
-                    .ok()
-                    .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0),
-                size: m.len(),
-            },
-            Err(_) => continue,
-        };
-        if state.file_stamps.read().unwrap().get(&rel_path) == Some(&current) {
-            continue;
-        }
-
-        // Read contents and extract trigrams OUTSIDE the index write lock
-        // so a concurrent search (which needs a read lock) is not blocked
-        // on our file I/O and trigram parsing. Windows' SRWLock is
-        // writer-preferring: a single waiting writer here would otherwise
-        // stall every subsequent search request.
-        let data = match std::fs::read(path) {
-            Ok(d) => d,
-            Err(_) => continue,
-        };
-        let text = tgrep_core::encoding::decode_for_index(&data);
-        let is_binary = tgrep_core::trigram::is_binary(&text);
-        let per_tri = if is_binary {
-            None
-        } else {
-            Some(tgrep_core::live::LiveIndex::compute_trigram_masks(&text))
-        };
-
-        eprintln!("[trace] reindex: modified {rel_path}");
-        // gate acquired at the function level — the commit + stamp
-        // update is processed atomically with respect to flush/auto-save.
-        {
-            let mut index = state.index.write().unwrap();
-            match per_tri {
-                Some(per_tri) => index.live.commit_upsert(&rel_path, per_tri),
-                None => index.live.delete_file(&rel_path),
+            if PER_DIRECTORY_WATCHES && path.is_dir() {
+                // With non-recursive subscriptions notify will not extend the
+                // watch set for us, so a directory that just appeared — and
+                // anything already inside it — has to be picked up here.
+                watch_new_subtree(state, root, path);
             }
+            continue;
         }
-        state
-            .file_stamps
-            .write()
-            .unwrap()
-            .insert(rel_path.clone(), current);
-        if let Ok(mut cache) = state.cache.write() {
-            cache.pop(&rel_path);
+
+        reindex_file(state, path, &rel_path);
+    }
+}
+
+/// Read a file and merge it into the live index, unless its stamp says the
+/// content we already indexed is current.
+///
+/// The caller must hold `snapshot_gate`: the read, the commit, and the stamp
+/// update have to be atomic with respect to a flush or auto-save.
+fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
+    use tgrep_core::meta::FileStamp;
+
+    // Compute the file's current stamp and skip if it matches what we
+    // last indexed. notify on Windows in particular fires Modify events
+    // for atime/attribute updates, opens, etc. — re-indexing on those
+    // would re-read large files, churn the live overlay, and produce a
+    // misleading "modified" trace for files that didn't actually change.
+    let current = match std::fs::metadata(path) {
+        Ok(m) => FileStamp {
+            mtime: m
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            size: m.len(),
+        },
+        Err(_) => return,
+    };
+    if state.file_stamps.read().unwrap().get(rel_path) == Some(&current) {
+        return;
+    }
+
+    // Read contents and extract trigrams OUTSIDE the index write lock
+    // so a concurrent search (which needs a read lock) is not blocked
+    // on our file I/O and trigram parsing. Windows' SRWLock is
+    // writer-preferring: a single waiting writer here would otherwise
+    // stall every subsequent search request.
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let text = tgrep_core::encoding::decode_for_index(&data);
+    let is_binary = tgrep_core::trigram::is_binary(&text);
+    let per_tri = if is_binary {
+        None
+    } else {
+        Some(tgrep_core::live::LiveIndex::compute_trigram_masks(&text))
+    };
+
+    eprintln!("[trace] reindex: modified {rel_path}");
+    // Gate held by the caller — the commit + stamp update is processed
+    // atomically with respect to flush/auto-save.
+    {
+        let mut index = state.index.write().unwrap();
+        match per_tri {
+            Some(per_tri) => index.live.commit_upsert(rel_path, per_tri),
+            None => index.live.delete_file(rel_path),
         }
+    }
+    state
+        .file_stamps
+        .write()
+        .unwrap()
+        .insert(rel_path.to_string(), current);
+    if let Ok(mut cache) = state.cache.write() {
+        cache.pop(rel_path);
     }
 }
 
@@ -2369,7 +2681,7 @@ fn background_refresh_stale(
     // this function holds `snapshot_gate` for write across its whole body, and
     // the only reader of `state.gitignore` takes the read side first, so no
     // event can observe the matcher before this function returns either way.
-    commit_stale_matcher(state, build_stale_matcher(state, root, &walk));
+    publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -2607,8 +2919,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             state.no_require_git,
         );
         let found = matcher.is_some();
-        *state.gitignore.write().unwrap() = matcher;
-        state.gitignore_pending.store(false, Ordering::SeqCst);
+        publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -2701,8 +3012,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             state.no_require_git,
         );
         let has_matcher = matcher.is_some();
-        *state.gitignore.write().unwrap() = matcher;
-        state.gitignore_pending.store(false, Ordering::SeqCst);
+        publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -3455,6 +3765,7 @@ mod tests {
             index_progress: std::sync::atomic::AtomicU64::new(0),
             index_total: std::sync::atomic::AtomicU64::new(0),
             watch_enabled: true,
+            watch_registry: Mutex::new(None),
             exclude_dirs: Vec::new(),
             no_ignore: false,
             no_require_git: false,
@@ -3674,6 +3985,160 @@ mod tests {
             &no_exclude,
             Some(&gi)
         ));
+    }
+
+    #[test]
+    fn watchable_dirs_prunes_ignored_and_hidden_subtrees() {
+        // The point of the subscription set: an ignored directory costs one
+        // inotify watch descriptor per directory inside it, so pruning has to
+        // happen before the subtree is walked, not after its events arrive.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        std::fs::write(root.join(".gitignore"), "build/\n").unwrap();
+
+        for dir in [
+            "src",
+            "src/nested",
+            "build",
+            "build/a",
+            "build/a/deep",
+            ".git/objects",
+            "vendor",
+            "vendor/pkg",
+        ] {
+            std::fs::create_dir_all(root.join(dir)).unwrap();
+        }
+
+        let gi = tgrep_core::gitignore::build_matcher(root).expect("matcher should build");
+        let exclude = vec!["vendor".to_string()];
+        let dirs = watchable_dirs(root, root, &exclude, Some(&gi));
+
+        let rel: std::collections::HashSet<String> = dirs
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        // The root itself is always watched, plus the directories the indexer
+        // would descend into.
+        assert!(rel.contains(""), "root must always be watched: {rel:?}");
+        assert!(rel.contains("src"));
+        assert!(rel.contains("src/nested"));
+
+        // A gitignored directory and everything beneath it.
+        assert!(
+            !rel.contains("build"),
+            "gitignored dir was watched: {rel:?}"
+        );
+        assert!(!rel.contains("build/a"));
+        assert!(!rel.contains("build/a/deep"));
+
+        // Hidden directories, which the walker skips too.
+        assert!(!rel.contains(".git"));
+        assert!(!rel.contains(".git/objects"));
+
+        // `--exclude` names prune the directory itself, not just its children.
+        assert!(!rel.contains("vendor"), "excluded dir was watched: {rel:?}");
+        assert!(!rel.contains("vendor/pkg"));
+    }
+
+    #[test]
+    fn watchable_dirs_without_a_matcher_keeps_everything_visible() {
+        // `--no-ignore` publishes no matcher. The subscription set must then
+        // be the whole tree minus hidden paths, matching what the walk indexes;
+        // silently narrowing it would drop events for files that ARE indexed.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("build/a")).unwrap();
+        std::fs::create_dir_all(root.join(".hidden")).unwrap();
+
+        let dirs = watchable_dirs(root, root, &[], None);
+        let rel: std::collections::HashSet<String> = dirs
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        assert!(rel.contains("build"));
+        assert!(rel.contains("build/a"));
+        assert!(!rel.contains(".hidden"));
+    }
+
+    #[test]
+    fn watchable_dirs_anchors_rules_at_the_root_not_the_start_directory() {
+        // A subtree that appears at runtime is walked from itself, but the
+        // ignore rules are written against paths relative to the repository
+        // root. Walking with the subtree as the anchor would test "nested"
+        // against a rule meant for "src/nested" and prune the wrong things.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        std::fs::write(root.join(".gitignore"), "src/fresh/skipped/\n/keep/\n").unwrap();
+
+        for dir in ["src/fresh/skipped", "src/fresh/keep", "src/fresh/kept"] {
+            std::fs::create_dir_all(root.join(dir)).unwrap();
+        }
+
+        let gi = tgrep_core::gitignore::build_matcher(root).expect("matcher should build");
+        let dirs = watchable_dirs(root, &root.join("src/fresh"), &[], Some(&gi));
+        let rel: std::collections::HashSet<String> = dirs
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+
+        assert!(
+            rel.contains("src/fresh"),
+            "start dir must be watched: {rel:?}"
+        );
+        assert!(rel.contains("src/fresh/kept"));
+        assert!(
+            !rel.contains("src/fresh/skipped"),
+            "a root-anchored rule was not applied: {rel:?}"
+        );
+        // `keep/` is anchored at the root, so it must NOT prune
+        // `src/fresh/keep` just because the walk started at `src/fresh`.
+        assert!(
+            rel.contains("src/fresh/keep"),
+            "a root-anchored rule was applied at the wrong depth: {rel:?}"
+        );
+    }
+
+    #[test]
+    fn skip_watcher_dir_applies_directory_semantics() {
+        // A directory-only gitignore rule (`build/`) does not match the path
+        // `build` when it is tested as a file, which is why the subscription
+        // set needs its own dir-aware entry point.
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        std::fs::write(tmp.path().join(".gitignore"), "build/\n").unwrap();
+        let gi = tgrep_core::gitignore::build_matcher(tmp.path()).expect("matcher should build");
+
+        assert!(should_skip_watcher_dir("build", &[], Some(&gi)));
+        assert!(!should_skip_watcher_path("build", &[], Some(&gi)));
+
+        // `--exclude` prunes the named directory itself...
+        let exclude = vec!["target".to_string()];
+        assert!(should_skip_watcher_dir("target", &exclude, None));
+        assert!(should_skip_watcher_dir("src/target", &exclude, None));
+        // ...but a *file* of that name is still indexed, so it must not be
+        // skipped. This is the invariant `should_skip_watcher_path` already
+        // held, and sharing an implementation must not have changed it.
+        assert!(!should_skip_watcher_path("target", &exclude, None));
+        assert!(!should_skip_watcher_path("src/target", &exclude, None));
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1928,6 +1928,34 @@ impl WatchRegistry {
             }
             match self.watcher.watch(dir, RecursiveMode::NonRecursive) {
                 Ok(()) => {
+                    // notify's inotify backend registers without
+                    // `IN_DONT_FOLLOW`, so the descriptor lands on whatever the
+                    // name resolves to at that instant — and the no-follow
+                    // check that qualified this directory happened earlier, in
+                    // the walk. A checkout or a rename can replace it with a
+                    // symlink in between, leaving the descriptor watching an
+                    // inode outside the root while `watched` records an
+                    // in-root name as covered.
+                    //
+                    // Re-checking after the fact catches that: if the name is
+                    // no longer a real directory, the registration is undone
+                    // and the entry is not recorded, so a later `sync` retries
+                    // it rather than treating a poisoned subscription as live.
+                    //
+                    // This narrows the window rather than closing it — notify
+                    // takes a path, not a handle, so a swap that is reverted
+                    // before this check is undetectable through its API. What
+                    // that costs is bounded: it is missed *events* on a real
+                    // directory, which the periodic reconcile picks up, and
+                    // never misplaced content, since `open_within_root`
+                    // establishes containment from the handle it reads.
+                    if !is_real_dir(dir) {
+                        let _ = self.watcher.unwatch(dir);
+                        if known {
+                            self.watched.remove(dir);
+                        }
+                        continue;
+                    }
                     if !known {
                         self.watched.insert(dir.clone());
                         added.push(dir.clone());
@@ -2178,7 +2206,17 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
             continue;
         };
         let mut subdirs: Vec<PathBuf> = Vec::new();
-        for entry in entries.flatten() {
+        // A per-entry error is as much a gap in the evidence as a failed
+        // listing: the name it would have yielded is simply absent from
+        // `present`, and the sweep below would read that as a deletion. The
+        // entry is skipped either way, but the directory then does not get to
+        // claim it was enumerated.
+        let mut listing_complete = true;
+        for entry in entries {
+            let Ok(entry) = entry else {
+                listing_complete = false;
+                continue;
+            };
             let path = entry.path();
             let Ok(rel) = path.strip_prefix(root) else {
                 continue;
@@ -2249,7 +2287,9 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
                 reindex_file(state, &path, &rel);
             }
         }
-        swept.insert(rel_dir);
+        if listing_complete {
+            swept.insert(rel_dir);
+        }
 
         // A directory created in the same window is in neither `dirs` (the
         // walk did not see it) nor any event (its parent's subscription is
@@ -2861,27 +2901,37 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         // it is recognised as ineligible and any content indexed under that
         // path before it became a link is dropped.
         if !path.is_file() {
-            // Only for events that can actually introduce a directory. Any
-            // `Modify` would include `Modify(Metadata)`, which a recursive
-            // chmod or a checkout fires once per directory — and each one
-            // would re-walk and re-subscribe that directory's whole subtree
-            // on the single watcher worker, turning a linear operation into
-            // quadratic work. inotify announces a new directory as `Create`
-            // and one moved in as `Modify(Name)`; nothing else can.
-            let introduces_dir = matches!(
-                event.kind,
-                EventKind::Create(_) | EventKind::Modify(notify::event::ModifyKind::Name(_))
-            );
             // `is_real_dir` rather than `is_dir`: the latter follows symlinks,
             // and a link to a directory is not something the walker descends
             // into, so subscribing to and indexing its target would pull in a
             // tree the index never contained — possibly outside `root`.
-            if PER_DIRECTORY_WATCHES && introduces_dir && is_real_dir(path) {
-                // With non-recursive subscriptions notify will not extend the
-                // watch set for us, so a directory that just appeared — and
-                // anything already inside it — has to be picked up here.
-                watch_new_subtree(state, root, path);
+            if is_real_dir(path) {
+                // Only for events that can actually introduce a directory. Any
+                // `Modify` would include `Modify(Metadata)`, which a recursive
+                // chmod or a checkout fires once per directory — and each one
+                // would re-walk and re-subscribe that directory's whole subtree
+                // on the single watcher worker, turning a linear operation into
+                // quadratic work. inotify announces a new directory as `Create`
+                // and one moved in as `Modify(Name)`; nothing else can.
+                let introduces_dir = matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(notify::event::ModifyKind::Name(_))
+                );
+                if PER_DIRECTORY_WATCHES && introduces_dir {
+                    // With non-recursive subscriptions notify will not extend
+                    // the watch set for us, so a directory that just appeared —
+                    // and anything already inside it — has to be picked up here.
+                    watch_new_subtree(state, root, path);
+                }
+                continue;
             }
+            // Neither a regular file nor a directory: a fifo, a socket, a
+            // device, or a symlink of any kind. An indexed `x.rs` atomically
+            // replaced by one of those is not a removal — `path.exists()` is
+            // still true and inotify may report only the rename destination —
+            // so nothing above catches it, and without this the old contents
+            // stay searchable indefinitely.
+            drop_indexed_file(state, &rel_path, "no longer a regular file");
             continue;
         }
 
@@ -6051,6 +6101,85 @@ mod tests {
         assert!(
             !state.index.read().unwrap().live.has_path("kept.rs"),
             "the scan must abandon rather than index under rules it knows are stale"
+        );
+    }
+
+    /// A directory whose listing was only partly enumerated has not proved
+    /// anything about the names it did not yield, so the sweep must not treat
+    /// them as deleted.
+    #[cfg(unix)]
+    #[test]
+    fn a_directory_that_was_not_fully_enumerated_is_not_swept() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+
+        let path = root.join("d").join("a.rs");
+        std::fs::create_dir(root.join("d")).unwrap();
+        std::fs::write(&path, "fn a() {}\n").unwrap();
+        reindex_file(&state, &path, "d/a.rs");
+        assert!(state.index.read().unwrap().live.has_path("d/a.rs"));
+
+        // What `reindex_files_in` produces when an entry in `d` failed to
+        // enumerate: the file is missing from `present`, and `d` is therefore
+        // withheld from `swept`.
+        let swept = std::collections::HashSet::new();
+        let present = std::collections::HashSet::new();
+        sweep_removed_files(&state, &swept, &present);
+        assert!(
+            !state.index.read().unwrap().live.is_deleted("d/a.rs"),
+            "an unenumerated directory must not tombstone the files under it"
+        );
+
+        // And with the listing complete, the same absence is a deletion.
+        let swept = std::collections::HashSet::from(["d".to_string()]);
+        sweep_removed_files(&state, &swept, &present);
+        assert!(
+            state.index.read().unwrap().live.is_deleted("d/a.rs"),
+            "a fully enumerated directory must sweep what it no longer contains"
+        );
+    }
+
+    /// An indexed file replaced in place by something that is not a regular
+    /// file is not a removal — the path still exists — but its contents are no
+    /// longer there to be found.
+    #[cfg(unix)]
+    #[test]
+    fn a_file_replaced_by_a_fifo_loses_its_indexed_content() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let path = root.join("x.rs");
+        std::fs::write(&path, "fn was_a_real_file() {}\n").unwrap();
+        reindex_file(&state, &path, "x.rs");
+        assert!(state.index.read().unwrap().live.has_path("x.rs"));
+
+        std::fs::remove_file(&path).unwrap();
+        let name = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: `name` is a NUL-terminated path that outlives the call.
+        assert_eq!(unsafe { libc::mkfifo(name.as_ptr(), 0o644) }, 0);
+
+        handle_fs_event(
+            &state,
+            &root,
+            &Event {
+                kind: EventKind::Modify(notify::event::ModifyKind::Name(
+                    notify::event::RenameMode::To,
+                )),
+                paths: vec![path.clone()],
+                attrs: Default::default(),
+            },
+        );
+
+        assert!(
+            state.index.read().unwrap().live.is_deleted("x.rs"),
+            "content indexed before the path became a fifo must not stay searchable"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -838,15 +838,13 @@ type IgnoreStamps = std::collections::HashMap<String, (u64, u64)>;
 /// a source that has become unreadable has stopped contributing the rules the
 /// matcher is enforcing, and that is a change.
 fn ignore_digest_of(path: &Path) -> Option<(u64, u64)> {
-    use std::hash::{Hash, Hasher};
-
-    // The whole file, as the matcher builder reads it. These are rule files:
-    // a few hundred bytes each in practice, and already in the page cache from
-    // the walk that found them.
-    let bytes = std::fs::read(path).ok()?;
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    bytes.hash(&mut hasher);
-    Some((bytes.len() as u64, hasher.finish()))
+    let meta = std::fs::metadata(path).ok()?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|m| m.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map_or(0, |d| d.as_secs());
+    Some((meta.len(), mtime))
 }
 
 /// How far an mtime may lag the write it records.

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -299,6 +299,24 @@ struct ServerState {
     /// until something else forces a rebuild. Keeping the source list lets the
     /// scan test for it directly, at one stat per ignore file per scan.
     ignore_sources: RwLock<Vec<PathBuf>>,
+    /// What the published matcher actually read, per ignore source: the size
+    /// and mtime each file had, keyed by its path relative to `root`.
+    ///
+    /// A pathname is not evidence about contents. An existing `.gitignore` can
+    /// be replaced after the matcher walk by one restored from an archive,
+    /// carrying an mtime older than the scan window — the path is still a known
+    /// source and the mtime still predates the window, so neither test in
+    /// [`changed_ignore_rules_in`] fires and the subtree is indexed under rules
+    /// that were never read. Comparing against what was read closes that.
+    ///
+    /// Also holds an entry for the target of any source reached through a
+    /// symlink, when that target is itself under `root`. Following links is
+    /// what the walker does, so the matcher's contents come from the target —
+    /// but an edit to the target does not touch the link, and no event names a
+    /// path whose basename is `.gitignore`. The target's own entry is what
+    /// lets that event be recognised. A target outside `root` is not watched at
+    /// all, so for those the reconcile stays the backstop.
+    ignore_source_stamps: RwLock<IgnoreStamps>,
     /// Serializes the whole check-read-commit cycle in [`reindex_file`].
     ///
     /// `snapshot_gate` is held for *read* by everything that indexes a file, so
@@ -621,6 +639,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
         ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
         ignore_sources: RwLock::new(Vec::new()),
+        ignore_source_stamps: RwLock::new(IgnoreStamps::new()),
         reindex_lock: Mutex::new(()),
         deferred_events: Mutex::new(Some(std::collections::HashMap::new())),
         index_progress: std::sync::atomic::AtomicU64::new(0),
@@ -800,6 +819,10 @@ fn build_stale_matcher(
     matcher
 }
 
+/// The size and mtime an ignore source had when the matcher read it, keyed by
+/// its path relative to the served root.
+type IgnoreStamps = std::collections::HashMap<String, (u64, Option<SystemTime>)>;
+
 /// The ignore files a matcher was built from, as one list.
 ///
 /// Root-level `p4ignore.ini` is a separate source from the walker's point of
@@ -821,6 +844,42 @@ fn ignore_sources_of(
     sources
 }
 
+/// Stat every source so a later scan can ask whether the file it finds is the
+/// one the matcher read, rather than merely whether something of that name is
+/// there.
+///
+/// A source reached through a symlink gets a second entry under its target's
+/// own relative path, when the target is under `root`. The stat follows links
+/// either way, so both entries describe the contents that were read.
+fn ignore_stamps_of(root: &Path, sources: &[PathBuf]) -> IgnoreStamps {
+    let canonical_root = std::fs::canonicalize(root).ok();
+    let mut stamps = IgnoreStamps::with_capacity(sources.len());
+    let mut record = |path: &Path, base: &Path| {
+        let Ok(rel) = path.strip_prefix(base) else {
+            return;
+        };
+        let rel = rel.to_string_lossy().replace('\\', "/");
+        // Follows links: what matters is the content behind the name.
+        if let Ok(meta) = std::fs::metadata(path) {
+            stamps.insert(rel, (meta.len(), meta.modified().ok()));
+        }
+    };
+    for source in sources {
+        record(source, root);
+        let is_link = std::fs::symlink_metadata(source).is_ok_and(|m| m.file_type().is_symlink());
+        if !is_link {
+            continue;
+        }
+        if let Some(canonical_root) = canonical_root.as_ref()
+            && let Ok(target) = std::fs::canonicalize(source)
+            && target.starts_with(canonical_root)
+        {
+            record(&target, canonical_root);
+        }
+    }
+    stamps
+}
+
 /// Publish a new ignore matcher and bring everything that depends on it up to
 /// date. `None` is a legitimate matcher when no rules exist.
 ///
@@ -834,15 +893,17 @@ fn ignore_sources_of(
 /// them to [`reindex_files_in`] once `state.file_stamps` describes the index
 /// they just published.
 ///
-/// `since` is when the walk that produced `matcher` began, and is only passed
-/// through so the recovery scan can use it. It has to come from the caller: the
-/// subscription walk inside this function starts later, and an ignore file
-/// written between the two would predate a timestamp taken here and be read as
-/// already accounted for by rules that never saw it.
+/// The returned directories must be paired with a timestamp the *caller*
+/// captured before the walk that produced `matcher`, and handed to
+/// [`reindex_files_in`] as its `since`. This function cannot supply it: the
+/// subscription walk below starts later, so an ignore file written between the
+/// caller's walk and this point would predate any timestamp taken here and be
+/// read as already accounted for by rules that never saw it.
 ///
-/// `sources` are the ignore files `matcher` was built from, recorded so a
-/// recovery scan can notice one of them being deleted — an event the mtime
-/// heuristic cannot see, since a deleted file leaves nothing to stat.
+/// `sources` are the ignore files `matcher` was built from. They are recorded
+/// so a recovery scan can notice one being deleted — which no mtime test can
+/// see, a deleted file leaving nothing to stat — and stat'd so it can also
+/// notice one being replaced, which a pathname cannot show.
 #[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
@@ -850,6 +911,7 @@ fn publish_ignore_matcher(
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
     sources: Vec<PathBuf>,
 ) -> Vec<PathBuf> {
+    *state.ignore_source_stamps.write().unwrap() = ignore_stamps_of(root, &sources);
     *state.ignore_sources.write().unwrap() = sources;
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
@@ -2140,7 +2202,8 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
 }
 
 /// The first ignore-rules file in `dirs` that the published matcher did not
-/// read, or that has been edited since `since`.
+/// read, that has been replaced since it did, or that has been edited since
+/// `since`.
 ///
 /// Probing by name rather than inspecting listings, for three reasons. It is
 /// how the walker itself discovers these files, so the two agree by
@@ -2153,13 +2216,22 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
 /// rules before it ever reaches the file that changes them. Answering for the
 /// whole scan up front closes that window across directories as well.
 ///
-/// Two tests, because neither alone is enough. Absence from the published
-/// sources is the exact question — this file did not feed the matcher in force
-/// — and it catches an arrival however old the file says it is, which matters
-/// because `git checkout`, `tar -x` and `rsync -a` all restore mtimes from what
-/// they unpack and would sail past a recency test. The mtime window then covers
-/// what the source list cannot: a file that was already a source and has just
-/// been edited.
+/// Three tests, because none alone is enough.
+///
+/// Absence from the published sources is the exact question for an arrival —
+/// this file did not feed the matcher in force — and it catches one however old
+/// the file says it is, which matters because `git checkout`, `tar -x` and
+/// `rsync -a` all restore mtimes from what they unpack and would sail past a
+/// recency test.
+///
+/// A stamp mismatch answers the same question for a file that was *already* a
+/// source: a pathname proves nothing about contents, and the same archive
+/// restore can swap a source for a different file bearing an older mtime, which
+/// is invisible to both of the other tests.
+///
+/// The mtime window then covers the gap the stamps cannot: they are taken when
+/// the matcher is published, which is after the walk that read these files, so
+/// a write landing between the two is recorded as if it had been read.
 ///
 /// That window is bounded at both ends, not just the near one. On a network
 /// mount whose server clock runs ahead of ours, every recently touched file
@@ -2170,7 +2242,7 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
 fn changed_ignore_rules_in(
     root: &Path,
     dirs: &[PathBuf],
-    known_sources: &std::collections::HashSet<String>,
+    known_sources: &IgnoreStamps,
     since: SystemTime,
 ) -> Option<(String, &'static str)> {
     let mut probed: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
@@ -2191,11 +2263,19 @@ fn changed_ignore_rules_in(
                 continue;
             };
             let rel = rel.to_string_lossy().replace('\\', "/");
-            if !known_sources.contains(&rel) {
+            let Some(read_as) = known_sources.get(&rel) else {
                 return Some((rel, "not a known source"));
+            };
+            // Follows links, matching how the stamp was taken.
+            let Ok(meta) = std::fs::metadata(&candidate) else {
+                continue;
+            };
+            let current = (meta.len(), meta.modified().ok());
+            if current != *read_as {
+                return Some((rel, "not the file the matcher read"));
             }
-            if std::fs::metadata(&candidate)
-                .and_then(|m| m.modified())
+            if meta
+                .modified()
                 .is_ok_and(|m| m >= since && m <= SystemTime::now())
             {
                 return Some((rel, "modified"));
@@ -2230,32 +2310,21 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
     }
     let start = Instant::now();
 
-    // An ignore file that was deleted during the window is invisible to the
-    // per-entry test below — there is no entry left to stat. It is also the
-    // more damaging direction: rules that no longer have a source keep being
-    // enforced, so the subtree they hide stays unsubscribed and unindexed until
-    // an unrelated rebuild happens along. Checking the sources the published
-    // matcher was built from catches it at one stat apiece, once per scan
-    // rather than once per file.
-    //
-    // The same list answers the opposite question for free: an ignore file that
-    // is *not* among the sources is one the published matcher never read.
-    let known_sources: std::collections::HashSet<String> = if state.no_ignore {
-        std::collections::HashSet::new()
+    // An ignore file that was deleted during the window leaves nothing to stat,
+    // so no test over what is on disk can see it. It is also the more damaging
+    // direction: rules that no longer have a source keep being enforced, so the
+    // subtree they hide stays unsubscribed and unindexed until an unrelated
+    // rebuild happens along. Checking the sources the published matcher was
+    // built from catches it at one stat apiece, once per scan.
+    let known_sources: IgnoreStamps = if state.no_ignore {
+        IgnoreStamps::new()
     } else {
-        let (vanished, known) = {
+        let vanished = {
             let sources = state.ignore_sources.read().unwrap();
-            (
-                // `exists` follows links, matching how the walker collected
-                // these — a symlinked source whose target is gone has stopped
-                // contributing rules just as surely as a deleted one.
-                sources.iter().find(|p| !p.exists()).cloned(),
-                sources
-                    .iter()
-                    .filter_map(|p| p.strip_prefix(root).ok())
-                    .map(|rel| rel.to_string_lossy().replace('\\', "/"))
-                    .collect::<std::collections::HashSet<String>>(),
-            )
+            // `exists` follows links, matching how the walker collected these —
+            // a symlinked source whose target is gone has stopped contributing
+            // rules just as surely as a deleted one.
+            sources.iter().find(|p| !p.exists()).cloned()
         };
         if let Some(gone) = vanished {
             state.ignore_rules_dirty.store(true, Ordering::SeqCst);
@@ -2266,7 +2335,7 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
             );
             return;
         }
-        known
+        state.ignore_source_stamps.read().unwrap().clone()
     };
 
     // Before a single file is indexed: an ignore-rules file that landed in this
@@ -2867,11 +2936,29 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         return;
     }
 
-    let ignore_rules_changed = !state.no_ignore
-        && event
-            .paths
-            .iter()
-            .any(|path| is_ignore_rules_file(root, path));
+    // Two ways an event can carry a rules change. The obvious one is a path the
+    // walker would read as a rules file, recognised by name.
+    //
+    // The other is a path the published matcher actually read through a
+    // symlink. `ignore_files_in` uses `Path::is_file`, which follows links, so
+    // a `.gitignore` symlinked to `shared-rules` contributes the *target's*
+    // contents — but editing the target produces an event naming `shared-rules`,
+    // whose basename means nothing to `is_ignore_rules_file`, and touches
+    // nothing whose name does. Recognising the paths that were read, and not
+    // just the names rules usually go by, is what closes that.
+    //
+    // Only targets inside `root` can appear here, because only those are
+    // watched; for one outside, no event arrives at all and the periodic
+    // reconcile remains the backstop.
+    let ignore_rules_changed = !state.no_ignore && {
+        let stamps = state.ignore_source_stamps.read().unwrap();
+        event.paths.iter().any(|path| {
+            is_ignore_rules_file(root, path)
+                || path
+                    .strip_prefix(root)
+                    .is_ok_and(|rel| stamps.contains_key(&rel.to_string_lossy().replace('\\', "/")))
+        })
+    };
     if ignore_rules_changed {
         state.ignore_rules_dirty.store(true, Ordering::SeqCst);
         if state.indexing.load(Ordering::SeqCst) {
@@ -5156,7 +5243,6 @@ mod tests {
     /// A `ServerState` over an empty index, for exercising the stale path
     /// directly. Mirrors the defaults `run` uses with a watcher and ignore
     /// rules enabled, which is the configuration `gitignore_pending` gates.
-    #[cfg(unix)]
     fn test_server_state(root: &Path, index_dir: &Path) -> Arc<ServerState> {
         create_empty_index(index_dir).expect("create empty index");
         let hybrid = HybridIndex::open(index_dir, root).expect("open empty index");
@@ -5175,6 +5261,7 @@ mod tests {
             ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
             ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
             ignore_sources: RwLock::new(Vec::new()),
+            ignore_source_stamps: RwLock::new(IgnoreStamps::new()),
             reindex_lock: Mutex::new(()),
             deferred_events: Mutex::new(Some(std::collections::HashMap::new())),
             index_progress: std::sync::atomic::AtomicU64::new(0),
@@ -6541,6 +6628,96 @@ mod tests {
         assert!(
             !state.index.read().unwrap().live.has_path("a/keep.rs"),
             "nothing may be indexed before every directory has been asked for rules"
+        );
+    }
+
+    /// A path is not evidence about contents. An archive restore can put a
+    /// different `.gitignore` at a path the matcher already read, carrying an
+    /// mtime older than the scan window — known name, untouched by the clock,
+    /// and yet not the file whose rules are being enforced.
+    #[test]
+    fn a_rule_file_swapped_for_an_older_one_is_not_taken_on_faith() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let rules = root.join(".gitignore");
+        std::fs::write(&rules, "nothing-at-all.rs\n").unwrap();
+        std::fs::write(root.join("keep.rs"), "fn keep() {}\n").unwrap();
+        *state.ignore_source_stamps.write().unwrap() =
+            ignore_stamps_of(&root, std::slice::from_ref(&rules));
+        *state.ignore_sources.write().unwrap() = vec![rules.clone()];
+
+        // Far enough ahead that the mtime window cannot fire for anything on
+        // disk: what is left is the question of whether the file is the one
+        // that was read.
+        let since = SystemTime::now() + std::time::Duration::from_secs(3600);
+        state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
+        reindex_files_in(&state, &root, std::slice::from_ref(&root), since);
+        assert!(
+            !state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "the file the matcher read must not be reported as changed"
+        );
+        assert!(
+            state.index.read().unwrap().live.has_path("keep.rs"),
+            "and the scan must get on with its work"
+        );
+
+        // Same path, same age as far as the window is concerned, different
+        // rules.
+        std::fs::write(&rules, "keep.rs\n").unwrap();
+        reindex_files_in(&state, &root, std::slice::from_ref(&root), since);
+        assert!(
+            state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "a source that is no longer the file that was read must schedule a refresh"
+        );
+    }
+
+    /// A `.gitignore` symlinked to `shared-rules` contributes the target's
+    /// contents, because the walker follows links. Editing the target is
+    /// therefore a rules change — but it touches nothing named like one.
+    #[cfg(unix)]
+    #[test]
+    fn an_edit_to_a_symlinked_rule_files_target_schedules_a_refresh() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let target = root.join("shared-rules");
+        std::fs::write(&target, "keep.rs\n").unwrap();
+        let link = root.join(".gitignore");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let stamps = ignore_stamps_of(&root, std::slice::from_ref(&link));
+        assert!(
+            stamps.contains_key("shared-rules"),
+            "the file the rules were actually read from has to be recorded too"
+        );
+        *state.ignore_source_stamps.write().unwrap() = stamps;
+
+        // Stop at the flag: what is being pinned is that the event is
+        // recognised, not what the refresh then does.
+        state.indexing.store(true, Ordering::SeqCst);
+        handle_fs_event(
+            &state,
+            &root,
+            &Event {
+                kind: EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Any,
+                )),
+                paths: vec![target],
+                attrs: Default::default(),
+            },
+        );
+
+        assert!(
+            state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "an edit to the file a rules symlink resolves to is a rules change, \
+             whatever the path is called"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -6316,11 +6316,14 @@ mod tests {
         );
     }
 
-    /// The whole point of the bound: a file past the cap loses what the index
-    /// held for it rather than keeping a stale, smaller copy.
+    /// The size gate is checked against a fresh stat on every visit, so a file
+    /// that outgrew the cap since it was indexed loses what the index holds
+    /// rather than keeping the smaller version until the reconcile. (The
+    /// growth this pins is between visits — growth *during* a read is what
+    /// `read_within_limit` above covers.)
     #[cfg(unix)]
     #[test]
-    fn a_file_that_outgrows_the_cap_loses_its_indexed_content() {
+    fn a_file_that_outgrew_the_cap_between_visits_loses_its_indexed_content() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().to_path_buf();
         let index_dir = root.join(".tgrep");

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -5448,13 +5448,21 @@ mod tests {
         };
         defer_events_during_build(&state, &small);
         assert_eq!(
-            state.deferred_events.lock().unwrap().as_ref().unwrap().len(),
+            state
+                .deferred_events
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .len(),
             1
         );
 
         let flood = Event {
             kind: EventKind::Create(notify::event::CreateKind::Any),
-            paths: (0..200_001).map(|i| root.join(format!("f{i}.rs"))).collect(),
+            paths: (0..100_000)
+                .map(|i| root.join(format!("f{i}.rs")))
+                .collect(),
             attrs: Default::default(),
         };
         defer_events_during_build(&state, &flood);

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -823,6 +823,15 @@ fn build_stale_matcher(
 /// its path relative to the served root.
 type IgnoreStamps = std::collections::HashMap<String, (u64, Option<SystemTime>)>;
 
+/// How far an mtime may lag the write it records.
+///
+/// Two seconds, which covers the coarsest granularity still in use: FAT and
+/// its descendants store modification times in two-second units, HFS+ and
+/// ext3 in whole seconds. Used to widen comparisons against a wall-clock
+/// instant, which has no such rounding, so a write cannot be dated before a
+/// moment it actually followed.
+const MTIME_GRANULARITY: Duration = Duration::from_secs(2);
+
 /// The ignore files a matcher was built from, as one list.
 ///
 /// Root-level `p4ignore.ini` is a separate source from the walker's point of
@@ -2233,18 +2242,27 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
 /// the matcher is published, which is after the walk that read these files, so
 /// a write landing between the two is recorded as if it had been read.
 ///
-/// That window is bounded at both ends, not just the near one. On a network
-/// mount whose server clock runs ahead of ours, every recently touched file
-/// carries a future mtime and would pass a one-sided test — on every scan,
-/// including the one at the end of the refresh this schedules, which walks the
-/// whole repository and then arms the next. Treating a future mtime as skew
-/// rather than as an edit keeps that loop closed.
+/// That window is widened by [`MTIME_GRANULARITY`] at the near end, because
+/// `since` is a wall-clock instant with nanosecond precision and an mtime is
+/// not. HFS+ and ext3 store whole seconds, FAT-derived filesystems two, so a
+/// write that happens after `since` can be stamped before it and read as
+/// historical. Over-triggering costs one rewalk that finds nothing; the slack
+/// is bounded, so a file whose mtime keeps qualifying stops doing so as later
+/// scans take later timestamps.
+///
+/// The far end is bounded too. On a network mount whose server clock runs
+/// ahead of ours, every recently touched file carries a future mtime and would
+/// pass a one-sided test — on every scan, including the one at the end of the
+/// refresh this schedules, which walks the whole repository and then arms the
+/// next. Treating a future mtime as skew rather than as an edit keeps that
+/// loop closed.
 fn changed_ignore_rules_in(
     root: &Path,
     dirs: &[PathBuf],
     known_sources: &IgnoreStamps,
     since: SystemTime,
 ) -> Option<(String, &'static str)> {
+    let since = since.checked_sub(MTIME_GRANULARITY).unwrap_or(since);
     let mut probed: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
     for dir in dirs {
         let mut candidates = vec![
@@ -2472,6 +2490,19 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
 /// eligibility. Filtering `present` would delete entries for files that are
 /// still on disk and were indexed under a laxer configuration.
 ///
+/// Candidates come from everything that can answer a search, not from
+/// `file_stamps` alone. A stamp is not a precondition for being searchable:
+/// `filestamps.json` is optional by design — missing or unreadable leaves the
+/// map empty, and a build that predates a given file's stamp leaves it partial
+/// — while the reader still holds that file's content. Sweeping only what has
+/// a stamp would then delete nothing at all, and the deleted files would keep
+/// answering searches until the hourly reconcile.
+///
+/// Reader paths already hidden by a tombstone are skipped. `delete_file`
+/// tombstones unconditionally and counts a mutation for it, so re-deleting
+/// them would make every scan over a directory with deletions in it look like
+/// fresh churn and pull flushes forward for no reason.
+///
 /// The caller must already hold `snapshot_gate`.
 fn sweep_removed_files(
     state: &ServerState,
@@ -2481,20 +2512,28 @@ fn sweep_removed_files(
     if swept.is_empty() {
         return;
     }
-    // One pass over the stamps rather than a lookup per swept directory: at
-    // startup both sides of this span the whole repository, and anything
-    // proportional to their product would not finish.
-    let gone: Vec<String> = {
-        let stamps = state.file_stamps.read().unwrap();
-        stamps
-            .keys()
-            .filter(|rel| {
-                let parent = rel.rsplit_once('/').map_or("", |(dir, _)| dir);
-                swept.contains(parent) && !present.contains(rel.as_str())
-            })
-            .cloned()
-            .collect()
+    // One pass per source rather than a lookup per swept directory: at startup
+    // both sides of this span the whole repository, and anything proportional
+    // to their product would not finish.
+    let missing = |rel: &str| {
+        let parent = rel.rsplit_once('/').map_or("", |(dir, _)| dir);
+        swept.contains(parent) && !present.contains(rel)
     };
+    let mut gone: std::collections::HashSet<String> = {
+        let stamps = state.file_stamps.read().unwrap();
+        stamps.keys().filter(|rel| missing(rel)).cloned().collect()
+    };
+    {
+        let index = state.index.read().unwrap();
+        gone.extend(index.reader_paths_matching(|rel| missing(rel) && !index.live.is_deleted(rel)));
+        gone.extend(
+            index
+                .live
+                .overlay_paths()
+                .into_iter()
+                .filter(|rel| missing(rel)),
+        );
+    }
     if gone.is_empty() {
         return;
     }
@@ -6718,6 +6757,78 @@ mod tests {
             state.ignore_rules_dirty.load(Ordering::SeqCst),
             "an edit to the file a rules symlink resolves to is a rules change, \
              whatever the path is called"
+        );
+    }
+
+    /// An mtime is not a wall-clock instant. Whole-second (HFS+, ext3) or
+    /// two-second (FAT) granularity can date a write before the moment it
+    /// actually followed, and a source edited between the walk and the
+    /// publication carries a stamp that matches it — so the window is the only
+    /// test left, and it has to allow for the rounding.
+    #[test]
+    fn a_rule_file_stamped_a_second_early_is_still_inside_the_window() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let rules = root.join(".gitignore");
+        std::fs::write(&rules, "nothing-at-all.rs\n").unwrap();
+        *state.ignore_source_stamps.write().unwrap() =
+            ignore_stamps_of(&root, std::slice::from_ref(&rules));
+        *state.ignore_sources.write().unwrap() = vec![rules.clone()];
+        let stamped = std::fs::metadata(&rules).unwrap().modified().unwrap();
+        state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
+
+        // Far outside any rounding: this one really is history.
+        let old = stamped + std::time::Duration::from_secs(3600);
+        reindex_files_in(&state, &root, std::slice::from_ref(&root), old);
+        assert!(
+            !state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "a source last written an hour before the walk is not a change"
+        );
+
+        // Within the granularity of a coarse filesystem's clock: the file may
+        // well have been written after the walk began and been rounded down.
+        let rounded = stamped + std::time::Duration::from_secs(1);
+        reindex_files_in(&state, &root, std::slice::from_ref(&root), rounded);
+        assert!(
+            state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "an mtime that sits just under the window has to be treated as recent"
+        );
+    }
+
+    /// A stamp is not what makes a file searchable — the index is.
+    /// `filestamps.json` is optional, and a partial or absent map used to mean
+    /// the sweep had no candidates and deleted files kept answering searches.
+    #[test]
+    fn the_sweep_drops_a_deleted_file_that_never_had_a_stamp() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let path = root.join("seeded.rs");
+        std::fs::write(&path, "fn seeded() {}\n").unwrap();
+        let gate = state.snapshot_gate.read().unwrap();
+        reindex_file(&state, &path, "seeded.rs");
+        assert!(state.index.read().unwrap().live.has_path("seeded.rs"));
+
+        // Indexed, and searchable, but with nothing in the stamp map to say so
+        // — as after a seed whose stamps could not be read.
+        state.file_stamps.write().unwrap().remove("seeded.rs");
+        std::fs::remove_file(&path).unwrap();
+
+        let swept: std::collections::HashSet<String> = [String::new()].into_iter().collect();
+        sweep_removed_files(&state, &swept, &std::collections::HashSet::new());
+        drop(gate);
+
+        assert!(
+            state.index.read().unwrap().live.is_deleted("seeded.rs"),
+            "a file that is gone from disk must stop answering searches whether or \
+             not it had a stamp"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1771,36 +1771,31 @@ struct WatchRegistry {
 }
 
 impl WatchRegistry {
-    /// Bring the subscription set in line with `desired`, subscribing to
-    /// directories that are newly relevant and dropping ones that are not.
+    /// Subscribe to every directory in `desired` that is not already
+    /// subscribed, leaving existing subscriptions alone.
     ///
-    /// Returns `(added, removed)`. A single directory that cannot be
-    /// subscribed is reported and skipped rather than failing the sync: the
-    /// watcher is still useful for everything else, and giving up on the whole
-    /// tree is exactly the failure mode this registration exists to avoid.
-    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (usize, usize) {
-        let stale: Vec<PathBuf> = self.watched.difference(desired).cloned().collect();
-        let mut removed = 0;
-        for dir in stale {
-            // Best effort. inotify drops a descriptor by itself when the
-            // directory is deleted, so "not found" is an expected outcome
-            // here, not an error worth reporting.
-            let _ = self.watcher.unwatch(&dir);
-            self.watched.remove(&dir);
-            removed += 1;
-        }
-
-        let missing: Vec<PathBuf> = desired.difference(&self.watched).cloned().collect();
+    /// Returns the number added. A single directory that cannot be subscribed
+    /// is reported and skipped rather than failing the whole call: the watcher
+    /// is still useful for everything else, and giving up on the entire tree is
+    /// exactly the failure mode this registration exists to avoid.
+    fn add_all(&mut self, desired: &std::collections::HashSet<PathBuf>) -> usize {
         let mut added = 0;
         let mut failures = 0;
-        for dir in missing {
-            match self.watcher.watch(&dir, RecursiveMode::NonRecursive) {
+        // Iterating `desired` and testing membership is deliberate: a
+        // `difference` would be proportional to the whole watched set, and
+        // this runs per newly created directory on repositories where that set
+        // is tens of thousands of entries.
+        for dir in desired {
+            if self.watched.contains(dir) {
+                continue;
+            }
+            match self.watcher.watch(dir, RecursiveMode::NonRecursive) {
                 Ok(()) => {
-                    self.watched.insert(dir);
+                    self.watched.insert(dir.clone());
                     added += 1;
                 }
                 Err(e) => {
-                    // One line per sync, not per directory: exhausting the
+                    // One line per call, not per directory: exhausting the
                     // inotify budget fails thousands of these at once.
                     if failures == 0 {
                         eprintln!(
@@ -1816,7 +1811,28 @@ impl WatchRegistry {
         if failures > 1 {
             eprintln!("[trace] warning: {failures} directories could not be watched");
         }
-        (added, removed)
+        added
+    }
+
+    /// Bring the subscription set in line with `desired`, subscribing to
+    /// directories that are newly relevant and dropping ones that are not.
+    ///
+    /// Returns `(added, removed)`. Only for a set that describes the whole
+    /// tree — anything absent from `desired` is unsubscribed. To subscribe to
+    /// a subtree without disturbing the rest, use [`Self::add_all`].
+    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (usize, usize) {
+        let stale: Vec<PathBuf> = self.watched.difference(desired).cloned().collect();
+        let mut removed = 0;
+        for dir in stale {
+            // Best effort. inotify drops a descriptor by itself when the
+            // directory is deleted, so "not found" is an expected outcome
+            // here, not an error worth reporting.
+            let _ = self.watcher.unwatch(&dir);
+            self.watched.remove(&dir);
+            removed += 1;
+        }
+
+        (self.add_all(desired), removed)
     }
 }
 
@@ -1941,12 +1957,13 @@ fn watch_new_subtree(state: &ServerState, root: &Path, dir: &Path) {
         let Some(registry) = registry.as_mut() else {
             return;
         };
-        // A union, not a replacement: `desired` covers only this subtree, and
-        // `sync` would read anything outside it as newly stale and unsubscribe
-        // from the entire rest of the repository.
-        let union: std::collections::HashSet<PathBuf> =
-            registry.watched.union(&desired).cloned().collect();
-        registry.sync(&union);
+        // Additive, not a sync: `desired` covers only this subtree, and `sync`
+        // would read everything outside it as stale and unsubscribe from the
+        // entire rest of the repository. Doing this without materialising a
+        // union also matters at scale — a monorepo can hold tens of thousands
+        // of watched directories, and copying that set for every newly created
+        // directory would be quadratic over a checkout or a build.
+        registry.add_all(&desired);
     }
 
     for subdir in &desired {
@@ -3985,6 +4002,46 @@ mod tests {
             &no_exclude,
             Some(&gi)
         ));
+    }
+
+    #[test]
+    fn watch_registry_add_all_is_additive_but_sync_prunes() {
+        // These two must not be confused. `watch_new_subtree` learns only
+        // about the subtree that just appeared, so if it went through `sync`
+        // every directory outside that subtree would look stale and the server
+        // would unsubscribe from the entire rest of the repository — turning a
+        // new folder into a silent, total loss of file watching.
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        let c = tmp.path().join("c");
+        for dir in [&a, &b, &c] {
+            std::fs::create_dir(dir).unwrap();
+        }
+
+        let watcher = notify::recommended_watcher(|_: notify::Result<Event>| {}).unwrap();
+        let mut registry = WatchRegistry {
+            watcher,
+            watched: std::collections::HashSet::new(),
+        };
+
+        let added = registry.add_all(&[a.clone(), b.clone()].into_iter().collect());
+        assert_eq!(added, 2);
+
+        // Adding a subtree leaves existing subscriptions untouched, and
+        // re-adding one already present is a no-op rather than a duplicate.
+        let added = registry.add_all(&[b.clone(), c.clone()].into_iter().collect());
+        assert_eq!(added, 1, "b was already watched and must not be re-added");
+        assert_eq!(
+            registry.watched,
+            [a.clone(), b.clone(), c.clone()].into_iter().collect(),
+            "add_all dropped a subscription outside the set it was given"
+        );
+
+        // `sync`, by contrast, is authoritative over the whole tree.
+        let (added, removed) = registry.sync(&[c.clone()].into_iter().collect());
+        assert_eq!((added, removed), (0, 2));
+        assert_eq!(registry.watched, [c].into_iter().collect());
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -290,6 +290,15 @@ struct ServerState {
     ignore_rules_dirty: std::sync::atomic::AtomicBool,
     /// Ensures a burst of ignore-file events uses at most one refresh worker.
     ignore_refresh_scheduled: std::sync::atomic::AtomicBool,
+    /// The ignore files the published matcher was built from.
+    ///
+    /// A recovery scan can spot an ignore file that *arrived* during its window
+    /// by its mtime, but a deleted one leaves nothing behind to notice. That is
+    /// the more damaging direction: the matcher keeps enforcing rules whose
+    /// source is gone, so an entire subtree stays unsubscribed and unindexed
+    /// until something else forces a rebuild. Keeping the source list lets the
+    /// scan test for it directly, at one stat per ignore file per scan.
+    ignore_sources: RwLock<Vec<PathBuf>>,
     /// Serializes the whole check-read-commit cycle in [`reindex_file`].
     ///
     /// `snapshot_gate` is held for *read* by everything that indexes a file, so
@@ -304,7 +313,8 @@ struct ServerState {
     /// anything but one file's read, and searches do not take it at all.
     reindex_lock: Mutex<()>,
     /// Paths the watcher saw while `indexing` was set, kept so they can be
-    /// replayed once the build publishes.
+    /// replayed once the build publishes, each with whether its original event
+    /// could have introduced a directory.
     ///
     /// Events that arrive during a build cannot be applied — the stamps do not
     /// describe the index yet, so every path would read as changed — but they
@@ -314,12 +324,19 @@ struct ServerState {
     /// back on, so discarding them leaves the change invisible until the hourly
     /// reconcile.
     ///
+    /// The flag has to be carried rather than reconstructed. Replaying
+    /// everything as a create would put every recorded path through
+    /// `watch_new_subtree`, and a recursive `chmod` or a checkout fires a
+    /// metadata-only modify per directory — so a tree that produced no new
+    /// directories at all would be walked and force-resubscribed once per
+    /// recorded path, which is quadratic over a deep checkout.
+    ///
     /// `None` means the buffer overflowed and the paths were dropped; the
     /// replay then falls back to a full stale refresh, which is slower but
     /// complete. Bounded because a build can run for minutes on a large
     /// repository and a checkout or a build tree churning underneath it is
     /// unbounded.
-    deferred_events: Mutex<Option<std::collections::HashSet<PathBuf>>>,
+    deferred_events: Mutex<Option<std::collections::HashMap<PathBuf, bool>>>,
     /// Progress: number of files indexed so far.
     index_progress: std::sync::atomic::AtomicU64,
     /// Total files discovered for indexing.
@@ -603,8 +620,9 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         gitignore_pending: std::sync::atomic::AtomicBool::new(!no_watch && !no_ignore),
         ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
         ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+        ignore_sources: RwLock::new(Vec::new()),
         reindex_lock: Mutex::new(()),
-        deferred_events: Mutex::new(Some(std::collections::HashSet::new())),
+        deferred_events: Mutex::new(Some(std::collections::HashMap::new())),
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
         watch_enabled: !no_watch,
@@ -782,6 +800,27 @@ fn build_stale_matcher(
     matcher
 }
 
+/// The ignore files a matcher was built from, as one list.
+///
+/// Root-level `p4ignore.ini` is a separate source from the walker's point of
+/// view — it is applied as its own filter rather than collected with the
+/// gitignore files — but deleting it invalidates the published rules exactly
+/// the same way, so it belongs in the list.
+fn ignore_sources_of(
+    root: &Path,
+    gitignore_files: &[PathBuf],
+    ignore_files: &[PathBuf],
+) -> Vec<PathBuf> {
+    let mut sources = Vec::with_capacity(gitignore_files.len() + ignore_files.len() + 1);
+    sources.extend_from_slice(gitignore_files);
+    sources.extend_from_slice(ignore_files);
+    let p4 = root.join(tgrep_core::gitignore::P4IGNORE_FILENAME);
+    if p4.is_file() {
+        sources.push(p4);
+    }
+    sources
+}
+
 /// Publish a new ignore matcher and bring everything that depends on it up to
 /// date. `None` is a legitimate matcher when no rules exist.
 ///
@@ -800,12 +839,18 @@ fn build_stale_matcher(
 /// subscription walk inside this function starts later, and an ignore file
 /// written between the two would predate a timestamp taken here and be read as
 /// already accounted for by rules that never saw it.
+///
+/// `sources` are the ignore files `matcher` was built from, recorded so a
+/// recovery scan can notice one of them being deleted — an event the mtime
+/// heuristic cannot see, since a deleted file leaves nothing to stat.
 #[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
     root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
+    sources: Vec<PathBuf>,
 ) -> Vec<PathBuf> {
+    *state.ignore_sources.write().unwrap() = sources;
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
     // New rules mean a different set of directories worth hearing about:
@@ -2078,7 +2123,9 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
 /// is closing. It is only consulted for ignore-rules files, where "did this
 /// arrive after the matcher was decided" cannot be answered from the stamps:
 /// the dot-prefixed ones are hidden, so they are never indexed and never have
-/// one.
+/// one. The opposite case — one that was *deleted* in the window — is handled
+/// separately, from `state.ignore_sources`, since a deleted file leaves nothing
+/// to stat.
 ///
 /// Callers must already hold `snapshot_gate`, and `state.file_stamps` must
 /// already describe the index as published — a merge that replaces the stamps
@@ -2089,6 +2136,30 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
         return;
     }
     let start = Instant::now();
+
+    // An ignore file that was deleted during the window is invisible to the
+    // per-entry mtime test below — there is no entry left to stat. It is also
+    // the more damaging direction: rules that no longer have a source keep
+    // being enforced, so the subtree they hide stays unsubscribed and
+    // unindexed until an unrelated rebuild happens along. Checking the sources
+    // the published matcher was built from catches it at one stat apiece, once
+    // per scan rather than once per file.
+    if !state.no_ignore {
+        let vanished = {
+            let sources = state.ignore_sources.read().unwrap();
+            sources.iter().find(|p| !p.exists()).cloned()
+        };
+        if let Some(gone) = vanished {
+            state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+            schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+            eprintln!(
+                "[trace] watcher: ignore rules source {} disappeared; deferring to a refresh",
+                gone.display()
+            );
+            return;
+        }
+    }
+
     // Directories whose listing succeeded, and the files those listings
     // contained, for the removal sweep at the end. Only files are recorded:
     // stamps describe files, so directory names would just be dead weight on a
@@ -2459,30 +2530,41 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
     });
 }
 
-/// Recheck newly watched directories on a background thread.
-///
 /// Remember the paths in an event that arrived mid-build, for replay once the
-/// build publishes.
+/// build publishes. Returns whether it did — a `false` means the build finished
+/// underneath us and the caller should handle the event normally.
 ///
 /// The event cannot be applied now: until `indexing` clears, `file_stamps` does
 /// not describe the index, so every path would compare as changed and the
 /// watcher would re-read the repository alongside the build already reading it.
 /// It cannot simply be dropped either — see [`ServerState::deferred_events`].
 ///
+/// `indexing` is re-read *under the buffer lock*, and that is what makes the
+/// handoff safe. The caller's own check is only a hint: between it and this
+/// call the build can finish and [`replay_deferred_events`] can swap the buffer
+/// out, and an insert landing after that swap is in a set nothing will ever
+/// look at again. Because the replay cannot swap until `indexing` is false, and
+/// cannot swap without this lock, seeing `indexing` set while holding it proves
+/// the swap has not happened yet.
+///
 /// Capped, and the cap discards the whole set rather than truncating it: a
 /// partial set is indistinguishable from a complete one at replay time, and
 /// silently recovering nine tenths of a checkout is worse than knowing to fall
 /// back on a full refresh.
-fn defer_events_during_build(state: &ServerState, event: &Event) {
+fn defer_events_during_build(state: &ServerState, event: &Event) -> bool {
     /// A checkout of the Linux kernel is ~90k files. Above this the fallback
     /// refresh is cheaper than the replay would be anyway.
     const MAX_DEFERRED: usize = 100_000;
 
     let Ok(mut deferred) = state.deferred_events.lock() else {
-        return;
+        return false;
     };
+    if !state.indexing.load(Ordering::SeqCst) {
+        return false;
+    }
     let Some(paths) = deferred.as_mut() else {
-        return;
+        // Already overflowed, so the fallback refresh will cover this path too.
+        return true;
     };
     if paths.len().saturating_add(event.paths.len()) > MAX_DEFERRED {
         *deferred = None;
@@ -2490,26 +2572,43 @@ fn defer_events_during_build(state: &ServerState, event: &Event) {
             "[trace] warning: too many file changes during the initial index build to replay \
              individually; a full reconcile will run instead"
         );
-        return;
+        return true;
     }
-    paths.extend(event.paths.iter().cloned());
+    // Only these kinds can put a directory somewhere, and only they should
+    // trigger a subtree walk on replay. See `ServerState::deferred_events`.
+    let introduces_dir = matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(notify::event::ModifyKind::Name(_))
+    );
+    for path in &event.paths {
+        // A path seen both ways keeps the stronger claim: a directory that was
+        // created and then chmod'd still needs its subtree picked up.
+        let entry = paths.entry(path.clone()).or_insert(false);
+        *entry |= introduces_dir;
+    }
+    true
 }
 
 /// Apply the events that arrived during the build, now that it has published.
 ///
-/// Replayed as synthetic create events rather than handled directly so they go
-/// through exactly the filtering an ordinary event gets — ignore rules, the
-/// exclude list, the index directory, new-subtree subscription. `Create(Any)`
-/// is the right kind for all of them: `handle_fs_event` decides removal from
-/// whether the path still exists, and modifications and creations take the same
-/// route, so one kind covers arrivals, edits and deletions alike.
+/// Replayed as synthetic events rather than handled directly so they go through
+/// exactly the filtering an ordinary event gets — ignore rules, the exclude
+/// list, the index directory, new-subtree subscription. The kind is
+/// reconstructed from the flag recorded with each path so the directory gate
+/// still holds; beyond that gate, creations and modifications take the same
+/// route, and `handle_fs_event` decides removal from whether the path still
+/// exists, so one kind of each class covers arrivals, edits and deletions
+/// alike.
 ///
 /// The caller must *not* hold `snapshot_gate`; `handle_fs_event` takes it.
 fn replay_deferred_events(state: &Arc<ServerState>, root: &Path) {
     let deferred = match state.deferred_events.lock() {
-        // Leaves `Some(empty)` behind, so anything deferred by a later build
-        // (a reconcile sets `indexing` again) is collected from scratch.
-        Ok(mut guard) => guard.replace(std::collections::HashSet::new()),
+        // Leaves an empty map behind, so anything deferred by a later build
+        // (a reconcile sets `indexing` again) is collected from scratch. The
+        // caller has already waited out `indexing`, and `defer_events_during_
+        // build` re-reads it under this same lock, so nothing can be inserted
+        // into the old map after this point.
+        Ok(mut guard) => guard.replace(std::collections::HashMap::new()),
         Err(_) => return,
     };
     let Some(paths) = deferred else {
@@ -2541,12 +2640,19 @@ fn replay_deferred_events(state: &Arc<ServerState>, root: &Path) {
 
     let start = Instant::now();
     let count = paths.len();
-    for path in paths {
+    for (path, introduces_dir) in paths {
+        let kind = if introduces_dir {
+            EventKind::Create(notify::event::CreateKind::Any)
+        } else {
+            EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Any,
+            ))
+        };
         handle_fs_event(
             state,
             root,
             &Event {
-                kind: EventKind::Create(notify::event::CreateKind::Any),
+                kind,
                 paths: vec![path],
                 attrs: Default::default(),
             },
@@ -2664,8 +2770,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     // progress. The indexer will pick up those files itself — but only for the
     // parts of the tree it has not reached yet, so remember these and replay
     // them once it publishes.
-    if state.indexing.load(Ordering::SeqCst) {
-        defer_events_during_build(state, event);
+    //
+    // The load is a fast path that keeps the mutex out of the common case; the
+    // decision is made under the lock, since the build can finish between the
+    // two and an event deferred after that is never replayed.
+    if state.indexing.load(Ordering::SeqCst) && defer_events_during_build(state, event) {
         return;
     }
 
@@ -2822,6 +2931,37 @@ fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
     }
 }
 
+/// Whether a failure to open a path establishes that it does not belong in the
+/// index, as opposed to merely being unreadable right now.
+///
+/// The distinction decides whether the watcher drops what it has indexed. A
+/// path that is gone, or that cannot be reached without traversing a symlink,
+/// is genuinely ineligible and the entry has to go. A path that is locked,
+/// unreadable, or lost to a descriptor limit is none of those things — dropping
+/// on that would evict live content because a build held the file open for a
+/// moment, and the stale path deliberately keeps unreadable files and retries
+/// them later.
+fn proves_ineligible(error: &std::io::Error) -> bool {
+    use std::io::ErrorKind;
+
+    // `InvalidInput` and `NotADirectory` are what `open_within_root` itself
+    // returns for a path that escapes the root, has a non-literal component, or
+    // runs through something that is not a directory.
+    if matches!(
+        error.kind(),
+        ErrorKind::NotFound | ErrorKind::NotADirectory | ErrorKind::InvalidInput
+    ) {
+        return true;
+    }
+    // A symlink met under `O_NOFOLLOW`, at any level. Not yet a stable
+    // `ErrorKind`, so it has to be read from the raw code.
+    #[cfg(unix)]
+    if error.raw_os_error() == Some(libc::ELOOP) {
+        return true;
+    }
+    false
+}
+
 /// Open a file without following a final symlink, so the handle is the path
 /// itself rather than wherever it points.
 ///
@@ -2898,13 +3038,80 @@ fn open_within_root(root: &Path, path: &Path) -> std::io::Result<std::fs::File> 
     Ok(std::fs::File::from(dir))
 }
 
-/// As above. Windows has no `openat`, so the ancestors are checked by path
-/// instead of by handle: this rejects a symlink or junction that is actually
-/// there, but not one substituted between the check and the open. Closing that
-/// window needs handle-relative opens (`NtCreateFile` with a `RootDirectory`),
-/// which is a great deal of unsafe code for a platform where creating a symlink
-/// needs a privilege the machine does not grant by default.
-#[cfg(not(unix))]
+/// As above. Windows has no `openat`, so containment is established after the
+/// fact instead of during resolution: the file is opened without following a
+/// final reparse point, and the *handle* is then asked where it actually ended
+/// up. Anything that is not under the root's own resolved path is refused.
+///
+/// This is race-free in the way that matters. Checking each ancestor by path
+/// first would only reject a junction that happened to be there at the time of
+/// the check — one substituted between the check and the open would still be
+/// followed. Asking the handle removes the second lookup entirely: whatever the
+/// open resolved through, the answer describes the object we are actually
+/// holding.
+#[cfg(windows)]
+fn open_within_root(root: &Path, path: &Path) -> std::io::Result<std::fs::File> {
+    use std::io::{Error, ErrorKind};
+
+    // Rejects escapes and non-literal components before anything is opened.
+    relative_components(root, path)?;
+    let file = open_no_follow(path)?;
+
+    // The root's own resolved path, since it may itself sit under a junction or
+    // a substituted drive — comparing against the path as given would then
+    // reject every file in the tree. `canonicalize` is the same
+    // `GetFinalPathNameByHandleW` query underneath, so the two agree on
+    // verbatim prefix and casing.
+    let anchor = std::fs::canonicalize(root)?;
+    let opened = final_path_of(&file)?;
+    if !opened.starts_with(&anchor) {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "path resolves outside the served root",
+        ));
+    }
+    Ok(file)
+}
+
+/// Where an open handle actually is, with every reparse point on the way
+/// resolved.
+#[cfg(windows)]
+fn final_path_of(file: &std::fs::File) -> std::io::Result<PathBuf> {
+    use std::os::windows::ffi::OsStringExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_NAME_NORMALIZED, GetFinalPathNameByHandleW, VOLUME_NAME_DOS,
+    };
+
+    let handle = file.as_raw_handle() as isize;
+    let mut buf = vec![0u16; 512];
+    loop {
+        // SAFETY: `handle` is a live file handle borrowed from `file`, and the
+        // buffer's length is passed as its capacity in `u16`s.
+        let needed = unsafe {
+            GetFinalPathNameByHandleW(
+                handle as _,
+                buf.as_mut_ptr(),
+                buf.len() as u32,
+                FILE_NAME_NORMALIZED | VOLUME_NAME_DOS,
+            )
+        };
+        if needed == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // The return value excludes the NUL when it fits and includes it when
+        // it does not, so a value at or past the capacity means "too small".
+        if (needed as usize) < buf.len() {
+            buf.truncate(needed as usize);
+            return Ok(PathBuf::from(std::ffi::OsString::from_wide(&buf)));
+        }
+        buf.resize(needed as usize + 1, 0);
+    }
+}
+
+/// A fallback for platforms that are neither unix nor Windows, where there is
+/// no way to do better than refusing a link that is actually there.
+#[cfg(not(any(unix, windows)))]
 fn open_within_root(root: &Path, path: &Path) -> std::io::Result<std::fs::File> {
     use std::io::{Error, ErrorKind};
 
@@ -2913,8 +3120,6 @@ fn open_within_root(root: &Path, path: &Path) -> std::io::Result<std::fs::File> 
     for component in &components[..components.len() - 1] {
         walked.push(component);
         let meta = std::fs::symlink_metadata(&walked)?;
-        // `is_symlink` covers junctions too: both are reparse points tagged as
-        // name surrogates, which is what std tests for.
         if meta.file_type().is_symlink() {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
@@ -2982,11 +3187,20 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // metadata we judged it by, or put it outside the tree we serve.
     let file = match open_within_root(&state.root, path) {
         Ok(f) => f,
-        Err(_) => {
-            // Includes the ELOOP that a symlink gets on unix. It may still be
-            // a path we indexed before it became one, so fall through to the
-            // drop rather than returning.
+        Err(e) if proves_ineligible(&e) => {
+            // Gone, or not a regular file reachable without traversing a link.
+            // It may still be a path we indexed before it became one, so fall
+            // through to the drop rather than returning.
             drop_indexed_file(state, rel_path, "no longer eligible");
+            return;
+        }
+        Err(_) => {
+            // A permission error, a Windows sharing violation, a descriptor
+            // limit — none of which say anything about whether the file
+            // belongs in the index. Dropping on those would evict live content
+            // because a build held the file open for a moment. The stale path
+            // already treats unreadable files this way, keeping what it has and
+            // retrying later, and the watcher should not disagree with it.
             return;
         }
     };
@@ -3619,7 +3833,12 @@ fn refresh_stale_locked(
     // event can observe the matcher before this function returns either way.
     // The caller's walk started before this publish; its timestamp is what the
     // recovery scan needs, so the one the subscription sync derives is dropped.
-    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
+    *newly_watched = publish_ignore_matcher(
+        state,
+        root,
+        build_stale_matcher(state, root, &walk),
+        ignore_sources_of(root, &walk.gitignore_files, &walk.ignore_files),
+    );
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -3870,7 +4089,12 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         // than skipped: the scan waits out `indexing` and then costs one
         // `metadata` call per file, since the stamps this build just wrote
         // describe the index exactly.
-        newly_watched = publish_ignore_matcher(state, root, matcher);
+        newly_watched = publish_ignore_matcher(
+            state,
+            root,
+            matcher,
+            ignore_sources_of(root, &outcome.gitignore_files, &outcome.ignore_files),
+        );
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -3980,7 +4204,12 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         // the build's results nor any event. The scan waits for the build to
         // finish before looking, because until then the stamps describe
         // nothing and every file would read as changed.
-        newly_watched = publish_ignore_matcher(state, root, matcher);
+        newly_watched = publish_ignore_matcher(
+            state,
+            root,
+            matcher,
+            ignore_sources_of(root, &walk.gitignore_files, &walk.ignore_files),
+        );
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -4748,8 +4977,9 @@ mod tests {
             gitignore_pending: std::sync::atomic::AtomicBool::new(true),
             ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
             ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+            ignore_sources: RwLock::new(Vec::new()),
             reindex_lock: Mutex::new(()),
-            deferred_events: Mutex::new(Some(std::collections::HashSet::new())),
+            deferred_events: Mutex::new(Some(std::collections::HashMap::new())),
             index_progress: std::sync::atomic::AtomicU64::new(0),
             index_total: std::sync::atomic::AtomicU64::new(0),
             watch_enabled: true,
@@ -5611,13 +5841,16 @@ mod tests {
         let root = tmp.path().to_path_buf();
         let index_dir = root.join(".tgrep");
         let state = test_server_state(&root, &index_dir);
+        // The function only defers while a build is running; it now reports
+        // back so the caller can handle an event that arrived after one ended.
+        state.indexing.store(true, Ordering::SeqCst);
 
         let small = Event {
             kind: EventKind::Create(notify::event::CreateKind::Any),
             paths: vec![root.join("a.rs")],
             attrs: Default::default(),
         };
-        defer_events_during_build(&state, &small);
+        assert!(defer_events_during_build(&state, &small));
         assert_eq!(
             state
                 .deferred_events
@@ -5636,14 +5869,14 @@ mod tests {
                 .collect(),
             attrs: Default::default(),
         };
-        defer_events_during_build(&state, &flood);
+        assert!(defer_events_during_build(&state, &flood));
         assert!(
             state.deferred_events.lock().unwrap().is_none(),
             "an overflowing burst must mark the buffer unusable, not truncate it"
         );
 
         // And stays given up on, rather than resuming a partial record.
-        defer_events_during_build(&state, &small);
+        assert!(defer_events_during_build(&state, &small));
         assert!(state.deferred_events.lock().unwrap().is_none());
     }
 
@@ -5694,6 +5927,125 @@ mod tests {
                 .as_ref()
                 .is_some_and(|p| p.is_empty()),
             "the buffer must be drained, and left usable for the next build"
+        );
+    }
+
+    /// A metadata-only change to a directory is not a claim that anything new
+    /// is under it. Replaying every deferred path as a creation would turn a
+    /// recursive `chmod` during a build into one subtree walk per directory.
+    #[cfg(unix)]
+    #[test]
+    fn a_deferred_metadata_change_does_not_replay_as_a_subtree_arrival() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let dir = root.join("vendor");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("deep.rs"), "fn deep() {}\n").unwrap();
+
+        state.indexing.store(true, Ordering::SeqCst);
+        handle_fs_event(
+            &state,
+            &root,
+            &Event {
+                kind: EventKind::Modify(notify::event::ModifyKind::Metadata(
+                    notify::event::MetadataKind::Permissions,
+                )),
+                paths: vec![dir.clone()],
+                attrs: Default::default(),
+            },
+        );
+        assert_eq!(
+            state
+                .deferred_events
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .get(&dir),
+            Some(&false),
+            "a metadata modify must not be recorded as introducing a directory"
+        );
+
+        state.indexing.store(false, Ordering::SeqCst);
+        replay_deferred_events(&state, &root);
+
+        // The replay reconstructs a modify, which stops at the directory gate.
+        // Had it reconstructed a create, `watch_new_subtree` would have walked
+        // in and indexed the file below.
+        assert!(
+            !state.index.read().unwrap().live.has_path("vendor/deep.rs"),
+            "a metadata modify must not trigger a subtree walk on replay"
+        );
+    }
+
+    /// A file that cannot be opened right now is not a file that stopped
+    /// belonging in the index. Evicting on a transient error would drop live
+    /// content because something else held the file open for a moment.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_file_keeps_its_indexed_content() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let path = root.join("locked.rs");
+        std::fs::write(&path, "fn readable() {}\n").unwrap();
+        reindex_file(&state, &path, "locked.rs");
+        assert!(state.index.read().unwrap().live.has_path("locked.rs"));
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::File::open(&path).is_ok() {
+            // Running as root, where the mode is advisory. Nothing to test.
+            return;
+        }
+        reindex_file(&state, &path, "locked.rs");
+
+        assert!(
+            !state.index.read().unwrap().live.is_deleted("locked.rs"),
+            "an unreadable file must keep what was already indexed for it"
+        );
+    }
+
+    /// Deleting an ignore file is invisible to a scan that looks for *arrivals*
+    /// by mtime, and leaves rules in force whose source is gone — so the
+    /// published sources are checked directly.
+    #[cfg(unix)]
+    #[test]
+    fn a_recovery_scan_notices_an_ignore_file_that_was_deleted() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        // Published as a source, then removed behind the matcher's back.
+        let rules = root.join(".gitignore");
+        std::fs::write(&rules, "build/\n").unwrap();
+        *state.ignore_sources.write().unwrap() = vec![rules.clone()];
+        std::fs::remove_file(&rules).unwrap();
+
+        std::fs::write(root.join("kept.rs"), "fn kept() {}\n").unwrap();
+        // Pretend a refresh worker is already running, so the scan's request
+        // for one is coalesced into it instead of spawning a real rewalk that
+        // would race the assertions below.
+        state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
+        reindex_files_in(&state, &root, &[root.clone()], SystemTime::UNIX_EPOCH);
+
+        assert!(
+            state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "a vanished ignore source must schedule a refresh"
+        );
+        assert!(
+            !state.index.read().unwrap().live.has_path("kept.rs"),
+            "the scan must abandon rather than index under rules it knows are stale"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -756,17 +756,24 @@ fn build_stale_matcher(
 /// Callers on the stale path hold `snapshot_gate` for write, which is what
 /// makes the matcher swap and the index decisions around it atomic from the
 /// watcher's point of view.
+///
+/// Returns the directories that were newly subscribed to as a result. Those
+/// were unwatched while the caller's walk ran, so anything written to them in
+/// that window produced no event and appears in no walk result. Callers pass
+/// the list to [`reindex_files_in`] once `state.file_stamps` describes the
+/// index they just published.
+#[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
     root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
-) {
+) -> Vec<PathBuf> {
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
     // New rules mean a different set of directories worth hearing about:
     // a tightened rule releases the subscriptions under it, and a relaxed
     // one takes subscriptions for the tree it used to hide.
-    sync_watch_registrations(state, root);
+    sync_watch_registrations(state, root)
 }
 
 fn handle_connection(stream: TcpStream, state: &ServerState) -> Result<()> {
@@ -1569,7 +1576,13 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
     if state.gitignore_pending.load(Ordering::SeqCst) {
         eprintln!("[trace] watcher subscriptions deferred until the ignore matcher is ready");
     } else {
-        sync_watch_registrations(&state, root);
+        // The newly watched directories are deliberately not rechecked here.
+        // This is every directory in the repository, the index was built or
+        // opened moments ago, and the stale check that follows startup
+        // reconciles the same drift while holding `snapshot_gate` — which this
+        // path does not hold and must not take, since the watcher has to be
+        // receiving events before that check runs.
+        let _ = sync_watch_registrations(&state, root);
     }
 
     let worker_state = Arc::clone(&state);
@@ -1761,6 +1774,17 @@ fn is_ignore_rules_file(root: &Path, path: &Path) -> bool {
 /// `PollWatcher` are per-path too, but nothing here builds or tests them.
 const PER_DIRECTORY_WATCHES: bool = cfg!(any(target_os = "linux", target_os = "android"));
 
+/// Whether `path` is a directory in its own right rather than a symlink to one.
+///
+/// [`Path::is_dir`] follows links, so it answers "does this lead to a
+/// directory", which is the wrong question here: the walker does not follow
+/// symlinks, so a symlinked directory is not part of the indexed tree. Treating
+/// one as a directory would subscribe to and index its target — possibly a tree
+/// outside `root` entirely, and possibly a cycle.
+fn is_real_dir(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir())
+}
+
 /// The watcher plus the set of directories it is currently subscribed to.
 ///
 /// Only meaningful when [`PER_DIRECTORY_WATCHES`] is true; elsewhere `watched`
@@ -1774,12 +1798,13 @@ impl WatchRegistry {
     /// Subscribe to every directory in `desired` that is not already
     /// subscribed, leaving existing subscriptions alone.
     ///
-    /// Returns the number added. A single directory that cannot be subscribed
-    /// is reported and skipped rather than failing the whole call: the watcher
-    /// is still useful for everything else, and giving up on the entire tree is
-    /// exactly the failure mode this registration exists to avoid.
-    fn add_all(&mut self, desired: &std::collections::HashSet<PathBuf>) -> usize {
-        let mut added = 0;
+    /// Returns the directories that were newly subscribed to. A single
+    /// directory that cannot be subscribed is reported and skipped rather than
+    /// failing the whole call: the watcher is still useful for everything
+    /// else, and giving up on the entire tree is exactly the failure mode this
+    /// registration exists to avoid.
+    fn add_all<'a>(&mut self, desired: impl IntoIterator<Item = &'a PathBuf>) -> Vec<PathBuf> {
+        let mut added = Vec::new();
         let mut failures = 0;
         // Iterating `desired` and testing membership is deliberate: a
         // `difference` would be proportional to the whole watched set, and
@@ -1792,7 +1817,7 @@ impl WatchRegistry {
             match self.watcher.watch(dir, RecursiveMode::NonRecursive) {
                 Ok(()) => {
                     self.watched.insert(dir.clone());
-                    added += 1;
+                    added.push(dir.clone());
                 }
                 Err(e) => {
                     // One line per call, not per directory: exhausting the
@@ -1820,7 +1845,7 @@ impl WatchRegistry {
     /// Returns `(added, removed)`. Only for a set that describes the whole
     /// tree — anything absent from `desired` is unsubscribed. To subscribe to
     /// a subtree without disturbing the rest, use [`Self::add_all`].
-    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (usize, usize) {
+    fn sync(&mut self, desired: &std::collections::HashSet<PathBuf>) -> (Vec<PathBuf>, usize) {
         let stale: Vec<PathBuf> = self.watched.difference(desired).cloned().collect();
         let mut removed = 0;
         for dir in stale {
@@ -1896,15 +1921,21 @@ fn watchable_dirs(
 /// Called when the watcher starts and every time the ignore matcher is
 /// published, so relaxing a rule subscribes to the tree it used to hide and
 /// tightening one drops it.
-fn sync_watch_registrations(state: &ServerState, root: &Path) {
+///
+/// Returns the directories that were newly subscribed to. Until a directory is
+/// subscribed it cannot report anything, so a file written to one of these
+/// between the caller's walk and this call is in neither the walk's results nor
+/// any event. The caller is expected to hand the list to
+/// [`reindex_files_in`] once its own bookkeeping is settled.
+fn sync_watch_registrations(state: &ServerState, root: &Path) -> Vec<PathBuf> {
     if !PER_DIRECTORY_WATCHES {
-        return;
+        return Vec::new();
     }
     let mut registry = state.watch_registry.lock().unwrap();
     let Some(registry) = registry.as_mut() else {
         // The watcher has not started yet. It syncs once as it comes up, so
         // there is nothing to do and nothing to remember.
-        return;
+        return Vec::new();
     };
 
     let start = Instant::now();
@@ -1914,60 +1945,34 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) {
     };
     let total = desired.len();
     let (added, removed) = registry.sync(&desired);
-    if added > 0 || removed > 0 {
+    if !added.is_empty() || removed > 0 {
         eprintln!(
             "[trace] watcher subscriptions: {total} directories \
-             (+{added}, -{removed}) in {:.1}ms",
+             (+{}, -{removed}) in {:.1}ms",
+            added.len(),
             start.elapsed().as_secs_f64() * 1000.0
         );
     }
+    added
 }
 
-/// Subscribe to a directory that has just appeared, and to anything already
-/// inside it.
+/// Re-check the files directly inside `dirs`, indexing the ones that changed.
 ///
-/// Non-recursive subscriptions are not extended by notify — it only auto-adds
-/// watches beneath a watch that was registered as recursive — so a new
-/// directory has to be picked up here or its contents are invisible.
+/// Used to close the gap between a walk and the subscriptions that follow it:
+/// [`reindex_file`] compares stamps first, so for a tree that did not change
+/// under us this costs one `metadata` call per file and indexes nothing.
 ///
-/// Files that landed between the directory's creation and its subscription
-/// would be missed by definition, so the same pass indexes what it finds.
-/// The caller must already hold `snapshot_gate`.
-fn watch_new_subtree(state: &ServerState, root: &Path, dir: &Path) {
-    let Ok(rel_dir) = dir.strip_prefix(root) else {
+/// Callers must already hold `snapshot_gate`, and `state.file_stamps` must
+/// already describe the index as published — a merge that replaces the stamps
+/// afterwards would both discard what this records and make every file here
+/// look changed.
+fn reindex_files_in(state: &ServerState, root: &Path, dirs: &[PathBuf]) {
+    if dirs.is_empty() {
         return;
-    };
-    let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
-
-    let desired = {
-        let gitignore = state.gitignore.read().unwrap();
-        // The event that brought us here was filtered with file semantics, so
-        // a `build/`-style rule that only ever matches directories has not
-        // been applied to this path yet. Re-check before subscribing to it.
-        if !rel_dir.is_empty()
-            && should_skip_watcher_dir(&rel_dir, &state.exclude_dirs, gitignore.as_ref())
-        {
-            return;
-        }
-        watchable_dirs(root, dir, &state.exclude_dirs, gitignore.as_ref())
-    };
-
-    {
-        let mut registry = state.watch_registry.lock().unwrap();
-        let Some(registry) = registry.as_mut() else {
-            return;
-        };
-        // Additive, not a sync: `desired` covers only this subtree, and `sync`
-        // would read everything outside it as stale and unsubscribe from the
-        // entire rest of the repository. Doing this without materialising a
-        // union also matters at scale — a monorepo can hold tens of thousands
-        // of watched directories, and copying that set for every newly created
-        // directory would be quadratic over a checkout or a build.
-        registry.add_all(&desired);
     }
-
-    for subdir in &desired {
-        let Ok(entries) = std::fs::read_dir(subdir) else {
+    let start = Instant::now();
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
             continue;
         };
         for entry in entries.flatten() {
@@ -1987,6 +1992,136 @@ fn watch_new_subtree(state: &ServerState, root: &Path, dir: &Path) {
                 reindex_file(state, &path, &rel);
             }
         }
+    }
+    eprintln!(
+        "[trace] watcher: rechecked {} newly watched directories in {:.1}ms",
+        dirs.len(),
+        start.elapsed().as_secs_f64() * 1000.0
+    );
+}
+
+/// Subscribe to a directory that has just appeared, and to anything already
+/// inside it.
+///
+/// Non-recursive subscriptions are not extended by notify — it only auto-adds
+/// watches beneath a watch that was registered as recursive — so a new
+/// directory has to be picked up here or its contents are invisible.
+///
+/// Files that landed between the directory's creation and its subscription
+/// would be missed by definition, so the same pass indexes what it finds.
+/// The caller must already hold `snapshot_gate`.
+///
+/// The descent subscribes to each level *before* reading it. Reading first
+/// leaves a window in which a child created in between is in neither place:
+/// not in what this pass enumerates, and not yet able to report itself. That
+/// window is small but it is exactly the one a checkout or a build fills, and
+/// anything lost in it stays invisible until the hourly reconcile.
+fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
+    // `is_dir` follows symlinks; the walker does not. Refuse a symlinked
+    // directory here so we never subscribe to, or index, a tree the indexer
+    // would not have walked into.
+    if !is_real_dir(dir) {
+        return;
+    }
+    let Ok(rel_dir) = dir.strip_prefix(root) else {
+        return;
+    };
+    let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+    // The event that brought us here was filtered with file semantics, so a
+    // `build/`-style rule that only ever matches directories has not been
+    // applied to this path yet. Re-check before subscribing to it.
+    if !rel_dir.is_empty() {
+        let gitignore = state.gitignore.read().unwrap();
+        if should_skip_watcher_dir(&rel_dir, &state.exclude_dirs, gitignore.as_ref()) {
+            return;
+        }
+    }
+
+    let mut level = vec![dir.to_path_buf()];
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    let mut files: Vec<(PathBuf, String)> = Vec::new();
+    let mut found_ignore_rules = false;
+
+    while !level.is_empty() {
+        {
+            let mut registry = state.watch_registry.lock().unwrap();
+            let Some(registry) = registry.as_mut() else {
+                return;
+            };
+            // Additive, not a sync: this covers only the new subtree, and
+            // `sync` would read everything outside it as stale and unsubscribe
+            // from the entire rest of the repository. Staying additive also
+            // matters at scale — a monorepo can hold tens of thousands of
+            // watched directories, and materialising a union for every newly
+            // created directory would be quadratic over a checkout.
+            registry.add_all(level.iter());
+        }
+
+        // The registry lock is released before any `read_dir`, so a large
+        // subtree does not hold it across the I/O for a whole level.
+        let mut next = Vec::new();
+        for subdir in level.drain(..) {
+            if !seen.insert(subdir.clone()) {
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&subdir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                let path = entry.path();
+                let Ok(rel) = path.strip_prefix(root) else {
+                    continue;
+                };
+                let rel = rel.to_string_lossy().replace('\\', "/");
+                // `DirEntry::file_type` does not follow symlinks, so a
+                // symlinked directory is neither descended into nor indexed.
+                if file_type.is_dir() {
+                    let skip = {
+                        let gitignore = state.gitignore.read().unwrap();
+                        should_skip_watcher_dir(&rel, &state.exclude_dirs, gitignore.as_ref())
+                    };
+                    if !skip {
+                        next.push(path);
+                    }
+                } else if file_type.is_file() {
+                    // A subtree that arrives whole — a clone, a `mv`, a branch
+                    // switch — can carry its own ignore rules. Those files are
+                    // dot-prefixed, so the scan below would silently drop them
+                    // and index the rest of the subtree against rules that do
+                    // not know about them.
+                    if !state.no_ignore && is_ignore_rules_file(root, &path) {
+                        found_ignore_rules = true;
+                        continue;
+                    }
+                    let skip = {
+                        let gitignore = state.gitignore.read().unwrap();
+                        should_skip_watcher_path(&rel, &state.exclude_dirs, gitignore.as_ref())
+                    };
+                    if !skip {
+                        files.push((path, rel));
+                    }
+                }
+            }
+        }
+        level = next;
+    }
+
+    if found_ignore_rules {
+        // Indexing now would apply the wrong rules to the whole subtree, and
+        // anything wrongly indexed would stay until something touched it
+        // again. The refresh rewalks and republishes, which covers these files
+        // correctly; it runs on its own thread and takes `snapshot_gate`
+        // there, so scheduling it while we hold the gate is safe.
+        state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+        schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+        return;
+    }
+
+    for (path, rel) in &files {
+        reindex_file(state, path, rel);
     }
 }
 
@@ -2122,7 +2257,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         }
 
         if !path.is_file() {
-            if PER_DIRECTORY_WATCHES && path.is_dir() {
+            // `is_real_dir` rather than `is_dir`: the latter follows symlinks,
+            // and a link to a directory is not something the walker descends
+            // into, so subscribing to and indexing its target would pull in a
+            // tree the index never contained — possibly outside `root`.
+            if PER_DIRECTORY_WATCHES && is_real_dir(path) {
                 // With non-recursive subscriptions notify will not extend the
                 // watch set for us, so a directory that just appeared — and
                 // anything already inside it — has to be picked up here.
@@ -2655,19 +2794,57 @@ fn stamps_for_indexed(
         .collect()
 }
 
+/// Rebuild the ignore matcher and reconcile the index against the filesystem.
+///
+/// Returns whether the index can be trusted afterwards. A `false` means the
+/// walk or the merge failed and the stamps are not describing the index.
 fn background_refresh_stale(
     state: &Arc<ServerState>,
     root: &Path,
     index_dir: &Path,
     compare_index_membership: bool,
 ) -> bool {
+    let _refresh = state.stale_refresh_lock.lock().unwrap();
+    // Keep watcher/auto-save mutations out for the complete walk → matcher →
+    // merge → recovery cycle. Search queries do not take this gate and remain
+    // available. Held here rather than inside so the recovery scan below is
+    // still covered by it.
+    let _gate = state.snapshot_gate.write().unwrap();
+
+    let mut newly_watched = Vec::new();
+    let ok = refresh_stale_locked(
+        state,
+        root,
+        index_dir,
+        compare_index_membership,
+        &mut newly_watched,
+    );
+
+    // Directories that were not subscribed while the walk ran could not report
+    // a write, and the walk may have passed them before it happened, so a file
+    // created in that window is in neither place. Recheck them now that the
+    // subscriptions exist.
+    //
+    // Only on success, and only here at the end: a failed walk or merge leaves
+    // `file_stamps` describing something other than the published index, and
+    // `stream_merge_stale_changes` replaces the stamps wholesale, so scanning
+    // any earlier would both be discarded and re-read every changed file.
+    if ok {
+        reindex_files_in(state, root, &newly_watched);
+    }
+    ok
+}
+
+fn refresh_stale_locked(
+    state: &Arc<ServerState>,
+    root: &Path,
+    index_dir: &Path,
+    compare_index_membership: bool,
+    newly_watched: &mut Vec<PathBuf>,
+) -> bool {
     use tgrep_core::meta;
     use tgrep_core::walker;
 
-    let _refresh = state.stale_refresh_lock.lock().unwrap();
-    // Keep watcher/auto-save mutations out for the complete walk → matcher →
-    // merge cycle. Search queries do not take this gate and remain available.
-    let _gate = state.snapshot_gate.write().unwrap();
     let start = Instant::now();
     eprintln!("[trace] stale check: comparing index against filesystem...");
 
@@ -2695,10 +2872,10 @@ fn background_refresh_stale(
     // with a delete, would be enough.
     //
     // Committing here rather than at each exit is invisible to the watcher:
-    // this function holds `snapshot_gate` for write across its whole body, and
+    // the caller holds `snapshot_gate` for write across this whole body, and
     // the only reader of `state.gitignore` takes the read side first, so no
     // event can observe the matcher before this function returns either way.
-    publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
+    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -2936,7 +3113,13 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
             state.no_require_git,
         );
         let found = matcher.is_some();
-        publish_ignore_matcher(state, root, matcher);
+        // These subscriptions are the repository's first, so "newly watched"
+        // is every directory in it. No recovery scan: the startup stale check
+        // runs right after this and does a full walk-versus-index diff, which
+        // is a strict superset of what a recovery scan would find — and doing
+        // it here would stat the entire tree while holding the gate, on the
+        // path a warm start exists to keep fast.
+        let _ = publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
@@ -3029,7 +3212,11 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             state.no_require_git,
         );
         let has_matcher = matcher.is_some();
-        publish_ignore_matcher(state, root, matcher);
+        // Same reasoning as the bootstrap publish: this is the cold-start
+        // build, so "newly watched" is the whole tree, `indexing` keeps the
+        // watcher off the index for the rest of the build, and the stale check
+        // that follows reconciles anything written during it.
+        let _ = publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -4025,13 +4212,17 @@ mod tests {
             watched: std::collections::HashSet::new(),
         };
 
-        let added = registry.add_all(&[a.clone(), b.clone()].into_iter().collect());
-        assert_eq!(added, 2);
+        let added = registry.add_all(&[a.clone(), b.clone()]);
+        assert_eq!(added.len(), 2);
 
         // Adding a subtree leaves existing subscriptions untouched, and
         // re-adding one already present is a no-op rather than a duplicate.
-        let added = registry.add_all(&[b.clone(), c.clone()].into_iter().collect());
-        assert_eq!(added, 1, "b was already watched and must not be re-added");
+        let added = registry.add_all(&[b.clone(), c.clone()]);
+        assert_eq!(
+            added,
+            vec![c.clone()],
+            "b was already watched and must not be re-added"
+        );
         assert_eq!(
             registry.watched,
             [a.clone(), b.clone(), c.clone()].into_iter().collect(),
@@ -4040,8 +4231,33 @@ mod tests {
 
         // `sync`, by contrast, is authoritative over the whole tree.
         let (added, removed) = registry.sync(&[c.clone()].into_iter().collect());
-        assert_eq!((added, removed), (0, 2));
+        assert_eq!((added.len(), removed), (0, 2));
         assert_eq!(registry.watched, [c].into_iter().collect());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn is_real_dir_rejects_a_symlink_to_a_directory() {
+        // `Path::is_dir` follows links, so it would report a symlinked
+        // directory as a directory and the watcher would subscribe to and
+        // index the link's target — a tree the walker never descends into, and
+        // one that can sit entirely outside the repository root.
+        let tmp = TempDir::new().unwrap();
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert!(is_real_dir(&real));
+        assert!(
+            link.is_dir(),
+            "precondition: is_dir follows the link, which is the trap"
+        );
+        assert!(!is_real_dir(&link));
+        assert!(!is_real_dir(&tmp.path().join("missing")));
+        let file = tmp.path().join("file.txt");
+        std::fs::write(&file, "x").unwrap();
+        assert!(!is_real_dir(&file));
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -299,15 +299,16 @@ struct ServerState {
     /// until something else forces a rebuild. Keeping the source list lets the
     /// scan test for it directly, at one stat per ignore file per scan.
     ignore_sources: RwLock<Vec<PathBuf>>,
-    /// What the published matcher actually read, per ignore source: the size
-    /// and mtime each file had, keyed by its path relative to `root`.
+    /// What the published matcher actually read, per ignore source: a hash of
+    /// the bytes, keyed by the file's path relative to `root`.
     ///
-    /// A pathname is not evidence about contents. An existing `.gitignore` can
-    /// be replaced after the matcher walk by one restored from an archive,
-    /// carrying an mtime older than the scan window — the path is still a known
-    /// source and the mtime still predates the window, so neither test in
-    /// [`changed_ignore_rules_in`] fires and the subtree is indexed under rules
-    /// that were never read. Comparing against what was read closes that.
+    /// A pathname is not evidence about contents, and neither is metadata. An
+    /// existing `.gitignore` can be replaced after the matcher was built by one
+    /// restored from an archive — same length, mtime preserved by the restore,
+    /// so the path is still a known source and nothing about its metadata has
+    /// moved. Neither test in [`changed_ignore_rules_in`] would fire, and the
+    /// subtree would be indexed under rules that were never read. Comparing
+    /// against what was read closes that.
     ///
     /// Also holds an entry for the target of any source reached through a
     /// symlink, when that target is itself under `root`. Following links is
@@ -819,9 +820,34 @@ fn build_stale_matcher(
     matcher
 }
 
-/// The size and mtime an ignore source had when the matcher read it, keyed by
-/// its path relative to the served root.
-type IgnoreStamps = std::collections::HashMap<String, (u64, Option<SystemTime>)>;
+/// What an ignore source contained when the matcher read it: its length and a
+/// hash of its bytes, keyed by its path relative to the served root.
+///
+/// A digest rather than metadata, because metadata does not answer the
+/// question. `rsync -a`, `tar -x` and a restore from an archive all preserve
+/// mtime, and two different sets of rules can easily be the same number of
+/// bytes — at which point a size-and-mtime pair is identical across a
+/// replacement and the scan accepts a matcher built from rules that are gone.
+///
+/// Never persisted, so the hash only has to be stable within a run.
+type IgnoreStamps = std::collections::HashMap<String, (u64, u64)>;
+
+/// The length and content hash of `path`, following links.
+///
+/// `None` when it cannot be read, which is treated as "not what was read":
+/// a source that has become unreadable has stopped contributing the rules the
+/// matcher is enforcing, and that is a change.
+fn ignore_digest_of(path: &Path) -> Option<(u64, u64)> {
+    use std::hash::{Hash, Hasher};
+
+    // The whole file, as the matcher builder reads it. These are rule files:
+    // a few hundred bytes each in practice, and already in the page cache from
+    // the walk that found them.
+    let bytes = std::fs::read(path).ok()?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    Some((bytes.len() as u64, hasher.finish()))
+}
 
 /// How far an mtime may lag the write it records.
 ///
@@ -853,13 +879,18 @@ fn ignore_sources_of(
     sources
 }
 
-/// Stat every source so a later scan can ask whether the file it finds is the
+/// Read every source so a later scan can ask whether the file it finds is the
 /// one the matcher read, rather than merely whether something of that name is
 /// there.
 ///
 /// A source reached through a symlink gets a second entry under its target's
-/// own relative path, when the target is under `root`. The stat follows links
+/// own relative path, when the target is under `root`. The read follows links
 /// either way, so both entries describe the contents that were read.
+///
+/// Taken here rather than inside the matcher builder because the `ignore`
+/// crate opens these files itself and does not hand back what it read. That
+/// leaves a window between its read and this one, which is what the mtime test
+/// in [`changed_ignore_rules_in`] is for.
 fn ignore_stamps_of(root: &Path, sources: &[PathBuf]) -> IgnoreStamps {
     let canonical_root = std::fs::canonicalize(root).ok();
     let mut stamps = IgnoreStamps::with_capacity(sources.len());
@@ -868,9 +899,8 @@ fn ignore_stamps_of(root: &Path, sources: &[PathBuf]) -> IgnoreStamps {
             return;
         };
         let rel = rel.to_string_lossy().replace('\\', "/");
-        // Follows links: what matters is the content behind the name.
-        if let Ok(meta) = std::fs::metadata(path) {
-            stamps.insert(rel, (meta.len(), meta.modified().ok()));
+        if let Some(digest) = ignore_digest_of(path) {
+            stamps.insert(rel, digest);
         }
     };
     for source in sources {
@@ -910,9 +940,10 @@ fn ignore_stamps_of(root: &Path, sources: &[PathBuf]) -> IgnoreStamps {
 /// read as already accounted for by rules that never saw it.
 ///
 /// `sources` are the ignore files `matcher` was built from. They are recorded
-/// so a recovery scan can notice one being deleted — which no mtime test can
-/// see, a deleted file leaving nothing to stat — and stat'd so it can also
-/// notice one being replaced, which a pathname cannot show.
+/// so a recovery scan can notice one being deleted — which no test against
+/// what is on disk can see, a deleted file leaving nothing to read — and read
+/// so it can also notice one being replaced, which neither a pathname nor a
+/// timestamp can show.
 #[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
@@ -2234,13 +2265,14 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
 /// recency test.
 ///
 /// A stamp mismatch answers the same question for a file that was *already* a
-/// source: a pathname proves nothing about contents, and the same archive
-/// restore can swap a source for a different file bearing an older mtime, which
-/// is invisible to both of the other tests.
+/// source: a pathname proves nothing about contents, and neither does
+/// metadata. `rsync -a` and `tar -x` preserve mtime, and two different sets of
+/// rules are easily the same length, so the comparison is against a hash of
+/// what was actually read.
 ///
-/// The mtime window then covers the gap the stamps cannot: they are taken when
-/// the matcher is published, which is after the walk that read these files, so
-/// a write landing between the two is recorded as if it had been read.
+/// The mtime window then covers the gap the digests cannot: they are taken
+/// when the matcher is published, which is after the builder read these files,
+/// so a write landing between the two is recorded as if it had been read.
 ///
 /// That window is widened by [`MTIME_GRANULARITY`] at the near end, because
 /// `since` is a wall-clock instant with nanosecond precision and an mtime is
@@ -2284,14 +2316,13 @@ fn changed_ignore_rules_in(
             let Some(read_as) = known_sources.get(&rel) else {
                 return Some((rel, "not a known source"));
             };
-            // Follows links, matching how the stamp was taken.
+            if ignore_digest_of(&candidate).as_ref() != Some(read_as) {
+                return Some((rel, "not the file the matcher read"));
+            }
+            // Follows links, matching how the digest was taken.
             let Ok(meta) = std::fs::metadata(&candidate) else {
                 continue;
             };
-            let current = (meta.len(), meta.modified().ok());
-            if current != *read_as {
-                return Some((rel, "not the file the matcher read"));
-            }
             if meta
                 .modified()
                 .is_ok_and(|m| m >= since && m <= SystemTime::now())
@@ -6829,6 +6860,59 @@ mod tests {
             state.index.read().unwrap().live.is_deleted("seeded.rs"),
             "a file that is gone from disk must stop answering searches whether or \
              not it had a stamp"
+        );
+    }
+
+    /// Metadata is not content either. `rsync -a` and `tar -x` preserve mtime,
+    /// and two different sets of rules are easily the same length — so a
+    /// size-and-mtime pair is identical across the replacement and only the
+    /// bytes tell them apart.
+    #[cfg(unix)]
+    #[test]
+    fn a_rule_file_swapped_for_one_of_the_same_size_and_age_is_still_caught() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let rules = root.join(".gitignore");
+        std::fs::write(&rules, "aaa.rs\n").unwrap();
+        let before = std::fs::metadata(&rules).unwrap();
+        *state.ignore_source_stamps.write().unwrap() =
+            ignore_stamps_of(&root, std::slice::from_ref(&rules));
+        *state.ignore_sources.write().unwrap() = vec![rules.clone()];
+
+        // Different rules, same seven bytes, and the restore puts the old
+        // timestamp back.
+        std::fs::write(&rules, "bbb.rs\n").unwrap();
+        let secs = before
+            .modified()
+            .unwrap()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap();
+        let name = std::ffi::CString::new(rules.as_os_str().as_bytes()).unwrap();
+        let stamp = libc::timeval {
+            tv_sec: secs.as_secs() as libc::time_t,
+            tv_usec: secs.subsec_micros() as libc::suseconds_t,
+        };
+        let times = [stamp, stamp];
+        // SAFETY: `name` is NUL-terminated and `times` is a two-element array,
+        // both outliving the call.
+        assert_eq!(unsafe { libc::utimes(name.as_ptr(), times.as_ptr()) }, 0);
+        let after = std::fs::metadata(&rules).unwrap();
+        assert_eq!(before.len(), after.len());
+        assert_eq!(before.modified().unwrap(), after.modified().unwrap());
+
+        state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
+        let since = SystemTime::now() + std::time::Duration::from_secs(3600);
+        reindex_files_in(&state, &root, std::slice::from_ref(&root), since);
+        assert!(
+            state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "rules that were swapped for different ones of the same size and age \
+             must still be noticed"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2139,10 +2139,75 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
     (added, since)
 }
 
+/// The first ignore-rules file in `dirs` that the published matcher did not
+/// read, or that has been edited since `since`.
+///
+/// Probing by name rather than inspecting listings, for three reasons. It is
+/// how the walker itself discovers these files, so the two agree by
+/// construction. `Path::is_file` follows symlinks, so a symlinked `.gitignore`
+/// — which carries rules exactly like a real one — is seen, where
+/// `DirEntry::file_type` does not resolve it and the entry gets dropped as "not
+/// a regular file". And it is ordering-independent: `read_dir` offers no
+/// ordering, and on macOS `.gitignore` routinely comes back *after* its
+/// siblings, so a per-entry check indexes part of a directory under the stale
+/// rules before it ever reaches the file that changes them. Answering for the
+/// whole scan up front closes that window across directories as well.
+///
+/// Two tests, because neither alone is enough. Absence from the published
+/// sources is the exact question — this file did not feed the matcher in force
+/// — and it catches an arrival however old the file says it is, which matters
+/// because `git checkout`, `tar -x` and `rsync -a` all restore mtimes from what
+/// they unpack and would sail past a recency test. The mtime window then covers
+/// what the source list cannot: a file that was already a source and has just
+/// been edited.
+///
+/// That window is bounded at both ends, not just the near one. On a network
+/// mount whose server clock runs ahead of ours, every recently touched file
+/// carries a future mtime and would pass a one-sided test — on every scan,
+/// including the one at the end of the refresh this schedules, which walks the
+/// whole repository and then arms the next. Treating a future mtime as skew
+/// rather than as an edit keeps that loop closed.
+fn changed_ignore_rules_in(
+    root: &Path,
+    dirs: &[PathBuf],
+    known_sources: &std::collections::HashSet<String>,
+    since: SystemTime,
+) -> Option<(String, &'static str)> {
+    let mut probed: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    for dir in dirs {
+        let mut candidates = vec![
+            dir.join(tgrep_core::gitignore::GITIGNORE_FILENAME),
+            dir.join(tgrep_core::gitignore::DOT_IGNORE_FILENAME),
+        ];
+        // Root-scoped, mirroring the walker, which only reads the root file.
+        if dir == root {
+            candidates.push(root.join(tgrep_core::gitignore::P4IGNORE_FILENAME));
+        }
+        for candidate in candidates {
+            if !probed.insert(candidate.clone()) || !candidate.is_file() {
+                continue;
+            }
+            let Ok(rel) = candidate.strip_prefix(root) else {
+                continue;
+            };
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            if !known_sources.contains(&rel) {
+                return Some((rel, "not a known source"));
+            }
+            if std::fs::metadata(&candidate)
+                .and_then(|m| m.modified())
+                .is_ok_and(|m| m >= since && m <= SystemTime::now())
+            {
+                return Some((rel, "modified"));
+            }
+        }
+    }
+    None
+}
+
 /// Re-check the files directly inside `dirs`, indexing the ones that changed,
 /// dropping the ones that are gone, and subscribing to subdirectories that
 /// appeared while the subscriptions were being established.
-///
 /// Used to close the gap between a walk and the subscriptions that follow it:
 /// [`reindex_file`] compares stamps first, so for a tree that did not change
 /// under us this costs one `metadata` call per file and indexes nothing.
@@ -2204,6 +2269,24 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
         known
     };
 
+    // Before a single file is indexed: an ignore-rules file that landed in this
+    // window was not seen by the walk that built the matcher in force, so every
+    // file in this scan would be judged by rules that do not know about it, and
+    // whatever was wrongly indexed would stay until something touched it again.
+    if !state.no_ignore
+        && let Some((rel, why)) = changed_ignore_rules_in(root, dirs, &known_sources, since)
+    {
+        // Abandon the scan: the refresh rewalks and republishes, which covers
+        // these directories properly.
+        state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+        schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+        eprintln!(
+            "[trace] watcher: ignore rules changed during recovery ({rel}, {why}); \
+             deferring to a refresh"
+        );
+        return;
+    }
+
     // Directories whose listing succeeded, and the files those listings
     // contained, for the removal sweep at the end. Only files are recorded:
     // stamps describe files, so directory names would just be dead weight on a
@@ -2251,69 +2334,6 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
                 subdirs.push(path);
                 continue;
             }
-
-            // Ahead of the regular-file test, and following links to decide.
-            // The walker collects rule files with `Path::is_file`, which
-            // resolves symlinks, so a symlinked `.gitignore` contributes rules
-            // exactly like a real one — while `DirEntry::file_type` above does
-            // not resolve them, which left those files falling through the
-            // `!is_file` bail and never triggering a refresh. They are still
-            // never indexed; they are only allowed to announce themselves.
-            //
-            // An ignore-rules file that landed in this window was not seen by
-            // the walk that built the matcher in force, so every other file in
-            // this scan is being judged by rules that do not know about it.
-            // Indexing them now would apply the wrong rules and leave whatever
-            // was wrongly indexed until something touched it again.
-            //
-            // Two tests, because neither alone is enough. Absence from the
-            // published sources is the exact question — this file did not feed
-            // the matcher — and it catches the arrival however old the file
-            // says it is, which matters because `git checkout`, `tar -x` and
-            // `rsync -a` all restore mtimes from the archive and would sail
-            // past a recency test. The mtime window then covers the case the
-            // source list cannot: a file that was already a source and has just
-            // been *edited*.
-            //
-            // The mtime test is what keeps the second one quiet: a repository
-            // has an ignore file in every other directory and the startup scan
-            // walks past all of them, but they predate the walk and are already
-            // accounted for. Only one written inside the window can have been
-            // missed — and a spurious match (a `touch` in the same millisecond)
-            // costs an idempotent refresh, not correctness.
-            //
-            // Bounded at both ends, not just the near one. On a network mount
-            // whose server clock runs ahead of ours, every recently touched
-            // file carries a future mtime and would pass a one-sided test — on
-            // every scan, including the one at the end of the refresh this
-            // schedules, which walks the whole repository and then arms the
-            // next. Treating a future mtime as skew rather than as an arrival
-            // gives up the fix on such a mount and keeps the loop closed.
-            if !state.no_ignore && is_ignore_rules_file(root, &path) && path.is_file() {
-                let unknown = !known_sources.contains(&rel);
-                let touched = std::fs::metadata(&path)
-                    .and_then(|m| m.modified())
-                    .is_ok_and(|m| m >= since && m <= SystemTime::now());
-                if unknown || touched {
-                    // Abandon the scan: the refresh rewalks and republishes,
-                    // which covers these directories properly, and anything
-                    // indexed between here and there would be judged by the
-                    // stale rules.
-                    state.ignore_rules_dirty.store(true, Ordering::SeqCst);
-                    schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
-                    let why = if unknown {
-                        "not a known source"
-                    } else {
-                        "modified"
-                    };
-                    eprintln!(
-                        "[trace] watcher: ignore rules changed during recovery ({rel}, {why}); \
-                         deferring to a refresh"
-                    );
-                    return;
-                }
-            }
-
             if !file_type.is_file() {
                 continue;
             }
@@ -6486,6 +6506,41 @@ mod tests {
         assert!(
             !state.index.read().unwrap().live.has_path("sub/kept.rs"),
             "the scan must abandon rather than index under rules it knows are stale"
+        );
+    }
+
+    /// `read_dir` promises no ordering, and the rules a scan must respect can
+    /// live in a directory it has not reached yet — so every directory in the
+    /// scan is asked before any file in it is indexed.
+    #[cfg(unix)]
+    #[test]
+    fn a_scan_checks_every_directory_for_rules_before_indexing_any_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+        *state.ignore_sources.write().unwrap() = Vec::new();
+
+        // The rules are in `b`, the file is in `a`, and `a` is scanned first.
+        let a = root.join("a");
+        let b = root.join("b");
+        std::fs::create_dir(&a).unwrap();
+        std::fs::create_dir(&b).unwrap();
+        std::fs::write(a.join("keep.rs"), "fn keep() {}\n").unwrap();
+        std::fs::write(b.join(".gitignore"), "keep.rs\n").unwrap();
+
+        state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
+        let since = SystemTime::now() - std::time::Duration::from_secs(60);
+        reindex_files_in(&state, &root, &[a, b], since);
+
+        assert!(
+            state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "the scan must notice rules that live later in its own list"
+        );
+        assert!(
+            !state.index.read().unwrap().live.has_path("a/keep.rs"),
+            "nothing may be indexed before every directory has been asked for rules"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1656,9 +1656,24 @@ fn should_skip_watcher_path(
     false
 }
 
+/// Whether a changed path is an ignore-rules source, i.e. one whose contents
+/// feed the matcher published in `ServerState::gitignore`.
+///
+/// `.gitignore` and `.ignore` are matched by file name at any depth, because
+/// [`tgrep_core::gitignore::matcher_from_ignore_paths`] anchors nested files of
+/// both kinds. `.ignore` must be included even though it is git-agnostic —
+/// leaving it out meant a `.ignore` written while the server was live never
+/// refreshed the matcher, so the watcher kept indexing files the rule excluded.
+///
+/// `p4ignore.ini` stays root-scoped, mirroring the walker, which only reads the
+/// root-level file.
 fn is_ignore_rules_file(root: &Path, path: &Path) -> bool {
-    path.file_name().and_then(|name| name.to_str()) == Some(".gitignore")
-        || path == root.join(tgrep_core::gitignore::P4IGNORE_FILENAME)
+    let name = path.file_name().and_then(|name| name.to_str());
+    matches!(
+        name,
+        Some(tgrep_core::gitignore::GITIGNORE_FILENAME)
+            | Some(tgrep_core::gitignore::DOT_IGNORE_FILENAME)
+    ) || path == root.join(tgrep_core::gitignore::P4IGNORE_FILENAME)
 }
 
 fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
@@ -3671,6 +3686,14 @@ mod tests {
         assert!(is_ignore_rules_file(
             root,
             Path::new("workspace/p4ignore.ini")
+        ));
+        // `.ignore` is a first-class ignore source (and, unlike `.gitignore`,
+        // applies outside a git repo), so live edits to it must refresh the
+        // matcher too — at the root and nested.
+        assert!(is_ignore_rules_file(root, Path::new("workspace/.ignore")));
+        assert!(is_ignore_rules_file(
+            root,
+            Path::new("workspace/nested/.ignore")
         ));
         assert!(!is_ignore_rules_file(
             root,

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2166,16 +2166,31 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
     let start = Instant::now();
 
     // An ignore file that was deleted during the window is invisible to the
-    // per-entry mtime test below — there is no entry left to stat. It is also
-    // the more damaging direction: rules that no longer have a source keep
-    // being enforced, so the subtree they hide stays unsubscribed and
-    // unindexed until an unrelated rebuild happens along. Checking the sources
-    // the published matcher was built from catches it at one stat apiece, once
-    // per scan rather than once per file.
-    if !state.no_ignore {
-        let vanished = {
+    // per-entry test below — there is no entry left to stat. It is also the
+    // more damaging direction: rules that no longer have a source keep being
+    // enforced, so the subtree they hide stays unsubscribed and unindexed until
+    // an unrelated rebuild happens along. Checking the sources the published
+    // matcher was built from catches it at one stat apiece, once per scan
+    // rather than once per file.
+    //
+    // The same list answers the opposite question for free: an ignore file that
+    // is *not* among the sources is one the published matcher never read.
+    let known_sources: std::collections::HashSet<String> = if state.no_ignore {
+        std::collections::HashSet::new()
+    } else {
+        let (vanished, known) = {
             let sources = state.ignore_sources.read().unwrap();
-            sources.iter().find(|p| !p.exists()).cloned()
+            (
+                // `exists` follows links, matching how the walker collected
+                // these — a symlinked source whose target is gone has stopped
+                // contributing rules just as surely as a deleted one.
+                sources.iter().find(|p| !p.exists()).cloned(),
+                sources
+                    .iter()
+                    .filter_map(|p| p.strip_prefix(root).ok())
+                    .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+                    .collect::<std::collections::HashSet<String>>(),
+            )
         };
         if let Some(gone) = vanished {
             state.ignore_rules_dirty.store(true, Ordering::SeqCst);
@@ -2186,7 +2201,8 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
             );
             return;
         }
-    }
+        known
+    };
 
     // Directories whose listing succeeded, and the files those listings
     // contained, for the removal sweep at the end. Only files are recorded:
@@ -2235,23 +2251,36 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
                 subdirs.push(path);
                 continue;
             }
-            if !file_type.is_file() {
-                continue;
-            }
-            present.insert(rel.clone());
 
+            // Ahead of the regular-file test, and following links to decide.
+            // The walker collects rule files with `Path::is_file`, which
+            // resolves symlinks, so a symlinked `.gitignore` contributes rules
+            // exactly like a real one — while `DirEntry::file_type` above does
+            // not resolve them, which left those files falling through the
+            // `!is_file` bail and never triggering a refresh. They are still
+            // never indexed; they are only allowed to announce themselves.
+            //
             // An ignore-rules file that landed in this window was not seen by
             // the walk that built the matcher in force, so every other file in
             // this scan is being judged by rules that do not know about it.
             // Indexing them now would apply the wrong rules and leave whatever
             // was wrongly indexed until something touched it again.
             //
-            // The mtime test is what keeps this quiet: a repository has an
-            // ignore file in every other directory and the startup scan walks
-            // past all of them, but they predate the walk and are already
+            // Two tests, because neither alone is enough. Absence from the
+            // published sources is the exact question — this file did not feed
+            // the matcher — and it catches the arrival however old the file
+            // says it is, which matters because `git checkout`, `tar -x` and
+            // `rsync -a` all restore mtimes from the archive and would sail
+            // past a recency test. The mtime window then covers the case the
+            // source list cannot: a file that was already a source and has just
+            // been *edited*.
+            //
+            // The mtime test is what keeps the second one quiet: a repository
+            // has an ignore file in every other directory and the startup scan
+            // walks past all of them, but they predate the walk and are already
             // accounted for. Only one written inside the window can have been
-            // missed — and a spurious match (a `touch` in the same
-            // millisecond) costs an idempotent refresh, not correctness.
+            // missed — and a spurious match (a `touch` in the same millisecond)
+            // costs an idempotent refresh, not correctness.
             //
             // Bounded at both ends, not just the near one. On a network mount
             // whose server clock runs ahead of ours, every recently touched
@@ -2260,24 +2289,35 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
             // schedules, which walks the whole repository and then arms the
             // next. Treating a future mtime as skew rather than as an arrival
             // gives up the fix on such a mount and keeps the loop closed.
-            if !state.no_ignore
-                && is_ignore_rules_file(root, &path)
-                && entry
-                    .metadata()
+            if !state.no_ignore && is_ignore_rules_file(root, &path) && path.is_file() {
+                let unknown = !known_sources.contains(&rel);
+                let touched = std::fs::metadata(&path)
                     .and_then(|m| m.modified())
-                    .is_ok_and(|m| m >= since && m <= SystemTime::now())
-            {
-                // Abandon the scan: the refresh rewalks and republishes, which
-                // covers these directories properly, and anything indexed
-                // between here and there would be judged by the stale rules.
-                state.ignore_rules_dirty.store(true, Ordering::SeqCst);
-                schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
-                eprintln!(
-                    "[trace] watcher: ignore rules changed during recovery ({rel}); \
-                     deferring to a refresh"
-                );
-                return;
+                    .is_ok_and(|m| m >= since && m <= SystemTime::now());
+                if unknown || touched {
+                    // Abandon the scan: the refresh rewalks and republishes,
+                    // which covers these directories properly, and anything
+                    // indexed between here and there would be judged by the
+                    // stale rules.
+                    state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+                    schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+                    let why = if unknown {
+                        "not a known source"
+                    } else {
+                        "modified"
+                    };
+                    eprintln!(
+                        "[trace] watcher: ignore rules changed during recovery ({rel}, {why}); \
+                         deferring to a refresh"
+                    );
+                    return;
+                }
             }
+
+            if !file_type.is_file() {
+                continue;
+            }
+            present.insert(rel.clone());
 
             let skip = {
                 let gitignore = state.gitignore.read().unwrap();
@@ -2381,10 +2421,7 @@ fn sweep_removed_files(
     // bug one instruction later.
     let mut dropped = 0usize;
     for rel in &gone {
-        let _reindex = match state.reindex_lock.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
+        let _reindex = lock_reindex(state);
         // No-follow: a path that came back as a symlink is still not something
         // the index should hold, so it stays swept.
         if std::fs::symlink_metadata(state.root.join(rel)).is_ok_and(|m| m.file_type().is_file()) {
@@ -2486,6 +2523,32 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
                     continue;
                 };
                 let rel = rel.to_string_lossy().replace('\\', "/");
+                // A subtree that arrives whole — a clone, a `mv`, a branch
+                // switch — can carry its own ignore rules. Those files are
+                // dot-prefixed, so the scan below would silently drop them and
+                // index the rest of the subtree against rules that do not know
+                // about them.
+                //
+                // Ahead of the type dispatch, and following links: the walker
+                // collects rule files with `Path::is_file`, which resolves
+                // symlinks, whereas `DirEntry::file_type` does not — so a
+                // symlinked `.gitignore` fell between the two branches below
+                // and was never noticed, despite carrying rules the walker
+                // would read.
+                //
+                // Abandon the descent immediately rather than finishing it.
+                // Everything gathered from here on is discarded by the refresh
+                // anyway, and the rules that are about to be published are the
+                // ones that decide whether these directories should be watched
+                // at all — continuing would subscribe to every level of, say, a
+                // `node_modules/` that was just moved into place, which on
+                // Linux is a watch descriptor apiece and the exhaustion this
+                // pass exists to avoid. The refresh's `sync` would prune them,
+                // but only after they had already been taken.
+                if !state.no_ignore && is_ignore_rules_file(root, &path) && path.is_file() {
+                    found_ignore_rules = true;
+                    break 'descend;
+                }
                 // `DirEntry::file_type` does not follow symlinks, so a
                 // symlinked directory is neither descended into nor indexed.
                 if file_type.is_dir() {
@@ -2497,26 +2560,6 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
                         next.push(path);
                     }
                 } else if file_type.is_file() {
-                    // A subtree that arrives whole — a clone, a `mv`, a branch
-                    // switch — can carry its own ignore rules. Those files are
-                    // dot-prefixed, so the scan below would silently drop them
-                    // and index the rest of the subtree against rules that do
-                    // not know about them.
-                    //
-                    // Abandon the descent immediately rather than finishing it.
-                    // Everything gathered from here on is discarded by the
-                    // refresh anyway, and the rules that are about to be
-                    // published are the ones that decide whether these
-                    // directories should be watched at all — continuing would
-                    // subscribe to every level of, say, a `node_modules/` that
-                    // was just moved into place, which on Linux is a watch
-                    // descriptor apiece and the exhaustion this pass exists to
-                    // avoid. The refresh's `sync` would prune them, but only
-                    // after they had already been taken.
-                    if !state.no_ignore && is_ignore_rules_file(root, &path) {
-                        found_ignore_rules = true;
-                        break 'descend;
-                    }
                     let skip = {
                         let gitignore = state.gitignore.read().unwrap();
                         should_skip_watcher_path(&rel, &state.exclude_dirs, gitignore.as_ref())
@@ -2894,6 +2937,15 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
             // `file_stamps` is missing/out-of-date (e.g. first run after
             // an older index), skipping the delete entirely would leave
             // stale entries for files that no longer exist.
+            //
+            // Under `reindex_lock`, or a concurrent `reindex_file` that has
+            // already read the file's bytes commits them *after* this delete
+            // and resurrects a file that is gone — with a fresh stamp, so
+            // nothing afterwards disagrees and no further event is coming to
+            // correct it. The lock makes the two orderings the only two: the
+            // delete lands on content that was committed, or the reindex opens
+            // a path that is already gone and drops it.
+            let _reindex = lock_reindex(state);
             let known_path = state.file_stamps.read().unwrap().contains_key(&rel_path);
             if known_path {
                 eprintln!("[trace] reindex: removed {rel_path}");
@@ -2943,11 +2995,27 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
             // still true and inotify may report only the rename destination —
             // so nothing above catches it, and without this the old contents
             // stay searchable indefinitely.
+            //
+            // Same lock as the removal above, for the same reason: a reindex
+            // already holding the old bytes must not commit them after this.
+            let _reindex = lock_reindex(state);
             drop_indexed_file(state, &rel_path, "no longer a regular file");
             continue;
         }
 
         reindex_file(state, path, &rel_path);
+    }
+}
+
+/// Take the mutation lock, tolerating a previous holder's panic.
+///
+/// Poisoning here means some other indexer panicked partway through an update,
+/// not that the index is unusable. Refusing to serialise from then on would
+/// turn one failure into the resurrection race this lock exists to prevent.
+fn lock_reindex(state: &ServerState) -> std::sync::MutexGuard<'_, ()> {
+    match state.reindex_lock.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 
@@ -2967,7 +3035,9 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
 /// path. The trace line, which is the part that would be actively misleading,
 /// stays conditional on there having been something to drop.
 ///
-/// The caller must already hold `snapshot_gate`.
+/// The caller must already hold `snapshot_gate` and `reindex_lock`. The lock is
+/// the caller's rather than this function's because `reindex_file` calls in
+/// while holding it, and a `Mutex` is not reentrant.
 fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
     let had_stamp = state
         .file_stamps
@@ -3277,10 +3347,7 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // read, so without this a recovery scan and the watcher worker can both be
     // here for the same path, both read, and the one that read the *older*
     // content can commit last. See `ServerState::reindex_lock`.
-    let _reindex = match state.reindex_lock.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
+    let _reindex = lock_reindex(state);
 
     // One handle for the whole decision, resolved a component at a time from
     // the root so no part of the path can be a symlink, and every fact below —
@@ -6276,6 +6343,149 @@ mod tests {
         assert!(
             state.index.read().unwrap().live.is_deleted("x.rs"),
             "content indexed before the path became a fifo must not stay searchable"
+        );
+    }
+
+    /// A removal must not land while another thread is midway through indexing
+    /// the same path, or the reindex commits bytes it read earlier and
+    /// resurrects a file that is gone — with a fresh stamp, so nothing
+    /// afterwards disagrees and no further event is coming to correct it.
+    #[cfg(unix)]
+    #[test]
+    fn a_removal_waits_for_an_in_flight_reindex() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let path = root.join("x.rs");
+        std::fs::write(&path, "fn indexed() {}\n").unwrap();
+        reindex_file(&state, &path, "x.rs");
+        assert!(state.index.read().unwrap().live.has_path("x.rs"));
+
+        std::fs::remove_file(&path).unwrap();
+
+        // Stands in for a `reindex_file` that has read the old bytes and not
+        // yet committed them: it holds exactly this lock across that window.
+        let held = state.reindex_lock.lock().unwrap();
+
+        let worker = {
+            let state = Arc::clone(&state);
+            let root = root.clone();
+            let path = path.clone();
+            std::thread::spawn(move || {
+                handle_fs_event(
+                    &state,
+                    &root,
+                    &Event {
+                        kind: EventKind::Remove(notify::event::RemoveKind::File),
+                        paths: vec![path],
+                        attrs: Default::default(),
+                    },
+                );
+            })
+        };
+
+        // The delete has to wait its turn. Without the lock it lands
+        // immediately, which is the ordering that loses the file.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(
+            !state.index.read().unwrap().live.is_deleted("x.rs"),
+            "a removal must not mutate the index while an indexer holds the lock"
+        );
+
+        drop(held);
+        worker.join().unwrap();
+        assert!(
+            state.index.read().unwrap().live.is_deleted("x.rs"),
+            "and it must still apply once the lock is free"
+        );
+    }
+
+    /// `git checkout`, `tar -x` and `rsync -a` all restore mtimes from what
+    /// they unpack, so a nested ignore file can arrive carrying a timestamp
+    /// from months ago. A recency test cannot see that; absence from the
+    /// published sources can.
+    #[cfg(unix)]
+    #[test]
+    fn an_arriving_ignore_file_with_a_preserved_mtime_still_refreshes_the_matcher() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        // The matcher in force was built without it.
+        *state.ignore_sources.write().unwrap() = Vec::new();
+
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let rules = sub.join(".gitignore");
+        std::fs::write(&rules, "kept.rs\n").unwrap();
+        std::fs::write(sub.join("kept.rs"), "fn kept() {}\n").unwrap();
+
+        // Backdated well outside any plausible scan window.
+        let name = std::ffi::CString::new(rules.as_os_str().as_bytes()).unwrap();
+        let stamp = libc::timeval {
+            tv_sec: 1_000_000,
+            tv_usec: 0,
+        };
+        let times = [stamp, stamp];
+        // SAFETY: `name` is NUL-terminated and `times` is a two-element array,
+        // both outliving the call.
+        assert_eq!(unsafe { libc::utimes(name.as_ptr(), times.as_ptr()) }, 0);
+
+        state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
+        let since = SystemTime::now() - std::time::Duration::from_secs(60);
+        reindex_files_in(&state, &root, std::slice::from_ref(&sub), since);
+
+        assert!(
+            state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "an ignore file the matcher never read must schedule a refresh, \
+             however old its mtime is"
+        );
+        assert!(
+            !state.index.read().unwrap().live.has_path("sub/kept.rs"),
+            "the scan must abandon rather than index under rules it knows are stale"
+        );
+    }
+
+    /// The walker collects rule files with `Path::is_file`, which follows
+    /// links, so a symlinked `.gitignore` contributes rules like any other —
+    /// but `DirEntry::file_type` does not follow links, and the scan used to
+    /// drop those entries before ever asking what they were.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_ignore_file_is_still_seen_by_a_recovery_scan() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let sub = root.join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let target = root.join("shared-rules");
+        std::fs::write(&target, "kept.rs\n").unwrap();
+        std::os::unix::fs::symlink(&target, sub.join(".gitignore")).unwrap();
+        std::fs::write(sub.join("kept.rs"), "fn kept() {}\n").unwrap();
+
+        // Recent enough that the mtime window alone would catch a *regular*
+        // file here: what this pins is that a symlink gets that far at all.
+        state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
+        let since = SystemTime::now() - std::time::Duration::from_secs(60);
+        reindex_files_in(&state, &root, std::slice::from_ref(&sub), since);
+
+        assert!(
+            state.ignore_rules_dirty.load(Ordering::SeqCst),
+            "a symlinked ignore file carries rules and must schedule a refresh"
+        );
+        assert!(
+            !state.index.read().unwrap().live.has_path("sub/kept.rs"),
+            "the scan must abandon rather than index under rules it knows are stale"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -290,6 +290,19 @@ struct ServerState {
     ignore_rules_dirty: std::sync::atomic::AtomicBool,
     /// Ensures a burst of ignore-file events uses at most one refresh worker.
     ignore_refresh_scheduled: std::sync::atomic::AtomicBool,
+    /// Serializes the whole check-read-commit cycle in [`reindex_file`].
+    ///
+    /// `snapshot_gate` is held for *read* by everything that indexes a file, so
+    /// the watcher worker and a recovery scan can be inside `reindex_file` for
+    /// the same path at once. Both then see the same old stamp, both read, and
+    /// whichever commits last wins — which is not necessarily the one that read
+    /// the newer content. The losing write is already consumed, so the stale
+    /// version survives until the next reconcile.
+    ///
+    /// Taken per file rather than per scan, so a recovery pass and the watcher
+    /// interleave instead of one waiting out the other. It is never held across
+    /// anything but one file's read, and searches do not take it at all.
+    reindex_lock: Mutex<()>,
     /// Paths the watcher saw while `indexing` was set, kept so they can be
     /// replayed once the build publishes.
     ///
@@ -590,6 +603,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         gitignore_pending: std::sync::atomic::AtomicBool::new(!no_watch && !no_ignore),
         ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
         ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+        reindex_lock: Mutex::new(()),
         deferred_events: Mutex::new(Some(std::collections::HashSet::new())),
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
@@ -2811,22 +2825,11 @@ fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
 /// Open a file without following a final symlink, so the handle is the path
 /// itself rather than wherever it points.
 ///
-/// Every later question — is this a regular file, how big is it, what is in it
-/// — is then answered from the one handle, which is what makes the eligibility
-/// decision and the read describe the same object. Checking the path and then
-/// reading it separately leaves a window in which a tree being rewritten under
-/// us (a checkout, a build, `git mv`) can swap a regular file for a link, and
-/// the read would follow it out of the served root.
+/// Only the last component. For a path whose ancestors are not already trusted,
+/// use [`open_within_root`] — which on unix has no use for this, since `openat`
+/// resolves the final component the same way as every other one.
+#[cfg(not(unix))]
 fn open_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        // Fails outright on a symlink, which is the answer we want.
-        std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_NOFOLLOW)
-            .open(path)
-    }
     #[cfg(windows)]
     {
         use std::os::windows::fs::OpenOptionsExt;
@@ -2845,6 +2848,115 @@ fn open_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
     }
 }
 
+/// Open a file under `root` without traversing a symlink at *any* level.
+///
+/// Refusing to follow the final component is not enough. A path arrives here
+/// from an event or a replay as a name, and `root/a/file` reads the same
+/// whether `a` is a directory or a link to one — so an intermediate link is
+/// enough to hand back a file outside the served tree, which is exactly the
+/// containment the walker's `follow_links(false)` promises and the index's
+/// contract depends on.
+///
+/// `root` itself is the trust anchor and is opened normally: it is the
+/// directory the user asked us to serve, so a link there is theirs to have.
+///
+/// On unix this is race-free. Each component is resolved with `openat` against
+/// the handle for its parent, so the name is never re-resolved and there is no
+/// window in which a directory can be swapped for a link between the check and
+/// the use.
+#[cfg(unix)]
+fn open_within_root(root: &Path, path: &Path) -> std::io::Result<std::fs::File> {
+    use std::io::{Error, ErrorKind};
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    let components = relative_components(root, path)?;
+    let mut dir: OwnedFd = std::fs::File::open(root)?.into();
+    let last = components.len() - 1;
+    for (i, component) in components.iter().enumerate() {
+        let name = std::ffi::CString::new(component.as_bytes())
+            .map_err(|_| Error::new(ErrorKind::InvalidInput, "path component contains a NUL"))?;
+        // `O_DIRECTORY` on the intermediates so a *file* in the middle of the
+        // path fails here rather than at the next `openat`, and `O_NOFOLLOW` on
+        // every one of them, including the last. `O_NONBLOCK`: see
+        // `open_no_follow`.
+        let mut flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
+        if i != last {
+            flags |= libc::O_DIRECTORY;
+        }
+        // SAFETY: `dir` is a live directory descriptor for the parent, and
+        // `name` is a NUL-terminated single path component that outlives the
+        // call.
+        let fd = unsafe { libc::openat(dir.as_raw_fd(), name.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(Error::last_os_error());
+        }
+        // SAFETY: `openat` returned a fresh owned descriptor. Assigning it
+        // drops the previous one, closing the parent we no longer need.
+        dir = unsafe { OwnedFd::from_raw_fd(fd) };
+    }
+    Ok(std::fs::File::from(dir))
+}
+
+/// As above. Windows has no `openat`, so the ancestors are checked by path
+/// instead of by handle: this rejects a symlink or junction that is actually
+/// there, but not one substituted between the check and the open. Closing that
+/// window needs handle-relative opens (`NtCreateFile` with a `RootDirectory`),
+/// which is a great deal of unsafe code for a platform where creating a symlink
+/// needs a privilege the machine does not grant by default.
+#[cfg(not(unix))]
+fn open_within_root(root: &Path, path: &Path) -> std::io::Result<std::fs::File> {
+    use std::io::{Error, ErrorKind};
+
+    let components = relative_components(root, path)?;
+    let mut walked = root.to_path_buf();
+    for component in &components[..components.len() - 1] {
+        walked.push(component);
+        let meta = std::fs::symlink_metadata(&walked)?;
+        // `is_symlink` covers junctions too: both are reparse points tagged as
+        // name surrogates, which is what std tests for.
+        if meta.file_type().is_symlink() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "path traverses a symlink",
+            ));
+        }
+        if !meta.is_dir() {
+            return Err(Error::new(ErrorKind::NotADirectory, "not a directory"));
+        }
+    }
+    open_no_follow(path)
+}
+
+/// `path` split into the literal components below `root`.
+///
+/// Anything that is not a plain name — `..`, a root, a prefix — is refused
+/// rather than interpreted, since resolving those is the whole business
+/// [`open_within_root`] is avoiding.
+fn relative_components(root: &Path, path: &Path) -> std::io::Result<Vec<std::ffi::OsString>> {
+    use std::io::{Error, ErrorKind};
+
+    let rel = path
+        .strip_prefix(root)
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "path is outside the served root"))?;
+    let mut components = Vec::new();
+    for component in rel.components() {
+        match component {
+            std::path::Component::Normal(name) => components.push(name.to_os_string()),
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    "path has a non-literal component",
+                ));
+            }
+        }
+    }
+    if components.is_empty() {
+        return Err(Error::new(ErrorKind::InvalidInput, "path is the root"));
+    }
+    Ok(components)
+}
+
 /// Read a file and merge it into the live index, unless its stamp says the
 /// content we already indexed is current.
 ///
@@ -2854,11 +2966,21 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     use std::io::Read;
     use tgrep_core::meta::FileStamp;
 
-    // One handle for the whole decision. Opened without following a final
-    // symlink, and every fact below — type, size, mtime, bytes — read back off
-    // it, so nothing that happens to the path in the meantime can make the
-    // content we index disagree with the metadata we judged it by.
-    let file = match open_no_follow(path) {
+    // Against other indexers, not against searches. The gate above is held for
+    // read, so without this a recovery scan and the watcher worker can both be
+    // here for the same path, both read, and the one that read the *older*
+    // content can commit last. See `ServerState::reindex_lock`.
+    let _reindex = match state.reindex_lock.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    // One handle for the whole decision, resolved a component at a time from
+    // the root so no part of the path can be a symlink, and every fact below —
+    // type, size, mtime, bytes — read back off it. Nothing that happens to the
+    // path in the meantime can then make the content we index disagree with the
+    // metadata we judged it by, or put it outside the tree we serve.
+    let file = match open_within_root(&state.root, path) {
         Ok(f) => f,
         Err(_) => {
             // Includes the ELOOP that a symlink gets on unix. It may still be
@@ -2894,8 +3016,9 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // the link's path — and the target need not be under `root` at all, so a
     // link committed to a branch (or dropped in by a build) is enough to pull
     // `~/.ssh/id_rsa` into an index whose whole contract is that it covers the
-    // served tree. On unix the open above has already failed for a link; this
-    // is what rejects one on Windows, where the reparse point opens fine.
+    // served tree. On unix the open above has already failed for a link at any
+    // level; this is what rejects a final one on Windows, where the reparse
+    // point opens fine.
     let eligible = meta.is_file()
         && !tgrep_core::walker::is_binary_extension(path)
         && !state
@@ -4625,6 +4748,7 @@ mod tests {
             gitignore_pending: std::sync::atomic::AtomicBool::new(true),
             ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
             ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+            reindex_lock: Mutex::new(()),
             deferred_events: Mutex::new(Some(std::collections::HashSet::new())),
             index_progress: std::sync::atomic::AtomicU64::new(0),
             index_total: std::sync::atomic::AtomicU64::new(0),
@@ -5396,14 +5520,15 @@ mod tests {
     /// The metadata the eligibility check uses and the bytes that get indexed
     /// have to describe the same object, which means one handle.
     #[test]
-    fn open_no_follow_reads_a_regular_file() {
+    fn open_within_root_reads_a_regular_file() {
         use std::io::Read;
 
         let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("plain.rs");
+        std::fs::create_dir(tmp.path().join("src")).unwrap();
+        let path = tmp.path().join("src").join("plain.rs");
         std::fs::write(&path, "fn main() {}\n").unwrap();
 
-        let file = open_no_follow(&path).expect("a regular file opens");
+        let file = open_within_root(tmp.path(), &path).expect("a regular file opens");
         let meta = file.metadata().expect("metadata off the handle");
         assert!(meta.is_file());
         assert_eq!(meta.len(), 13);
@@ -5417,16 +5542,62 @@ mod tests {
     /// would pull a file from outside the served root into the index.
     #[cfg(unix)]
     #[test]
-    fn open_no_follow_refuses_a_symlink() {
-        let tmp = TempDir::new().unwrap();
-        let target = tmp.path().join("secret.txt");
+    fn open_within_root_refuses_a_symlinked_file() {
+        let outside = TempDir::new().unwrap();
+        let target = outside.path().join("secret.txt");
         std::fs::write(&target, "sensitive\n").unwrap();
-        let link = tmp.path().join("link.txt");
+
+        let root = TempDir::new().unwrap();
+        let link = root.path().join("link.txt");
         std::os::unix::fs::symlink(&target, &link).unwrap();
 
         assert!(
-            open_no_follow(&link).is_err(),
-            "O_NOFOLLOW must reject the link rather than open its target"
+            open_within_root(root.path(), &link).is_err(),
+            "the link must not open as its target"
+        );
+    }
+
+    /// And neither must a symlink anywhere *above* the file: `root/a/file`
+    /// reads the same whether `a` is a directory or a link to one, so guarding
+    /// only the last component still lets a whole tree in from outside.
+    #[cfg(unix)]
+    #[test]
+    fn open_within_root_refuses_a_symlinked_ancestor() {
+        let outside = TempDir::new().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), "sensitive\n").unwrap();
+
+        let root = TempDir::new().unwrap();
+        let link = root.path().join("a");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+        let through_link = link.join("secret.txt");
+
+        // The file at the end of that path is a perfectly ordinary file, and
+        // opening it by name works — which is the point.
+        assert!(std::fs::File::open(&through_link).is_ok());
+        assert!(
+            open_within_root(root.path(), &through_link).is_err(),
+            "an intermediate symlink must not be traversed"
+        );
+    }
+
+    /// Nothing may be resolved that could climb back out of the root.
+    #[test]
+    fn open_within_root_refuses_paths_that_escape_or_are_not_literal() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src").join("a.rs"), "x\n").unwrap();
+
+        assert!(
+            open_within_root(tmp.path(), tmp.path()).is_err(),
+            "the root"
+        );
+        assert!(
+            open_within_root(tmp.path(), &tmp.path().join("..").join("a.rs")).is_err(),
+            "a parent component"
+        );
+        assert!(
+            open_within_root(&tmp.path().join("src"), &tmp.path().join("src")).is_err(),
+            "outside the given root"
         );
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -290,6 +290,23 @@ struct ServerState {
     ignore_rules_dirty: std::sync::atomic::AtomicBool,
     /// Ensures a burst of ignore-file events uses at most one refresh worker.
     ignore_refresh_scheduled: std::sync::atomic::AtomicBool,
+    /// Paths the watcher saw while `indexing` was set, kept so they can be
+    /// replayed once the build publishes.
+    ///
+    /// Events that arrive during a build cannot be applied — the stamps do not
+    /// describe the index yet, so every path would read as changed — but they
+    /// are the only record that those paths moved. The build's own walk misses
+    /// anything written to a directory it has already passed, and on a
+    /// whole-subtree backend there is no per-directory recovery scan to fall
+    /// back on, so discarding them leaves the change invisible until the hourly
+    /// reconcile.
+    ///
+    /// `None` means the buffer overflowed and the paths were dropped; the
+    /// replay then falls back to a full stale refresh, which is slower but
+    /// complete. Bounded because a build can run for minutes on a large
+    /// repository and a checkout or a build tree churning underneath it is
+    /// unbounded.
+    deferred_events: Mutex<Option<std::collections::HashSet<PathBuf>>>,
     /// Progress: number of files indexed so far.
     index_progress: std::sync::atomic::AtomicU64,
     /// Total files discovered for indexing.
@@ -573,6 +590,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         gitignore_pending: std::sync::atomic::AtomicBool::new(!no_watch && !no_ignore),
         ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
         ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+        deferred_events: Mutex::new(Some(std::collections::HashSet::new())),
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
         watch_enabled: !no_watch,
@@ -757,24 +775,29 @@ fn build_stale_matcher(
 /// makes the matcher swap and the index decisions around it atomic from the
 /// watcher's point of view.
 ///
-/// Returns the directories that were newly subscribed to as a result, and the
-/// moment the walk behind that decision began. Those were unwatched while the
-/// caller's walk ran, so anything written to them in that window produced no
-/// event and appears in no walk result. Callers pass both to
-/// [`reindex_files_in`] once `state.file_stamps` describes the index they just
-/// published.
+/// Returns the directories that were newly subscribed to as a result. Those
+/// were unwatched while the caller's walk ran, so anything written to them in
+/// that window produced no event and appears in no walk result. Callers pass
+/// them to [`reindex_files_in`] once `state.file_stamps` describes the index
+/// they just published.
+///
+/// `since` is when the walk that produced `matcher` began, and is only passed
+/// through so the recovery scan can use it. It has to come from the caller: the
+/// subscription walk inside this function starts later, and an ignore file
+/// written between the two would predate a timestamp taken here and be read as
+/// already accounted for by rules that never saw it.
 #[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
 fn publish_ignore_matcher(
     state: &ServerState,
     root: &Path,
     matcher: Option<tgrep_core::gitignore::IgnoreMatcher>,
-) -> (Vec<PathBuf>, SystemTime) {
+) -> Vec<PathBuf> {
     *state.gitignore.write().unwrap() = matcher;
     state.gitignore_pending.store(false, Ordering::SeqCst);
     // New rules mean a different set of directories worth hearing about:
     // a tightened rule releases the subscriptions under it, and a relaxed
     // one takes subscriptions for the tree it used to hide.
-    sync_watch_registrations(state, root)
+    sync_watch_registrations(state, root).0
 }
 
 fn handle_connection(stream: TcpStream, state: &ServerState) -> Result<()> {
@@ -2424,6 +2447,103 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 
 /// Recheck newly watched directories on a background thread.
 ///
+/// Remember the paths in an event that arrived mid-build, for replay once the
+/// build publishes.
+///
+/// The event cannot be applied now: until `indexing` clears, `file_stamps` does
+/// not describe the index, so every path would compare as changed and the
+/// watcher would re-read the repository alongside the build already reading it.
+/// It cannot simply be dropped either — see [`ServerState::deferred_events`].
+///
+/// Capped, and the cap discards the whole set rather than truncating it: a
+/// partial set is indistinguishable from a complete one at replay time, and
+/// silently recovering nine tenths of a checkout is worse than knowing to fall
+/// back on a full refresh.
+fn defer_events_during_build(state: &ServerState, event: &Event) {
+    /// A checkout of the Linux kernel is ~90k files. Above this the fallback
+    /// refresh is cheaper than the replay would be anyway.
+    const MAX_DEFERRED: usize = 100_000;
+
+    let Ok(mut deferred) = state.deferred_events.lock() else {
+        return;
+    };
+    let Some(paths) = deferred.as_mut() else {
+        return;
+    };
+    if paths.len().saturating_add(event.paths.len()) > MAX_DEFERRED {
+        *deferred = None;
+        eprintln!(
+            "[trace] warning: too many file changes during the initial index build to replay \
+             individually; a full reconcile will run instead"
+        );
+        return;
+    }
+    paths.extend(event.paths.iter().cloned());
+}
+
+/// Apply the events that arrived during the build, now that it has published.
+///
+/// Replayed as synthetic create events rather than handled directly so they go
+/// through exactly the filtering an ordinary event gets — ignore rules, the
+/// exclude list, the index directory, new-subtree subscription. `Create(Any)`
+/// is the right kind for all of them: `handle_fs_event` decides removal from
+/// whether the path still exists, and modifications and creations take the same
+/// route, so one kind covers arrivals, edits and deletions alike.
+///
+/// The caller must *not* hold `snapshot_gate`; `handle_fs_event` takes it.
+fn replay_deferred_events(state: &Arc<ServerState>, root: &Path) {
+    let deferred = match state.deferred_events.lock() {
+        // Leaves `Some(empty)` behind, so anything deferred by a later build
+        // (a reconcile sets `indexing` again) is collected from scratch.
+        Ok(mut guard) => guard.replace(std::collections::HashSet::new()),
+        Err(_) => return,
+    };
+    let Some(paths) = deferred else {
+        // Overflowed. A stale refresh rewalks the tree and diffs it against the
+        // index, which covers every path the replay would have, and it is what
+        // already runs when ignore rules change mid-build.
+        eprintln!("[trace] watcher: reconciling after too many changes during the initial build");
+        let state = Arc::clone(state);
+        let root = root.to_path_buf();
+        if thread::Builder::new()
+            .name("tgrep-deferred-reconcile".into())
+            .spawn(move || {
+                if !background_refresh_stale(&state, &root, &state.index_dir, true) {
+                    eprintln!(
+                        "[trace] warning: the post-build reconcile did not complete; changes made \
+                         during the build wait for the next one"
+                    );
+                }
+            })
+            .is_err()
+        {
+            eprintln!("[trace] warning: could not start the post-build reconcile");
+        }
+        return;
+    };
+    if paths.is_empty() {
+        return;
+    }
+
+    let start = Instant::now();
+    let count = paths.len();
+    for path in paths {
+        handle_fs_event(
+            state,
+            root,
+            &Event {
+                kind: EventKind::Create(notify::event::CreateKind::Any),
+                paths: vec![path],
+                attrs: Default::default(),
+            },
+        );
+    }
+    eprintln!(
+        "[trace] watcher: replayed {count} change(s) deferred during the initial build in {:.1}ms",
+        start.elapsed().as_secs_f64() * 1000.0
+    );
+}
+
 /// For the publish sites that cannot scan inline. Until a directory is
 /// subscribed it cannot report a write, and the walk that decided to subscribe
 /// to it may have passed it before that write happened, so a file landing in
@@ -2436,16 +2556,16 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 ///
 /// Waits out `indexing` first. During a build the stamps do not describe the
 /// index yet, so every file would look changed and the scan would re-read the
-/// whole repository alongside the build that is already doing it.
+/// whole repository alongside the build that is already doing it. That wait is
+/// also what makes this the right place to replay the events the build made the
+/// watcher discard, which is why it runs even on a backend that has nothing
+/// per-directory to recover.
 fn spawn_recovery_scan(
     state: &Arc<ServerState>,
     root: &Path,
     dirs: Vec<PathBuf>,
     since: SystemTime,
 ) {
-    if dirs.is_empty() || !PER_DIRECTORY_WATCHES {
-        return;
-    }
     let state = Arc::clone(state);
     let root = root.to_path_buf();
     let spawned = thread::Builder::new()
@@ -2453,6 +2573,15 @@ fn spawn_recovery_scan(
         .spawn(move || {
             while state.indexing.load(Ordering::SeqCst) {
                 thread::sleep(Duration::from_millis(200));
+            }
+            // Before the gate, not under it: this takes `snapshot_gate` for
+            // read itself, and std's `RwLock` may deadlock on a recursive read
+            // if a writer queues up in between.
+            replay_deferred_events(&state, &root);
+
+            let dirs = recovery_scan_dirs(&state, &root, dirs);
+            if dirs.is_empty() {
+                return;
             }
             // Read, not write: this does exactly what `handle_fs_event` does,
             // and that runs under the read side. Taking it at all is what
@@ -2468,6 +2597,30 @@ fn spawn_recovery_scan(
              wait for the next reconcile"
         );
     }
+}
+
+/// The directories a recovery scan should recheck, given the ones a
+/// subscription sync reported as newly watched.
+///
+/// The root is added because it is never in that list: it is subscribed as the
+/// watcher starts, before any matcher exists, so every later sync sees it as
+/// already watched. Nothing else covers it — a file written to the top level
+/// while a build walk was deeper in the tree produced no event the build could
+/// use and no event the watcher would keep — and it costs one directory
+/// listing.
+///
+/// Empty on a whole-subtree backend, where there are no per-directory
+/// subscriptions to have raced and `reindex_files_in`'s pickup of unwatched
+/// subdirectories would take exactly the per-directory watches that backend
+/// exists to avoid.
+fn recovery_scan_dirs(state: &ServerState, root: &Path, mut dirs: Vec<PathBuf>) -> Vec<PathBuf> {
+    if !PER_DIRECTORY_WATCHES || !state.watch_enabled {
+        return Vec::new();
+    }
+    if !dirs.iter().any(|d| d == root) {
+        dirs.push(root.to_path_buf());
+    }
+    dirs
 }
 
 fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
@@ -2494,8 +2647,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     }
 
     // Skip ordinary file events while the initial background index build is in
-    // progress. The indexer will pick up those files itself.
+    // progress. The indexer will pick up those files itself — but only for the
+    // parts of the tree it has not reached yet, so remember these and replay
+    // them once it publishes.
     if state.indexing.load(Ordering::SeqCst) {
+        defer_events_during_build(state, event);
         return;
     }
 
@@ -2610,26 +2766,110 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     }
 }
 
+/// Drop everything the index holds for a path.
+///
+/// The delete is not conditional on a stamp entry. `ServerState` accepts an
+/// empty stamp map when `filestamps.json` is missing or unreadable, and the
+/// reader can still hold the path in that state, so keying the delete on the
+/// stamp alone would leave content the walk now rejects searchable. The stamp
+/// removal is best-effort; the index and cache deletes always happen.
+///
+/// The cost of that is a tombstone in the overlay for paths that were never
+/// indexed — `live::delete_file` records one either way — and this runs for
+/// every ineligible file a recovery scan walks past, which at startup is every
+/// binary asset in the repository. An existing tombstone is therefore taken as
+/// proof there is nothing left to do, which bounds that to one per distinct
+/// path. The trace line, which is the part that would be actively misleading,
+/// stays conditional on there having been something to drop.
+///
+/// The caller must already hold `snapshot_gate`.
+fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
+    let had_stamp = state
+        .file_stamps
+        .write()
+        .unwrap()
+        .remove(rel_path)
+        .is_some();
+    {
+        let index = state.index.read().unwrap();
+        if index.live.has_path(rel_path) || had_stamp {
+            eprintln!("[trace] reindex: dropped {rel_path} ({reason})");
+        } else if index.live.is_deleted(rel_path) {
+            // Already tombstoned, so there is nothing to record and no reason
+            // to dirty the overlay again. This is the repeat case: a recovery
+            // scan or a chatty editor can bring the same rejected path back
+            // here any number of times.
+            return;
+        }
+    }
+    state.index.write().unwrap().live.delete_file(rel_path);
+    if let Ok(mut cache) = state.cache.write() {
+        cache.pop(rel_path);
+    }
+}
+
+/// Open a file without following a final symlink, so the handle is the path
+/// itself rather than wherever it points.
+///
+/// Every later question — is this a regular file, how big is it, what is in it
+/// — is then answered from the one handle, which is what makes the eligibility
+/// decision and the read describe the same object. Checking the path and then
+/// reading it separately leaves a window in which a tree being rewritten under
+/// us (a checkout, a build, `git mv`) can swap a regular file for a link, and
+/// the read would follow it out of the served root.
+fn open_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // Fails outright on a symlink, which is the answer we want.
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // Opens the reparse point rather than its target. Unlike O_NOFOLLOW
+        // this succeeds, so the caller's `is_file` check on the handle's
+        // metadata is what rejects it — a reparse point is not a regular file.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        std::fs::File::open(path)
+    }
+}
+
 /// Read a file and merge it into the live index, unless its stamp says the
 /// content we already indexed is current.
 ///
 /// The caller must hold `snapshot_gate`: the read, the commit, and the stamp
 /// update have to be atomic with respect to a flush or auto-save.
 fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
+    use std::io::Read;
     use tgrep_core::meta::FileStamp;
 
-    // Compute the file's current stamp and skip if it matches what we
-    // last indexed. notify on Windows in particular fires Modify events
-    // for atime/attribute updates, opens, etc. — re-indexing on those
-    // would re-read large files, churn the live overlay, and produce a
-    // misleading "modified" trace for files that didn't actually change.
-    //
-    // `symlink_metadata` describes the link itself; `metadata` would describe
-    // its target. See the eligibility check below for why that distinction
-    // matters here.
-    let meta = match std::fs::symlink_metadata(path) {
-        Ok(m) => m,
-        Err(_) => return,
+    // One handle for the whole decision. Opened without following a final
+    // symlink, and every fact below — type, size, mtime, bytes — read back off
+    // it, so nothing that happens to the path in the meantime can make the
+    // content we index disagree with the metadata we judged it by.
+    let file = match open_no_follow(path) {
+        Ok(f) => f,
+        Err(_) => {
+            // Includes the ELOOP that a symlink gets on unix. It may still be
+            // a path we indexed before it became one, so fall through to the
+            // drop rather than returning.
+            drop_indexed_file(state, rel_path, "no longer eligible");
+            return;
+        }
+    };
+    let Ok(meta) = file.metadata() else {
+        return;
     };
     let current = FileStamp {
         mtime: meta
@@ -2648,13 +2888,14 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // — would be read whole and indexed, and the next reconcile would silently
     // delete it again.
     //
-    // `is_file` on the link's own metadata is the third rule, and the one with
-    // teeth: the walker runs with `follow_links(false)`, where a symlink is
-    // neither file nor dir and is skipped outright. Following one here would
-    // read the target and index its bytes under the link's path — and the
-    // target need not be under `root` at all, so a link committed to a branch
-    // (or dropped in by a build) is enough to pull `~/.ssh/id_rsa` into an
-    // index whose whole contract is that it covers the served tree.
+    // `is_file` is the third rule, and the one with teeth: the walker runs with
+    // `follow_links(false)`, where a symlink is neither file nor dir and is
+    // skipped outright. Indexing through one would put the target's bytes under
+    // the link's path — and the target need not be under `root` at all, so a
+    // link committed to a branch (or dropped in by a build) is enough to pull
+    // `~/.ssh/id_rsa` into an index whose whole contract is that it covers the
+    // served tree. On unix the open above has already failed for a link; this
+    // is what rejects one on Windows, where the reparse point opens fine.
     let eligible = meta.is_file()
         && !tgrep_core::walker::is_binary_extension(path)
         && !state
@@ -2665,36 +2906,7 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
         // past the cap, and a real file can be replaced by a link to one. Drop
         // what we hold so the index matches the walk rather than keeping a
         // stale copy of the smaller version until the reconcile.
-        //
-        // The stamp is not the only evidence that something is indexed. A file
-        // the watcher added since the last flush lives in the live overlay,
-        // and a stamp map that was replaced wholesale — by a stale merge, or
-        // by a load that failed and left it empty — no longer mentions it, so
-        // testing the stamp alone would skip the drop and keep serving content
-        // the walk rejects. `has_path` covers the overlay; an entry that is
-        // only in the persisted reader with no stamp to match is beyond what
-        // can be checked cheaply here (the reader has no path index) and is
-        // left to the reconcile's membership diff.
-        //
-        // Both are checked before deleting rather than deleting unconditionally
-        // the way the removal branch does: removals are rare, but this runs for
-        // every ineligible file a recovery scan walks past, and `delete_file`
-        // records a tombstone and dirties the overlay even when the path was
-        // never indexed.
-        let had_stamp = state
-            .file_stamps
-            .write()
-            .unwrap()
-            .remove(rel_path)
-            .is_some();
-        let in_overlay = state.index.read().unwrap().live.has_path(rel_path);
-        if had_stamp || in_overlay {
-            eprintln!("[trace] reindex: dropped {rel_path} (no longer eligible)");
-            state.index.write().unwrap().live.delete_file(rel_path);
-            if let Ok(mut cache) = state.cache.write() {
-                cache.pop(rel_path);
-            }
-        }
+        drop_indexed_file(state, rel_path, "no longer eligible");
         return;
     }
 
@@ -2707,10 +2919,14 @@ fn reindex_file(state: &ServerState, path: &Path, rel_path: &str) {
     // on our file I/O and trigram parsing. Windows' SRWLock is
     // writer-preferring: a single waiting writer here would otherwise
     // stall every subsequent search request.
-    let data = match std::fs::read(path) {
-        Ok(d) => d,
-        Err(_) => return,
-    };
+    //
+    // From the handle, not the path: re-opening here is what would let a
+    // symlink take the place of the file we just approved.
+    let mut file = file;
+    let mut data = Vec::with_capacity(current.size.min(1 << 20) as usize);
+    if file.read_to_end(&mut data).is_err() {
+        return;
+    }
     let text = tgrep_core::encoding::decode_for_index(&data);
     let is_binary = tgrep_core::trigram::is_binary(&text);
     let per_tri = if is_binary {
@@ -3278,10 +3494,9 @@ fn refresh_stale_locked(
     // the caller holds `snapshot_gate` for write across this whole body, and
     // the only reader of `state.gitignore` takes the read side first, so no
     // event can observe the matcher before this function returns either way.
-    // The caller anchored the recovery window at its own walk, which starts
-    // earlier than the subscription sync inside this call, so the timestamp
-    // that comes back here is the looser of the two and is dropped.
-    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk)).0;
+    // The caller's walk started before this publish; its timestamp is what the
+    // recovery scan needs, so the one the subscription sync derives is dropped.
+    *newly_watched = publish_ignore_matcher(state, root, build_stale_matcher(state, root, &walk));
 
     if walk.skipped_error > 0 {
         eprintln!(
@@ -3435,6 +3650,13 @@ fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
 /// caller to fall back.
 fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path) -> bool {
     let start = Instant::now();
+    // Anchors the recovery window at the start of the build's traversal, which
+    // is the point from which writes could be missed: nothing under `root` is
+    // subscribed yet, and the walk below has not reached most of it. Taking it
+    // after the build — or letting the later subscription sync derive its own —
+    // would exclude everything written while the build ran, which is precisely
+    // the window that needs recovering.
+    let since = SystemTime::now();
     eprintln!("[trace] bootstrapping index with the external merge sort (memory-bounded)...");
 
     // Dropped once the build is done so the sampled peak (on platforms without
@@ -3510,6 +3732,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
              the watcher may reindex on spurious events"
         ),
     }
+    let mut newly_watched = Vec::new();
     if state.watch_enabled && !state.no_ignore {
         let t_gi = Instant::now();
         let matcher = tgrep_core::walker::build_gitignore_matcher_from_files(
@@ -3524,14 +3747,19 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         // than skipped: the scan waits out `indexing` and then costs one
         // `metadata` call per file, since the stamps this build just wrote
         // describe the index exactly.
-        let (newly_watched, since) = publish_ignore_matcher(state, root, matcher);
-        spawn_recovery_scan(state, root, newly_watched, since);
+        newly_watched = publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from {} file(s) in {:.1}ms{}",
             outcome.gitignore_files.len(),
             t_gi.elapsed().as_secs_f64() * 1000.0,
             if found { "" } else { " (no rules found)" }
         );
+    }
+    // Outside that block, because it also drains the events the watcher had to
+    // discard while this build ran, and those pile up whether or not there are
+    // ignore rules to publish.
+    if state.watch_enabled {
+        spawn_recovery_scan(state, root, newly_watched, since);
     }
 
     state.indexing.store(false, Ordering::SeqCst);
@@ -3596,6 +3824,11 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
 
     // Phase 1: Walk file paths (no content reads)
     let t_walk = Instant::now();
+    // The recovery window opens with this traversal, not with the subscriptions
+    // it later feeds: a nested `.ignore` written after the walk read its parent
+    // directory but before the matcher is published is invisible to both, and a
+    // timestamp taken any later would date it as already accounted for.
+    let since = SystemTime::now();
     let walk = walker::walk_dir(
         root,
         &WalkOptions {
@@ -3609,6 +3842,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         },
     );
 
+    let mut newly_watched = Vec::new();
     if state.watch_enabled && !state.no_ignore {
         let start = Instant::now();
         let matcher = walker::build_gitignore_matcher_from_files(
@@ -3623,8 +3857,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         // the build's results nor any event. The scan waits for the build to
         // finish before looking, because until then the stamps describe
         // nothing and every file would read as changed.
-        let (newly_watched, since) = publish_ignore_matcher(state, root, matcher);
-        spawn_recovery_scan(state, root, newly_watched, since);
+        newly_watched = publish_ignore_matcher(state, root, matcher);
         eprintln!(
             "[trace] gitignore matcher built from index walk in {:.1}ms \
              ({} .gitignore + {} .ignore files{})",
@@ -3633,6 +3866,11 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             walk.ignore_files.len(),
             if has_matcher { "" } else { ", no rules found" }
         );
+    }
+    // Outside that block: the scan also drains the events discarded while this
+    // build ran, which accumulate with or without ignore rules.
+    if state.watch_enabled {
+        spawn_recovery_scan(state, root, newly_watched, since);
     }
 
     // Filter out already-indexed files
@@ -4387,6 +4625,7 @@ mod tests {
             gitignore_pending: std::sync::atomic::AtomicBool::new(true),
             ignore_rules_dirty: std::sync::atomic::AtomicBool::new(false),
             ignore_refresh_scheduled: std::sync::atomic::AtomicBool::new(false),
+            deferred_events: Mutex::new(Some(std::collections::HashSet::new())),
             index_progress: std::sync::atomic::AtomicU64::new(0),
             index_total: std::sync::atomic::AtomicU64::new(0),
             watch_enabled: true,
@@ -5151,6 +5390,131 @@ mod tests {
         assert!(
             state.gitignore.read().unwrap().is_some(),
             "the matcher the walk did find must still be published"
+        );
+    }
+
+    /// The metadata the eligibility check uses and the bytes that get indexed
+    /// have to describe the same object, which means one handle.
+    #[test]
+    fn open_no_follow_reads_a_regular_file() {
+        use std::io::Read;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("plain.rs");
+        std::fs::write(&path, "fn main() {}\n").unwrap();
+
+        let file = open_no_follow(&path).expect("a regular file opens");
+        let meta = file.metadata().expect("metadata off the handle");
+        assert!(meta.is_file());
+        assert_eq!(meta.len(), 13);
+
+        let mut data = String::new();
+        (&file).read_to_string(&mut data).unwrap();
+        assert_eq!(data, "fn main() {}\n");
+    }
+
+    /// A symlink must not open as its target, or a link committed to a branch
+    /// would pull a file from outside the served root into the index.
+    #[cfg(unix)]
+    #[test]
+    fn open_no_follow_refuses_a_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("secret.txt");
+        std::fs::write(&target, "sensitive\n").unwrap();
+        let link = tmp.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert!(
+            open_no_follow(&link).is_err(),
+            "O_NOFOLLOW must reject the link rather than open its target"
+        );
+    }
+
+    /// A burst big enough to be worth replaying individually is not worth
+    /// replaying individually. The buffer gives up as a whole, because a
+    /// truncated set looks exactly like a complete one at replay time.
+    #[cfg(unix)]
+    #[test]
+    fn deferring_more_changes_than_the_cap_gives_up_on_the_whole_set() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+
+        let small = Event {
+            kind: EventKind::Create(notify::event::CreateKind::Any),
+            paths: vec![root.join("a.rs")],
+            attrs: Default::default(),
+        };
+        defer_events_during_build(&state, &small);
+        assert_eq!(
+            state.deferred_events.lock().unwrap().as_ref().unwrap().len(),
+            1
+        );
+
+        let flood = Event {
+            kind: EventKind::Create(notify::event::CreateKind::Any),
+            paths: (0..200_001).map(|i| root.join(format!("f{i}.rs"))).collect(),
+            attrs: Default::default(),
+        };
+        defer_events_during_build(&state, &flood);
+        assert!(
+            state.deferred_events.lock().unwrap().is_none(),
+            "an overflowing burst must mark the buffer unusable, not truncate it"
+        );
+
+        // And stays given up on, rather than resuming a partial record.
+        defer_events_during_build(&state, &small);
+        assert!(state.deferred_events.lock().unwrap().is_none());
+    }
+
+    /// Events seen while a build ran are not applied then, but they are the
+    /// only record that those paths moved: the build's walk misses anything
+    /// written to a directory it already passed.
+    #[cfg(unix)]
+    #[test]
+    fn changes_deferred_during_a_build_are_applied_once_it_publishes() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+        // As it is once a build publishes: no rules to wait for, nothing
+        // indexing.
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let path = root.join("late.rs");
+        std::fs::write(&path, "fn written_during_the_build() {}\n").unwrap();
+
+        state.indexing.store(true, Ordering::SeqCst);
+        handle_fs_event(
+            &state,
+            &root,
+            &Event {
+                kind: EventKind::Create(notify::event::CreateKind::Any),
+                paths: vec![path.clone()],
+                attrs: Default::default(),
+            },
+        );
+        assert!(
+            !state.index.read().unwrap().live.has_path("late.rs"),
+            "an event during a build must not touch the index"
+        );
+
+        state.indexing.store(false, Ordering::SeqCst);
+        replay_deferred_events(&state, &root);
+
+        assert!(
+            state.index.read().unwrap().live.has_path("late.rs"),
+            "the deferred change must be applied once the build is done"
+        );
+        assert!(
+            state
+                .deferred_events
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|p| p.is_empty()),
+            "the buffer must be drained, and left usable for the next build"
         );
     }
 

--- a/tgrep-cli/tests/watcher_dot_ignore.rs
+++ b/tgrep-cli/tests/watcher_dot_ignore.rs
@@ -101,6 +101,48 @@ fn wait_for_match(port: u16, pattern: &str, timeout: Duration) -> bool {
     }
 }
 
+/// Poll until `pattern` stops being searchable, returning whether it went away.
+fn wait_for_no_match(port: u16, pattern: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        if search_matches(port, pattern) == 0 {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn build_index(root: &Path, index_dir: &Path) {
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+}
+
+fn spawn_server(root: &Path, index_dir: &Path) -> ServerGuard {
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    ServerGuard { child }
+}
+
 #[test]
 fn watcher_honors_dot_ignore_and_still_indexes_new_files() {
     let dir = TempDir::new().unwrap();
@@ -117,29 +159,8 @@ fn watcher_honors_dot_ignore_and_still_indexes_new_files() {
     )
     .unwrap();
 
-    let status = Command::new(tgrep_bin())
-        .args([
-            "index",
-            root.to_str().unwrap(),
-            "--index-path",
-            index_dir.to_str().unwrap(),
-        ])
-        .status()
-        .expect("failed to run tgrep index");
-    assert!(status.success(), "initial index build failed");
-
-    let child = Command::new(tgrep_bin())
-        .args([
-            "serve",
-            "--index-path",
-            index_dir.to_str().unwrap(),
-            root.to_str().unwrap(),
-        ])
-        .stderr(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .spawn()
-        .expect("failed to start tgrep serve");
-    let _server = ServerGuard { child };
+    build_index(root, &index_dir);
+    let _server = spawn_server(root, &index_dir);
 
     let port = wait_for_port(&index_dir);
 
@@ -174,5 +195,73 @@ fn watcher_honors_dot_ignore_and_still_indexes_new_files() {
         search_matches(port, "dot_ignored_leak_marker"),
         0,
         "watcher indexed a file under a directory excluded by .ignore"
+    );
+}
+
+/// A `.ignore` written *after* the server is live must refresh the ignore
+/// rules, exactly as a `.gitignore` write does.
+///
+/// The startup matcher is built from the walk that the initial index used, so
+/// a `.ignore` that already exists is honored for free — which is what the
+/// test above covers. Rules that appear later only take effect if the watcher
+/// recognizes the `.ignore` write as an ignore-rules change and schedules the
+/// refresh; when it does not, the stale matcher stays published and the
+/// already-indexed content under the newly excluded directory stays
+/// searchable indefinitely (the periodic reconcile is on an hourly timer).
+///
+/// The fixture seeds the ignored file *before* indexing, so the assertion is a
+/// transition — searchable, then not — rather than a fixed sleep racing the
+/// refresh.
+#[test]
+fn late_dot_ignore_refreshes_the_watchers_ignore_rules() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    // No `.git` here either: `.ignore` is not git-gated, so this pins the
+    // refresh path for the one ignore source that works outside a repo.
+    fs::create_dir_all(root.join("secret")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("secret").join("creds.txt"),
+        "late_ignored_leak_marker\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    build_index(root, &index_dir);
+    let _server = spawn_server(root, &index_dir);
+
+    let port = wait_for_port(&index_dir);
+
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source file to be searchable"
+    );
+    // Positive control: with no `.ignore` yet, the seeded file under `secret/`
+    // is legitimately indexed. Without this the assertion below could pass
+    // simply because the file was never indexed in the first place.
+    assert!(
+        wait_for_match(port, "late_ignored_leak_marker", Duration::from_secs(30)),
+        "expected the file under secret/ to be indexed before any .ignore exists"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    fs::write(root.join(".ignore"), "secret/\n").unwrap();
+
+    assert!(
+        wait_for_no_match(port, "late_ignored_leak_marker", Duration::from_secs(60)),
+        "a .ignore written while the server was live never refreshed the ignore \
+         rules; content under the newly excluded directory is still searchable"
+    );
+
+    // The refresh must not take the rest of the index with it.
+    assert!(
+        search_matches(port, "normal_source_marker") > 0,
+        "the ignore-rules refresh dropped a file that is not ignored"
     );
 }

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -306,3 +306,84 @@ fn watcher_indexes_files_in_directories_created_after_startup() {
         "watcher indexed a file in a directory created under a gitignored path"
     );
 }
+
+/// A subtree that arrives already populated can carry its own ignore rules.
+///
+/// A clone, a `git mv`, a branch switch or an unpacked archive all land this
+/// way: the directory and everything under it appear in one step, so there is
+/// no moment at which the `.gitignore` inside it is seen on its own. The
+/// recovery pass skips dot-prefixed files, so without explicitly looking for
+/// ignore rules it would index the subtree against rules that never mentioned
+/// it — and the wrongly indexed files would stay until something touched them
+/// again or the hourly reconcile came round.
+#[test]
+fn watcher_honors_ignore_rules_inside_a_subtree_that_arrives_whole() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source file to be searchable"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    // Staged under a dot-prefixed name so the watcher ignores it while it is
+    // being built, and on the same filesystem so the move below is atomic.
+    let staging = root.join(".staging");
+    fs::create_dir_all(&staging).unwrap();
+    fs::write(staging.join(".gitignore"), "secret.txt\n").unwrap();
+    fs::write(staging.join("secret.txt"), "moved_subtree_secret_marker\n").unwrap();
+    fs::write(
+        staging.join("keep.rs"),
+        "fn keep() { let moved_subtree_keep_marker = 3; }\n",
+    )
+    .unwrap();
+
+    fs::rename(&staging, root.join("vendor")).unwrap();
+
+    assert!(
+        wait_for_match(port, "moved_subtree_keep_marker", Duration::from_secs(60)),
+        "watcher never indexed the non-ignored file in a subtree that arrived whole"
+    );
+    assert_eq!(
+        search_matches(port, "moved_subtree_secret_marker"),
+        0,
+        "watcher indexed a file excluded by a .gitignore that arrived inside \
+         the same subtree, so the subtree was indexed against stale rules"
+    );
+}

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -1,0 +1,308 @@
+//! The watcher must not take OS subscriptions for trees it is going to ignore.
+//!
+//! On Linux `notify` has no recursive inotify mode: `RecursiveMode::Recursive`
+//! walks the tree and spends one watch descriptor per directory. Ignored build
+//! output is usually most of the directories in a repository, so subscribing to
+//! it burns the per-user `fs.inotify.max_user_watches` budget on events that
+//! are then discarded — and because notify propagates the first registration
+//! failure, a repo large enough to exhaust that budget loses its watcher
+//! entirely.
+//!
+//! This is observable: the kernel reports a process's inotify watches in
+//! `/proc/<pid>/fdinfo/<fd>`, one `inotify wd:` line per watch. The test below
+//! counts them for a live server and pins that the ignored subtree is absent,
+//! while asserting the watcher still works — a watcher that registered nothing
+//! at all would trivially satisfy the count.
+//!
+//! Windows (ReadDirectoryChangesW) and macOS (FSEvents) subscribe once for the
+//! whole subtree, so there is no per-directory registration to withhold and
+//! nothing here applies; the count assertion is Linux-only for that reason.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+/// Directories inside the ignored tree. Large enough that a recursive
+/// subscription is unmistakable in the watch count, small enough to create
+/// quickly.
+#[cfg(target_os = "linux")]
+const IGNORED_DIRS: usize = 60;
+/// Directories inside the indexed tree.
+#[cfg(target_os = "linux")]
+const SOURCE_DIRS: usize = 4;
+
+fn tgrep_bin() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin("tgrep")
+}
+
+struct ServerGuard {
+    child: Child,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn send_request(port: u16, request: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    writeln!(stream, "{request}")?;
+    stream.flush()?;
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader.read_line(&mut response)?;
+    Ok(response)
+}
+
+fn search_matches(port: u16, pattern: &str) -> u64 {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "search",
+        "id": 1,
+        "params": { "pattern": pattern }
+    })
+    .to_string();
+    let response = send_request(port, &request).expect("search request failed");
+    let value: serde_json::Value = serde_json::from_str(&response).expect("invalid JSON response");
+    value
+        .pointer("/result/num_matches")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| panic!("missing num_matches in response: {response}"))
+}
+
+fn wait_for_match(port: u16, pattern: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        if search_matches(port, pattern) > 0 {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Read `(pid, port)` once the server is accepting connections.
+fn wait_for_server(index_dir: &Path) -> (u32, u16) {
+    let serve_json = index_dir.join("serve.json");
+    let start = Instant::now();
+    loop {
+        assert!(
+            start.elapsed() <= Duration::from_secs(60),
+            "tgrep serve did not start within 60 seconds"
+        );
+        if let Ok(data) = fs::read_to_string(&serve_json)
+            && let Ok(info) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(p) = info.get("port").and_then(|v| v.as_u64())
+            && let Some(pid) = info.get("pid").and_then(|v| v.as_u64())
+            && TcpStream::connect(format!("127.0.0.1:{p}")).is_ok()
+        {
+            return (pid as u32, p as u16);
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Total inotify watch descriptors held by `pid`.
+///
+/// Each inotify file descriptor's `fdinfo` lists one `inotify wd:` line per
+/// watch, so summing them across the process's descriptors gives the number of
+/// directories it is subscribed to.
+#[cfg(target_os = "linux")]
+fn inotify_watch_count(pid: u32) -> usize {
+    let dir = format!("/proc/{pid}/fdinfo");
+    let Ok(entries) = fs::read_dir(&dir) else {
+        panic!("could not read {dir}; /proc must be mounted for this test");
+    };
+    let mut total = 0;
+    for entry in entries.flatten() {
+        // Descriptors come and go while we read; a vanished one is not a
+        // failure, it simply holds no watches we can count.
+        if let Ok(contents) = fs::read_to_string(entry.path()) {
+            total += contents
+                .lines()
+                .filter(|line| line.starts_with("inotify wd:"))
+                .count();
+        }
+    }
+    total
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn watcher_does_not_subscribe_to_gitignored_directories() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    // A real (if empty) `.git` entry: `.gitignore` rules only apply inside a
+    // repository, so without it the fixture would measure the wrong thing.
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+
+    for i in 0..IGNORED_DIRS {
+        let sub = root.join("build").join(format!("out{i}"));
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(sub.join("artifact.txt"), "ignored_build_output\n").unwrap();
+    }
+    for i in 0..SOURCE_DIRS {
+        let sub = root.join("src").join(format!("pkg{i}"));
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(
+            sub.join("lib.rs"),
+            format!("fn seeded{i}() {{ let normal_source_marker = {i}; }}\n"),
+        )
+        .unwrap();
+    }
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (pid, port) = wait_for_server(&index_dir);
+
+    // Positive control, and a wait for the watcher to be live: subscriptions
+    // are deferred until the ignore matcher is published, so counting before
+    // that would pass for the wrong reason.
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source files to be searchable"
+    );
+    fs::write(
+        root.join("src").join("added.rs"),
+        "fn added() { let watcher_added_marker = 1; }\n",
+    )
+    .unwrap();
+    assert!(
+        wait_for_match(port, "watcher_added_marker", Duration::from_secs(30)),
+        "watcher never indexed a newly created ordinary file, so the watch \
+         count below would be meaningless"
+    );
+
+    let watches = inotify_watch_count(pid);
+
+    // The tree the watcher legitimately needs is the root, `src`, `src/pkg*`,
+    // and `.git` is hidden so it is not watched either. Allow generous slack
+    // for anything else in the process holding an inotify fd, but stay far
+    // below the ~66 a recursive subscription over this fixture would take.
+    let allowed = SOURCE_DIRS + 8;
+    assert!(
+        watches <= allowed,
+        "watcher holds {watches} inotify watches for a tree whose only \
+         non-ignored directories are the root plus {SOURCE_DIRS} under src/; \
+         it is subscribing to the {IGNORED_DIRS} gitignored directories under \
+         build/ (expected at most {allowed})"
+    );
+}
+
+/// New directories still have to be picked up.
+///
+/// Non-recursive subscriptions are not extended by notify, so a directory
+/// created after startup is invisible unless the watcher subscribes to it as
+/// it appears. This runs everywhere: on a whole-subtree backend it simply
+/// re-confirms the existing behaviour, which is the point — the two paths must
+/// agree.
+#[test]
+fn watcher_indexes_files_in_directories_created_after_startup() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "normal_source_marker", Duration::from_secs(30)),
+        "expected the seeded source file to be searchable"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    // A whole new subtree, several levels deep, written in one go. The files
+    // land immediately after their directories, which is exactly the race the
+    // subscription pass has to close.
+    let nested = root.join("src").join("fresh").join("deeper");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(
+        nested.join("new.rs"),
+        "fn fresh() { let nested_new_dir_marker = 2; }\n",
+    )
+    .unwrap();
+
+    assert!(
+        wait_for_match(port, "nested_new_dir_marker", Duration::from_secs(30)),
+        "watcher never indexed a file created in a directory that did not \
+         exist when the server started"
+    );
+
+    // ...and a directory created inside the ignored tree stays ignored.
+    let ignored = root.join("build").join("fresh");
+    fs::create_dir_all(&ignored).unwrap();
+    fs::write(ignored.join("out.txt"), "new_ignored_dir_marker\n").unwrap();
+    thread::sleep(Duration::from_secs(3));
+    assert_eq!(
+        search_matches(port, "new_ignored_dir_marker"),
+        0,
+        "watcher indexed a file in a directory created under a gitignored path"
+    );
+}

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -387,3 +387,86 @@ fn watcher_honors_ignore_rules_inside_a_subtree_that_arrives_whole() {
          the same subtree, so the subtree was indexed against stale rules"
     );
 }
+
+/// A directory removed and recreated at the same path must still be watched.
+///
+/// The kernel drops an inotify watch when its directory goes away and does not
+/// say so, leaving the path recorded as watched with no descriptor behind it.
+/// Nothing later can tell that entry from a live one — it is in the desired set
+/// *and* in the watched set — so without explicitly clearing it on removal the
+/// directory stops being watched for the life of the process.
+///
+/// `rm -rf build && mkdir build`, a branch switch, and a `git clean` all do
+/// exactly this.
+#[test]
+fn watcher_rewatches_a_directory_that_is_removed_and_recreated() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir_all(root.join("src").join("gen")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let normal_source_marker = 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src").join("gen").join("old.rs"),
+        "fn old() { let pre_delete_marker = 2; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "pre_delete_marker", Duration::from_secs(30)),
+        "expected the seeded file in src/gen to be searchable"
+    );
+    thread::sleep(Duration::from_secs(2));
+
+    let gen_dir = root.join("src").join("gen");
+    fs::remove_dir_all(&gen_dir).unwrap();
+    thread::sleep(Duration::from_secs(2));
+    fs::create_dir_all(&gen_dir).unwrap();
+
+    // Deliberately after the recreation has been processed. A file written in
+    // the same breath would be picked up by the subscription pass's own scan
+    // and would say nothing about whether the watch itself was re-established.
+    thread::sleep(Duration::from_secs(3));
+    fs::write(
+        gen_dir.join("new.rs"),
+        "fn regenerated() { let post_recreate_marker = 3; }\n",
+    )
+    .unwrap();
+
+    assert!(
+        wait_for_match(port, "post_recreate_marker", Duration::from_secs(30)),
+        "watcher never saw a file written to a directory that was removed and \
+         recreated, so its subscription was not re-established"
+    );
+}

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -92,6 +92,25 @@ fn wait_for_match(port: u16, pattern: &str, timeout: Duration) -> bool {
     }
 }
 
+/// Wait until `pattern` stops matching.
+///
+/// For content that has to be *dropped* from the index. The barrier the other
+/// assertions use — a second file appearing — only proves that some later event
+/// was processed, which on a backend that coalesces or reorders events (macOS)
+/// says nothing about the drop.
+fn wait_for_no_match(port: u16, pattern: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        if search_matches(port, pattern) == 0 {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
 /// Read `(pid, port)` once the server is accepting connections.
 fn wait_for_server(index_dir: &Path) -> (u32, u16) {
     let serve_json = index_dir.join("serve.json");
@@ -497,6 +516,12 @@ fn watcher_applies_the_same_file_eligibility_rules_as_the_walker() {
         "fn seeded() { let seeded_source_marker = 1; }\n",
     )
     .unwrap();
+    // Small enough to be indexed now, and grown past the cap below.
+    fs::write(
+        root.join("src").join("grows.rs"),
+        "fn grows() { let outgrew_the_cap_marker = 5; }\n",
+    )
+    .unwrap();
 
     let status = Command::new(tgrep_bin())
         .args([
@@ -543,6 +568,11 @@ fn watcher_applies_the_same_file_eligibility_rules_as_the_walker() {
     let mut oversized = String::from("fn big() { let oversized_file_marker = 3; }\n");
     oversized.push_str(&"// padding\n".repeat(400));
     fs::write(src.join("huge.rs"), oversized).unwrap();
+    // Already in the index, and now over the cap: what was indexed has to go,
+    // not just stop being updated.
+    let mut grown = String::from("fn grows() { let outgrew_the_cap_marker = 5; }\n");
+    grown.push_str(&"// padding\n".repeat(400));
+    fs::write(src.join("grows.rs"), grown).unwrap();
     fs::write(
         src.join("extra.rs"),
         "fn extra() { let eligible_file_marker = 4; }\n",
@@ -564,5 +594,98 @@ fn watcher_applies_the_same_file_eligibility_rules_as_the_walker() {
         search_matches(port, "oversized_file_marker"),
         0,
         "the watcher indexed a file larger than --max-filesize"
+    );
+    assert!(
+        wait_for_no_match(port, "outgrew_the_cap_marker", Duration::from_secs(30)),
+        "a file that grew past --max-filesize kept its indexed content"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn watcher_does_not_index_through_symlinks() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    // Deliberately outside the served root: this stands in for anything a
+    // symlink committed to a branch could point at.
+    let outside = TempDir::new().unwrap();
+    let secret = outside.path().join("secret.txt");
+    fs::write(&secret, "fn leak() { let outside_root_marker = 1; }\n").unwrap();
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let seeded_source_marker = 1; }\n",
+    )
+    .unwrap();
+    // Indexed as a real file first, then replaced by a link below.
+    fs::write(
+        root.join("src").join("swapped.rs"),
+        "fn swapped() { let replaced_by_symlink_marker = 2; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "seeded_source_marker", Duration::from_secs(30)),
+        "expected the seeded file to be searchable"
+    );
+    assert_eq!(
+        search_matches(port, "replaced_by_symlink_marker"),
+        1,
+        "expected the file that is about to be replaced to start out indexed"
+    );
+
+    let src = root.join("src");
+    std::os::unix::fs::symlink(&secret, src.join("link.rs")).unwrap();
+    fs::remove_file(src.join("swapped.rs")).unwrap();
+    std::os::unix::fs::symlink(&secret, src.join("swapped.rs")).unwrap();
+    fs::write(
+        src.join("extra.rs"),
+        "fn extra() { let eligible_file_marker = 3; }\n",
+    )
+    .unwrap();
+
+    assert!(
+        wait_for_match(port, "eligible_file_marker", Duration::from_secs(30)),
+        "the eligible file written alongside the symlinks was never indexed, \
+         so this test cannot say anything about the symlinks"
+    );
+
+    assert!(
+        wait_for_no_match(port, "replaced_by_symlink_marker", Duration::from_secs(30)),
+        "a real file replaced by a symlink kept its old content in the index"
+    );
+    assert_eq!(
+        search_matches(port, "outside_root_marker"),
+        0,
+        "the watcher followed a symlink and indexed content from outside the served root"
     );
 }

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -470,3 +470,99 @@ fn watcher_rewatches_a_directory_that_is_removed_and_recreated() {
          recreated, so its subscription was not re-established"
     );
 }
+
+/// The walk decides what belongs in the index; the watcher must agree with it.
+///
+/// `should_skip_watcher_path` only filters by location — excludes, ignore
+/// rules, hidden paths. It says nothing about the two rules the walker applies
+/// per file: binary extensions are skipped, and so is anything over
+/// `--max-filesize`. A file arriving through the watcher therefore used to be
+/// indexed even when a walk of the very same tree would have rejected it, so
+/// the index disagreed with itself depending on whether a file was present at
+/// startup or written afterwards — and the next reconcile silently deleted it.
+///
+/// Both rejections are asserted alongside an eligible file written at the same
+/// moment. Without that control the test would pass just as happily against a
+/// watcher that had stopped indexing anything at all.
+#[test]
+fn watcher_applies_the_same_file_eligibility_rules_as_the_walker() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep_test_index");
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src").join("lib.rs"),
+        "fn seeded() { let seeded_source_marker = 1; }\n",
+    )
+    .unwrap();
+
+    let status = Command::new(tgrep_bin())
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--max-filesize",
+            "2K",
+        ])
+        .status()
+        .expect("failed to run tgrep index");
+    assert!(status.success(), "initial index build failed");
+
+    let child = Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--max-filesize",
+            "2K",
+            root.to_str().unwrap(),
+        ])
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+    let _server = ServerGuard { child };
+
+    let (_pid, port) = wait_for_server(&index_dir);
+    assert!(
+        wait_for_match(port, "seeded_source_marker", Duration::from_secs(30)),
+        "expected the seeded file to be searchable"
+    );
+
+    let src = root.join("src");
+    // Text content, so nothing but the extension can keep it out.
+    fs::write(
+        src.join("asset.png"),
+        "fn decoy() { let binary_extension_marker = 2; }\n",
+    )
+    .unwrap();
+    // Same marker, pushed past the 2K cap by padding.
+    let mut oversized = String::from("fn big() { let oversized_file_marker = 3; }\n");
+    oversized.push_str(&"// padding\n".repeat(400));
+    fs::write(src.join("huge.rs"), oversized).unwrap();
+    fs::write(
+        src.join("extra.rs"),
+        "fn extra() { let eligible_file_marker = 4; }\n",
+    )
+    .unwrap();
+
+    assert!(
+        wait_for_match(port, "eligible_file_marker", Duration::from_secs(30)),
+        "the eligible file written next to the rejected ones was never indexed, \
+         so this test cannot say anything about the rejections"
+    );
+
+    assert_eq!(
+        search_matches(port, "binary_extension_marker"),
+        0,
+        "the watcher indexed a file whose extension the walker rejects"
+    );
+    assert_eq!(
+        search_matches(port, "oversized_file_marker"),
+        0,
+        "the watcher indexed a file larger than --max-filesize"
+    );
+}

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -293,6 +293,21 @@ impl HybridIndex {
         self.reader().all_paths().iter().cloned().collect()
     }
 
+    /// The reader paths `keep` accepts.
+    ///
+    /// For callers that want a few of them — everything under one directory,
+    /// say. [`Self::reader_paths`] allocates a copy of every path in the index
+    /// to answer that, which at repository scale is the bulk of the cost and
+    /// all of it wasted.
+    pub fn reader_paths_matching(&self, mut keep: impl FnMut(&str) -> bool) -> Vec<String> {
+        self.reader()
+            .all_paths()
+            .iter()
+            .filter(|path| keep(path))
+            .cloned()
+            .collect()
+    }
+
     /// Number of files in the on-disk reader.
     pub fn reader_file_count(&self) -> usize {
         self.reader().num_files()

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -158,7 +158,11 @@ impl Default for WalkOptions {
 }
 
 /// Check if a file extension indicates a binary format.
-fn is_binary_extension(path: &Path) -> bool {
+///
+/// Public so the watcher can apply the same rule the walk does. A file the
+/// walk rejected here must not be inserted into the index by an incremental
+/// update, or the two disagree about what the index contains.
+pub fn is_binary_extension(path: &Path) -> bool {
     path.extension()
         .and_then(|e| e.to_str())
         .is_some_and(|ext| {


### PR DESCRIPTION
Scratch branch to verify the round-13 test fails without the content digest. Will be closed.