### PR TITLE
Use index for filename listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ tgrep <pattern> ---TCP---> tgrep serve (multi-client)
   flushed to disk and the reader is swapped, keeping memory bounded
 - **File Watcher** — `notify` crate watches the repo; updates LiveIndex in
   real time
+- **Filename Index** — `--files` unions content-index paths with a compact
+  sidecar containing only admitted paths that have no searchable content
 - **TCP Server** — JSON-RPC 2.0 over newline-delimited TCP; each connection
   handled in a separate thread; multiple clients can connect simultaneously
 - **File Cache** — 50K-entry content cache with RwLock for lock-free reads
@@ -350,6 +352,11 @@ tgrep --files src/main.rs         # list a single file if searchable
 tgrep --files -t rust .           # list Rust files only
 tgrep --type-list                 # show all file types
 ```
+
+With the default traversal rules, `--files` reads the live server or the local
+index instead of walking the repository. The local result is an index snapshot;
+use `--no-index` to inspect the filesystem as it exists now. Flags that change
+traversal membership or the file-size policy also fall back to a walk.
 
 ### Check status
 
@@ -700,6 +707,7 @@ exit code determined by the search alone. Suppress the message with
 | `lookup.bin` | Sorted 16-byte entries: `trigram(u32) + offset(u64) + length(u32)` |
 | `index.bin` | Concatenated posting lists: `file_id(u32)` per entry |
 | `files.bin` | File ID→path mapping: `file_id(u32) + path_len(u16) + path_bytes` |
+| `files-extra.bin` | Paths included by `--files` but absent from `files.bin` |
 | `meta.json` | Version, file/trigram counts, timestamps |
 | `serve.json` | Server PID and TCP port (for client discovery) |
 
@@ -723,6 +731,7 @@ tgrep/
 │       ├── ondisk.rs             # On-disk binary format
 │       ├── builder.rs            # Index construction (parallel via rayon)
 │       ├── reader.rs             # Mmap'd index reader
+│       ├── path_index.rs         # Filename-only path sidecar
 │       ├── query.rs              # Regex → trigram query decomposition
 │       ├── live.rs               # LiveIndex (in-memory mutable overlay)
 │       ├── hybrid.rs             # HybridIndex (reader + live overlay)

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -742,7 +742,7 @@ impl Cli {
 
         Ok(ResolvedArgs {
             max_filesize: self.max_filesize_bytes()?,
-            max_filesize_requested: self.max_filesize.is_some(),
+            max_filesize_requested: self.max_filesize.is_some() || self.no_max_filesize,
             encoding: self.encoding_mode()?,
             engine,
             regex_size_limit: self
@@ -1136,7 +1136,7 @@ fn run_cli() {
             if cli.list_files {
                 let opts = cli.build_search_opts(String::new(), &resolved);
                 let paths = list_files_paths(&cli);
-                list_files(&paths, &opts)
+                list_files(&paths, cli.index_path.as_deref(), &opts)
             } else if cli.pattern.is_some() || !cli.regexp.is_empty() || cli.pattern_file.is_some()
             {
                 let (pattern, paths) =
@@ -1232,7 +1232,11 @@ fn list_files_paths(cli: &Cli) -> Vec<String> {
     paths
 }
 
-fn list_files(paths: &[String], opts: &search::SearchOptions) -> anyhow::Result<()> {
+fn list_files(
+    paths: &[String],
+    index_path: Option<&std::path::Path>,
+    opts: &search::SearchOptions,
+) -> anyhow::Result<()> {
     let mut opts = opts.clone();
     for target in normalize_search_paths(paths) {
         if !target.path.exists() {
@@ -1240,7 +1244,7 @@ fn list_files(paths: &[String], opts: &search::SearchOptions) -> anyhow::Result<
             continue;
         }
         opts.path_display = target.display();
-        search::list_files(&target.path, &opts)?;
+        search::list_files(&target.path, index_path, &opts)?;
     }
     Ok(())
 }

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -507,6 +507,7 @@ fn filename_index_compatible(opts: &SearchOptions) -> bool {
         && !opts.follow
         && !opts.one_file_system
         && opts.ignore_files.is_empty()
+        && !opts.ignore_file_case_insensitive
         && !opts.max_filesize_requested
 }
 

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -403,8 +403,8 @@ pub fn new_writer(opts: &SearchOptions) -> OutputWriter {
     OutputWriter::new(opts.make_output_config())
 }
 
-/// List files that would be searched (--files mode).
-pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
+/// List files that would be searched (`--files` mode).
+pub fn list_files(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) -> Result<()> {
     let root = match std::fs::canonicalize(root) {
         Ok(root) => root,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -431,23 +431,184 @@ pub fn list_files(root: &Path, opts: &SearchOptions) -> Result<()> {
         return Ok(());
     }
 
-    let walk = walker::walk_dir(&root, &walk_opts);
-    let mut writer = OutputWriter::new(opts.make_output_config());
+    let index_dir = index_path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| builder::default_index_dir(&root));
 
-    for path in &walk.files {
-        let rel_path = path
-            .strip_prefix(&root)
+    if filename_index_compatible(opts) {
+        if let Ok(info) = ServerInfo::load(&index_dir)
+            && let Some((index_root, scope)) = resolve_scope(&index_dir, &root)
+            && let Ok(paths) = list_files_via_server(&info)
+        {
+            return write_indexed_file_paths(
+                &index_root,
+                &root,
+                &scope,
+                paths,
+                &glob_filter,
+                &type_filter,
+                opts,
+            );
+        }
+
+        match load_indexed_file_paths(&index_dir) {
+            Ok(Some(paths)) => {
+                if let Some((index_root, scope)) = resolve_scope(&index_dir, &root) {
+                    return write_indexed_file_paths(
+                        &index_root,
+                        &root,
+                        &scope,
+                        paths,
+                        &glob_filter,
+                        &type_filter,
+                        opts,
+                    );
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                if !opts.no_messages {
+                    eprintln!("warning: filename index unavailable ({error}) - walking filesystem");
+                }
+            }
+        }
+    }
+
+    let walk = walker::walk_dir(&root, &walk_opts);
+    let paths = walk.files.iter().map(|path| {
+        path.strip_prefix(&root)
             .unwrap_or(path)
             .to_string_lossy()
-            .replace('\\', "/");
+            .replace('\\', "/")
+    });
+    write_indexed_file_paths(
+        &root,
+        &root,
+        &IndexScope::Whole,
+        paths,
+        &glob_filter,
+        &type_filter,
+        opts,
+    )
+}
 
-        if !passes_filters(&rel_path, &glob_filter, &type_filter) {
-            continue;
+/// Whether an existing index was built under traversal rules that can answer
+/// this invocation without silently omitting files.
+fn filename_index_compatible(opts: &SearchOptions) -> bool {
+    !opts.no_index
+        && !opts.hidden
+        && !opts.no_ignore
+        && !opts.no_ignore_dot
+        && !opts.no_ignore_exclude
+        && !opts.no_ignore_global
+        && !opts.no_ignore_parent
+        && !opts.no_ignore_vcs
+        && !opts.no_require_git
+        && !opts.follow
+        && !opts.one_file_system
+        && opts.ignore_files.is_empty()
+        && !opts.max_filesize_requested
+}
+
+/// Load a complete local filename index, including the paths deliberately
+/// omitted from the content index.
+fn load_indexed_file_paths(index_dir: &Path) -> Result<Option<Vec<String>>> {
+    if !index_dir.join("lookup.bin").exists() {
+        return Ok(None);
+    }
+    let Some(mut extra_paths) = tgrep_core::path_index::read_extra_paths(index_dir)? else {
+        return Ok(None);
+    };
+    if !IndexMeta::load(index_dir)?.complete {
+        return Ok(None);
+    }
+
+    let reader = IndexReader::open(index_dir)?;
+    let mut paths = Vec::with_capacity(reader.num_files() + extra_paths.len());
+    paths.extend(reader.all_paths().iter().cloned());
+    paths.append(&mut extra_paths);
+    Ok(Some(paths))
+}
+
+/// Apply search-root scoping and CLI filters to index-root-relative paths.
+fn write_indexed_file_paths(
+    index_root: &Path,
+    search_root: &Path,
+    scope: &IndexScope,
+    paths: impl IntoIterator<Item = String>,
+    glob_filter: &crate::glob_filter::GlobFilter,
+    type_filter: &filetypes::TypeFilter,
+    opts: &SearchOptions,
+) -> Result<()> {
+    let mut seen = std::collections::HashSet::new();
+    let mut paths: Vec<String> = paths
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .filter_map(|path| scope.relativize(&path, search_root))
+        .filter(|path| within_max_depth(path, opts))
+        .filter(|path| passes_filters(path, glob_filter, type_filter))
+        .collect();
+
+    if let Some(sort) = opts.sort {
+        paths.sort_by_cached_key(|path| {
+            let time = if sort.key == SortKey::Path {
+                None
+            } else {
+                time_key(&scope.full_path(index_root, path), sort.key)
+            };
+            (time, PathBuf::from(path))
+        });
+        if sort.reverse {
+            paths.reverse();
         }
-        writer.write_file(&rel_path)?;
+    }
+
+    let mut writer = OutputWriter::new(opts.make_output_config());
+    for path in paths {
+        writer.write_file(&path)?;
     }
     writer.flush()?;
     Ok(())
+}
+
+fn list_files_via_server(info: &ServerInfo) -> Result<Vec<String>> {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", info.port))?;
+    stream.set_read_timeout(Some(std::time::Duration::from_secs(300)))?;
+    writeln!(
+        stream,
+        "{}",
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "files",
+            "id": 1,
+        })
+    )?;
+    stream.flush()?;
+
+    let mut reader = BufReader::new(&stream);
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    let response: serde_json::Value = serde_json::from_str(&line)?;
+    if let Some(error) = response.get("error") {
+        let message = error
+            .get("message")
+            .and_then(|message| message.as_str())
+            .unwrap_or("unknown error");
+        anyhow::bail!("server error: {message}");
+    }
+
+    response
+        .get("result")
+        .and_then(|result| result.get("files"))
+        .and_then(|files| files.as_array())
+        .ok_or_else(|| anyhow::anyhow!("server response did not contain files"))?
+        .iter()
+        .map(|path| {
+            path.as_str()
+                .map(str::to_string)
+                .ok_or_else(|| anyhow::anyhow!("server returned a non-string file path"))
+        })
+        .collect()
 }
 
 /// Run one search path's worth of work, writing through the caller's `writer`.

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -277,6 +277,9 @@ struct ServerState {
     /// False for legacy/partial indexes until a complete filesystem walk has
     /// established the extra-path set.
     filename_index_ready: std::sync::atomic::AtomicBool,
+    /// The in-memory extra-path set differs from the last sidecar successfully
+    /// published to disk. Authoritative walks retry while this remains set.
+    filename_index_dirty: std::sync::atomic::AtomicBool,
     cache: RwLock<ContentCache>,
     cache_generation: std::sync::atomic::AtomicU64,
     root: PathBuf,
@@ -679,6 +682,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         index: RwLock::new(hybrid),
         filename_extra_paths: RwLock::new(filename_extra_paths),
         filename_index_ready: std::sync::atomic::AtomicBool::new(filename_index_ready),
+        filename_index_dirty: std::sync::atomic::AtomicBool::new(false),
         cache: RwLock::new(ContentCache::new(
             CACHE_CAPACITY,
             CACHE_MAX_BYTES,
@@ -3155,8 +3159,9 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
 /// was inside it. Anything under one of these is swept on the strength of the
 /// directory's absence.
 ///
-/// Candidates come from everything that can answer a search, not from
-/// `file_stamps` alone. A stamp is not a precondition for being searchable:
+/// Candidates come from everything that can answer a content or filename
+/// query, not from `file_stamps` alone. A stamp is not a precondition for
+/// being searchable:
 /// `filestamps.json` is optional by design — missing or unreadable leaves the
 /// map empty, and a build that predates a given file's stamp leaves it partial
 /// — while the reader still holds that file's content. Sweeping only what has
@@ -3218,6 +3223,15 @@ fn sweep_removed_files(
                 .filter(|rel| missing(rel)),
         );
     }
+    gone.extend(
+        state
+            .filename_extra_paths
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|rel| missing(rel))
+            .cloned(),
+    );
     if gone.is_empty() {
         return;
     }
@@ -3256,12 +3270,7 @@ fn sweep_removed_files(
             Err(e) if proves_ineligible(&e) => {}
             Err(_) => continue,
         }
-        {
-            let mut index = state.index.write().unwrap();
-            index.live.delete_file(rel);
-            invalidate_cached_paths_locked(state, std::iter::once(rel.as_str()));
-        }
-        state.file_stamps.write().unwrap().remove(rel);
+        drop_indexed_file(state, rel, "removed during watcher recovery");
         dropped += 1;
     }
     if dropped > 0 {
@@ -3863,23 +3872,9 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
             // delete lands on content that was committed, or the reindex opens
             // a path that is already gone and drops it.
             let _reindex = lock_reindex(state);
-            let known_path = state.file_stamps.read().unwrap().contains_key(&rel_path);
-            if known_path {
-                eprintln!("[trace] reindex: removed {rel_path}");
-            }
             // gate acquired at the function level — the entire event
             // is processed atomically with respect to flush/auto-save.
-            {
-                let mut index = state.index.write().unwrap();
-                index.live.delete_file(&rel_path);
-                state
-                    .filename_extra_paths
-                    .write()
-                    .unwrap()
-                    .remove(&rel_path);
-                invalidate_cached_paths_locked(state, std::iter::once(rel_path.as_str()));
-            }
-            state.file_stamps.write().unwrap().remove(&rel_path);
+            drop_indexed_file(state, &rel_path, "removed");
             continue;
         }
 
@@ -3953,7 +3948,7 @@ fn lock_reindex(state: &ServerState) -> std::sync::MutexGuard<'_, ()> {
     }
 }
 
-/// Drop everything the index holds for a path.
+/// Drop everything the content and filename indexes hold for a path.
 ///
 /// A stamp is evidence, but not a precondition: `filestamps.json` may be missing
 /// while the active reader still holds the path. Conversely, a rejected file
@@ -3964,6 +3959,10 @@ fn lock_reindex(state: &ServerState) -> std::sync::MutexGuard<'_, ()> {
 /// the caller's rather than this function's because `reindex_file` calls in
 /// while holding it, and a `Mutex` is not reentrant.
 fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
+    let removed_extra = state.filename_extra_paths.write().unwrap().remove(rel_path);
+    if removed_extra {
+        state.filename_index_dirty.store(true, Ordering::SeqCst);
+    }
     let had_stamp = state
         .file_stamps
         .write()
@@ -3983,6 +3982,33 @@ fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
     let mut index = state.index.write().unwrap();
     index.live.delete_file(rel_path);
     invalidate_cached_paths_locked(state, std::iter::once(rel_path));
+}
+
+/// Move a listable path out of the content index.
+///
+/// The extra-path insertion is the membership transition. Only that first
+/// transition creates a tombstone, so duplicate watcher notifications for a
+/// binary path do not repeatedly dirty the live overlay.
+fn mark_filename_only(state: &ServerState, rel_path: &str) {
+    let inserted = {
+        let mut index = state.index.write().unwrap();
+        let mut extra = state.filename_extra_paths.write().unwrap();
+        if !extra.insert(rel_path.to_string()) {
+            false
+        } else {
+            if !index.live.is_deleted(rel_path) {
+                index.live.delete_file(rel_path);
+            }
+            invalidate_cached_paths_locked(state, std::iter::once(rel_path));
+            true
+        }
+    };
+    if !inserted {
+        return;
+    }
+
+    state.filename_index_dirty.store(true, Ordering::SeqCst);
+    state.file_stamps.write().unwrap().remove(rel_path);
 }
 
 /// What an event's stat result says about the path it named.
@@ -4392,12 +4418,12 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
     let mut version = tgrep_core::builder::file_version(&meta);
     let mut current = version.stamp().clone();
 
-    // The rules `walk_file_metadata` applies, and for the same reason: the walk
-    // is authoritative about what belongs in the index, so anything it rejects
-    // must not be added here. Without this a file that grew past the cap — or
-    // an ineligible extension in a directory a relaxed ignore rule just exposed
-    // — would be read whole and indexed, and the next reconcile would silently
-    // delete it again.
+    // The type and size rules `walk_file_metadata` applies, and for the same
+    // reason: the walk is authoritative about what belongs in the index, so
+    // anything it rejects must not be added here. Without this a file that grew
+    // past the cap would be read whole and indexed, and the next reconcile
+    // would silently delete it again. Binary extensions remain listable and
+    // move into the filename-only set below.
     //
     // `is_file` is the third rule, and the one with teeth: the walker runs with
     // `follow_links(false)`, where a symlink is neither file nor dir and is
@@ -4409,7 +4435,6 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
     // level; this is what rejects a final one on Windows, where the reparse
     // point opens fine.
     let eligible = meta.is_file()
-        && !tgrep_core::walker::is_binary_extension(path)
         && !state
             .max_file_size
             .is_some_and(|limit| current.size > limit);
@@ -4419,6 +4444,10 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
         // what we hold so the index matches the walk rather than keeping a
         // stale copy of the smaller version until the reconcile.
         drop_indexed_file(state, rel_path, "no longer eligible");
+        return;
+    }
+    if tgrep_core::walker::is_binary_extension(path) {
+        mark_filename_only(state, rel_path);
         return;
     }
 
@@ -4518,7 +4547,13 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
                 drop_indexed_file(state, rel_path, "grew past the size limit while being read");
                 return;
             }
-            CappedRead::Failed => return,
+            CappedRead::Failed => {
+                let already_indexed = state.index.read().unwrap().has_active_path(rel_path);
+                if !already_indexed {
+                    mark_filename_only(state, rel_path);
+                }
+                return;
+            }
         }
     };
     let text = tgrep_core::encoding::decode_for_index(&data);
@@ -4553,16 +4588,22 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
     }
 
     eprintln!("[trace] reindex: modified {rel_path}");
-    if per_tri.is_none() {
-        drop_indexed_file(state, rel_path, "binary content");
+    let Some(per_tri) = per_tri else {
+        mark_filename_only(state, rel_path);
         return;
-    }
+    };
     // Gate held by the caller — the commit + stamp update is processed
     // atomically with respect to flush/auto-save.
-    {
+    let removed_extra = {
         let mut index = state.index.write().unwrap();
-        index.live.commit_upsert(rel_path, per_tri.unwrap());
+        let mut extra = state.filename_extra_paths.write().unwrap();
+        index.live.commit_upsert(rel_path, per_tri);
+        let removed = extra.remove(rel_path);
         invalidate_cached_paths_locked(state, std::iter::once(rel_path));
+        removed
+    };
+    if removed_extra {
+        state.filename_index_dirty.store(true, Ordering::SeqCst);
     }
     state
         .file_stamps
@@ -4746,7 +4787,10 @@ fn replace_filename_extra_paths(state: &ServerState, listed_files: &[String]) ->
         .collect();
     let mut current = state.filename_extra_paths.write().unwrap();
     let changed = *current != next || !state.filename_index_ready.load(Ordering::SeqCst);
-    *current = next;
+    if changed {
+        *current = next;
+        state.filename_index_dirty.store(true, Ordering::SeqCst);
+    }
     state.filename_index_ready.store(true, Ordering::SeqCst);
     changed
 }
@@ -4788,11 +4832,15 @@ fn persist_filename_extra_paths(state: &ServerState, index_dir: &Path) -> bool {
         }
     };
     let _ = std::fs::remove_dir_all(&staging_dir);
+    if published {
+        state.filename_index_dirty.store(false, Ordering::SeqCst);
+    }
     published
 }
 
 fn refresh_filename_index(state: &ServerState, index_dir: &Path, listed_files: &[String]) {
-    if replace_filename_extra_paths(state, listed_files) {
+    let changed = replace_filename_extra_paths(state, listed_files);
+    if changed || state.filename_index_dirty.load(Ordering::SeqCst) {
         persist_filename_extra_paths(state, index_dir);
     }
 }
@@ -5571,6 +5619,7 @@ fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
             *index = empty;
             extra.clear();
             state.filename_index_ready.store(false, Ordering::SeqCst);
+            state.filename_index_dirty.store(false, Ordering::SeqCst);
             cache.clear();
             state.cache_generation.fetch_add(1, Ordering::SeqCst);
         }
@@ -5682,6 +5731,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         if let Some(paths) = filename_extra_paths {
             *extra = paths;
             state.filename_index_ready.store(true, Ordering::SeqCst);
+            state.filename_index_dirty.store(false, Ordering::SeqCst);
         }
         cache.clear();
         state.cache_generation.fetch_add(1, Ordering::SeqCst);
@@ -6308,6 +6358,8 @@ fn publish_staged_index(
     preserve_overlay_paths: &std::collections::HashSet<String>,
     filename_extra_paths: Option<&std::collections::HashSet<String>>,
 ) -> PublishStatus {
+    let stage_filename_index =
+        filename_extra_paths.is_some() || state.filename_index_ready.load(Ordering::SeqCst);
     let filename_stage_result = if let Some(paths) = filename_extra_paths {
         let mut paths: Vec<String> = paths.iter().cloned().collect();
         paths.sort_unstable();
@@ -6361,6 +6413,9 @@ fn publish_staged_index(
         if let Some(paths) = filename_extra_paths {
             *state.filename_extra_paths.write().unwrap() = paths.clone();
             state.filename_index_ready.store(true, Ordering::SeqCst);
+        }
+        if stage_filename_index {
+            state.filename_index_dirty.store(false, Ordering::SeqCst);
         }
         let mut cache = state.cache.write().unwrap();
         index.swap_reader(new_reader);
@@ -6430,6 +6485,7 @@ fn publish_reloaded_index(
         let mut index = state.index.write().unwrap();
         *state.filename_extra_paths.write().unwrap() = filename_extra_paths;
         state.filename_index_ready.store(true, Ordering::SeqCst);
+        state.filename_index_dirty.store(false, Ordering::SeqCst);
         let mut cache = state.cache.write().unwrap();
         index.swap_reader(new_reader);
         let mut reconciled = index.live.overlay_paths();
@@ -6907,6 +6963,7 @@ mod tests {
             index: RwLock::new(hybrid),
             filename_extra_paths: RwLock::new(Default::default()),
             filename_index_ready: std::sync::atomic::AtomicBool::new(false),
+            filename_index_dirty: std::sync::atomic::AtomicBool::new(false),
             cache: RwLock::new(ContentCache::new(
                 CACHE_CAPACITY,
                 CACHE_MAX_BYTES,
@@ -7038,6 +7095,16 @@ mod tests {
                 .contains("asset.bin")
         );
         assert!(state.index.read().unwrap().all_paths().is_empty());
+        let dirty = state.index.read().unwrap().live.dirty_count();
+
+        let duplicate =
+            Event::new(EventKind::Modify(notify::event::ModifyKind::Any)).add_path(asset.clone());
+        handle_fs_event(&state, &root, &duplicate);
+        assert_eq!(
+            state.index.read().unwrap().live.dirty_count(),
+            dirty,
+            "a duplicate event dirtied the binary path again"
+        );
 
         std::fs::remove_file(&asset).unwrap();
         let remove = Event::new(EventKind::Remove(notify::event::RemoveKind::File)).add_path(asset);
@@ -7049,6 +7116,70 @@ mod tests {
                 .unwrap()
                 .contains("asset.bin")
         );
+    }
+
+    #[test]
+    fn authoritative_filename_refresh_retries_a_dirty_sidecar() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        let index_dir = temp.path().join("index");
+        std::fs::create_dir_all(&root).unwrap();
+        let state = test_server_state(&root, &index_dir);
+        state
+            .filename_extra_paths
+            .write()
+            .unwrap()
+            .insert("asset.bin".to_string());
+        state.filename_index_ready.store(true, Ordering::SeqCst);
+        state.filename_index_dirty.store(true, Ordering::SeqCst);
+        tgrep_core::path_index::write_extra_paths(&index_dir, &[]).unwrap();
+
+        refresh_filename_index(state.as_ref(), &index_dir, &["asset.bin".to_string()]);
+
+        assert_eq!(
+            tgrep_core::path_index::read_extra_paths(&index_dir).unwrap(),
+            Some(vec!["asset.bin".to_string()])
+        );
+        assert!(!state.filename_index_dirty.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn watcher_recovery_sweeps_missing_filename_only_paths() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        let index_dir = temp.path().join("index");
+        std::fs::create_dir_all(root.join("assets")).unwrap();
+        let state = test_server_state(&root, &index_dir);
+        state
+            .filename_extra_paths
+            .write()
+            .unwrap()
+            .insert("assets/missing.bin".to_string());
+        state.filename_index_ready.store(true, Ordering::SeqCst);
+
+        sweep_removed_files(
+            state.as_ref(),
+            &std::collections::HashSet::from(["assets".to_string()]),
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+        );
+
+        assert!(
+            !state
+                .filename_extra_paths
+                .read()
+                .unwrap()
+                .contains("assets/missing.bin")
+        );
+        assert!(
+            state
+                .index
+                .read()
+                .unwrap()
+                .live
+                .is_deleted("assets/missing.bin")
+        );
+        assert!(state.filename_index_dirty.load(Ordering::SeqCst));
     }
 
     /// A binary marker's offset is a position in the file, not in the repaired

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -147,8 +147,9 @@ fn try_acquire_server_lock(index_dir: &Path) -> Result<File> {
 ///   2. `gitignore`     — guards the watcher matcher; drop before file/index work
 ///   3. `publish_lock`  — serializes on-disk index publication
 ///   4. `index`         — guards the in-memory HybridIndex (read-heavy)
-///   5. `cache`         — guards the file content LRU cache
-///   6. `file_stamps`   — guards per-file mtime/size stamps
+///   5. `filename_extra_paths` — guards paths omitted from the content index
+///   6. `cache`         — guards the file content LRU cache
+///   7. `file_stamps`   — guards per-file mtime/size stamps
 ///
 /// `indexing` and `flushing` coordinate the handoff between bulk indexing and
 /// final flush with the auto-save loop; use sequentially consistent accesses
@@ -269,6 +270,13 @@ impl ContentCache {
 
 struct ServerState {
     index: RwLock<HybridIndex>,
+    /// Paths admitted by traversal but deliberately absent from the content
+    /// index. Unioning these with `HybridIndex::all_paths` answers `--files`
+    /// without duplicating every searchable path in memory.
+    filename_extra_paths: RwLock<std::collections::HashSet<String>>,
+    /// False for legacy/partial indexes until a complete filesystem walk has
+    /// established the extra-path set.
+    filename_index_ready: std::sync::atomic::AtomicBool,
     cache: RwLock<ContentCache>,
     cache_generation: std::sync::atomic::AtomicU64,
     root: PathBuf,
@@ -640,6 +648,18 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     let index_complete = tgrep_core::meta::IndexMeta::load(&index_dir)
         .map(|m| m.complete)
         .unwrap_or(false);
+    let (filename_extra_paths, filename_index_ready) = if index_complete {
+        match tgrep_core::path_index::read_extra_paths(&index_dir) {
+            Ok(Some(paths)) => (paths.into_iter().collect(), true),
+            Ok(None) => (std::collections::HashSet::new(), false),
+            Err(error) => {
+                eprintln!("[trace] filename index failed to load ({error}); rebuilding");
+                (std::collections::HashSet::new(), false)
+            }
+        }
+    } else {
+        (std::collections::HashSet::new(), false)
+    };
 
     let needs_build = needs_build || !index_complete;
 
@@ -657,6 +677,8 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
 
     let state = Arc::new(ServerState {
         index: RwLock::new(hybrid),
+        filename_extra_paths: RwLock::new(filename_extra_paths),
+        filename_index_ready: std::sync::atomic::AtomicBool::new(filename_index_ready),
         cache: RwLock::new(ContentCache::new(
             CACHE_CAPACITY,
             CACHE_MAX_BYTES,
@@ -1103,10 +1125,30 @@ fn process_request(request: &str, state: &Arc<ServerState>) -> String {
 
     match method {
         "search" => handle_search(id, &params, state),
+        "files" => handle_files(id, state),
         "status" => handle_status(id, state),
         "reload" => handle_reload(id, state),
         _ => json_rpc_error(id, -32601, &format!("Method not found: {method}")),
     }
+}
+
+fn handle_files(id: Option<serde_json::Value>, state: &ServerState) -> String {
+    state.note_search();
+    if state.indexing.load(Ordering::SeqCst) || !state.filename_index_ready.load(Ordering::SeqCst) {
+        return json_rpc_error(id, -32001, "filename index is not ready");
+    }
+
+    let mut files = {
+        // Keep the documented index -> filename lock order.
+        let index = state.index.read().unwrap();
+        let extra = state.filename_extra_paths.read().unwrap();
+        let mut files = index.all_paths();
+        files.extend(extra.iter().cloned());
+        files
+    };
+    files.sort_unstable();
+    files.dedup();
+    json_rpc_result(id, serde_json::json!({ "files": files }))
 }
 
 /// Parsed and validated search request parameters.
@@ -3830,6 +3872,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
             {
                 let mut index = state.index.write().unwrap();
                 index.live.delete_file(&rel_path);
+                state
+                    .filename_extra_paths
+                    .write()
+                    .unwrap()
+                    .remove(&rel_path);
                 invalidate_cached_paths_locked(state, std::iter::once(rel_path.as_str()));
             }
             state.file_stamps.write().unwrap().remove(&rel_path);
@@ -4638,6 +4685,7 @@ fn auto_save_loop(state: Arc<ServerState>) {
                     preserved: &std::collections::HashSet::new(),
                     operation: "auto-save",
                     authoritative_membership: false,
+                    authoritative_listed_files: None,
                 },
             ) {
                 last_save = Instant::now();
@@ -4680,6 +4728,75 @@ fn json_rpc_error(id: Option<serde_json::Value>, code: i32, message: &str) -> St
     .to_string()
 }
 
+/// Replace the filename-only delta from an authoritative filesystem path set.
+///
+/// Returns whether the delta changed and therefore needs to be persisted.
+fn replace_filename_extra_paths(state: &ServerState, listed_files: &[String]) -> bool {
+    let content_paths: std::collections::HashSet<String> = state
+        .index
+        .read()
+        .unwrap()
+        .all_paths()
+        .into_iter()
+        .collect();
+    let next: std::collections::HashSet<String> = listed_files
+        .iter()
+        .filter(|path| !content_paths.contains(path.as_str()))
+        .cloned()
+        .collect();
+    let mut current = state.filename_extra_paths.write().unwrap();
+    let changed = *current != next || !state.filename_index_ready.load(Ordering::SeqCst);
+    *current = next;
+    state.filename_index_ready.store(true, Ordering::SeqCst);
+    changed
+}
+
+fn stage_filename_extra_paths(state: &ServerState, staging_dir: &Path) -> Result<()> {
+    let mut paths: Vec<String> = state
+        .filename_extra_paths
+        .read()
+        .unwrap()
+        .iter()
+        .cloned()
+        .collect();
+    paths.sort_unstable();
+    tgrep_core::path_index::write_extra_paths(staging_dir, &paths)?;
+    Ok(())
+}
+
+/// Publish just the filename sidecar after an authoritative walk that did not
+/// otherwise need to rewrite the content index.
+fn persist_filename_extra_paths(state: &ServerState, index_dir: &Path) -> bool {
+    let staging_dir = index_dir.join(".filename-index-staging");
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    if let Err(error) = stage_filename_extra_paths(state, &staging_dir) {
+        eprintln!("[trace] warning: could not stage filename index: {error}");
+        let _ = std::fs::remove_dir_all(&staging_dir);
+        return false;
+    }
+
+    let published = {
+        let _publish = state.publish_lock.lock().unwrap();
+        let src = staging_dir.join(tgrep_core::path_index::EXTRA_PATHS_FILENAME);
+        let dst = index_dir.join(tgrep_core::path_index::EXTRA_PATHS_FILENAME);
+        match publish_file(&src, &dst) {
+            Ok(()) => true,
+            Err(error) => {
+                eprintln!("[trace] warning: could not publish filename index: {error}");
+                false
+            }
+        }
+    };
+    let _ = std::fs::remove_dir_all(&staging_dir);
+    published
+}
+
+fn refresh_filename_index(state: &ServerState, index_dir: &Path, listed_files: &[String]) {
+    if replace_filename_extra_paths(state, listed_files) {
+        persist_filename_extra_paths(state, index_dir);
+    }
+}
+
 /// Create a minimal empty on-disk index so HybridIndex::open() succeeds.
 /// The actual data will be populated into the LiveIndex in the background.
 fn create_empty_index(index_dir: &Path) -> Result<()> {
@@ -4692,6 +4809,7 @@ fn create_empty_index(index_dir: &Path) -> Result<()> {
     std::fs::write(index_dir.join("lookup.bin"), b"")?;
     std::fs::write(index_dir.join("index.bin"), b"")?;
     std::fs::write(index_dir.join("files.bin"), b"")?;
+    tgrep_core::path_index::remove_extra_paths(index_dir)?;
     let mut meta = IndexMeta::new("", 0, 0);
     meta.complete = false; // empty skeleton — not a complete index
     meta.save(index_dir)?;
@@ -4862,6 +4980,7 @@ struct StaleMergePolicy<'a> {
     preserved: &'a std::collections::HashSet<String>,
     operation: &'a str,
     authoritative_membership: bool,
+    authoritative_listed_files: Option<&'a [String]>,
 }
 
 /// Apply a stale diff without materializing the existing index in heap.
@@ -4890,6 +5009,7 @@ fn stream_merge_stale_changes(
         preserved,
         operation,
         authoritative_membership,
+        authoritative_listed_files,
     } = policy;
     let root = &state.root;
     let index_dir = &state.index_dir;
@@ -5036,6 +5156,22 @@ fn stream_merge_stale_changes(
             .filter(|path| removed.contains(path.as_str()))
             .count();
         let expected_files = reader.num_files() - removed_reader_files + delta.num_files();
+        let filename_extra_paths = authoritative_listed_files.map(|listed_files| {
+            let mut content_paths = std::collections::HashSet::with_capacity(expected_files);
+            content_paths.extend(
+                reader
+                    .all_paths()
+                    .iter()
+                    .filter(|path| !removed.contains(path.as_str()))
+                    .map(String::as_str),
+            );
+            content_paths.extend(delta.all_paths().iter().map(String::as_str));
+            listed_files
+                .iter()
+                .filter(|path| !content_paths.contains(path.as_str()))
+                .cloned()
+                .collect::<std::collections::HashSet<_>>()
+        });
         let published = publish_staged_index(
             state,
             index_dir,
@@ -5043,6 +5179,7 @@ fn stream_merge_stale_changes(
             expected_files,
             &candidates,
             &preserve_overlay_paths,
+            filename_extra_paths.as_ref(),
         );
         if published.is_published() {
             // `publish_staged_index` prunes overlay entries represented by the
@@ -5311,6 +5448,7 @@ fn refresh_stale_locked(
         return false;
     }
     let current_meta = &walk.files;
+    let listed_files = &walk.listed_files;
 
     // Load stored per-file stamps from last index write
     let mut old_stamps = match meta::read_filestamps(index_dir) {
@@ -5339,6 +5477,7 @@ fn refresh_stale_locked(
         paths
     };
     if old_stamps.is_empty() && indexed_paths.is_empty() && current_meta.is_empty() {
+        refresh_filename_index(state, index_dir, listed_files);
         eprintln!("[trace] stale check: no indexed files or filesystem files, skipping");
         return true;
     }
@@ -5369,6 +5508,7 @@ fn refresh_stale_locked(
     let total_changes = changed.len() + added.len() + deleted.len();
     let live_pending = state.index.read().unwrap().live.has_pending_changes();
     if total_changes == 0 && !live_pending {
+        refresh_filename_index(state, index_dir, listed_files);
         eprintln!(
             "[trace] stale check: index is up-to-date ({} files checked in {}ms)",
             current_meta.len(),
@@ -5404,6 +5544,7 @@ fn refresh_stale_locked(
             preserved: &skipped_unreadable,
             operation: "stale check",
             authoritative_membership: true,
+            authoritative_listed_files: Some(listed_files),
         },
     ) {
         return false;
@@ -5425,8 +5566,11 @@ fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
     match HybridIndex::open(index_dir, root) {
         Ok(empty) => {
             let mut index = state.index.write().unwrap();
+            let mut extra = state.filename_extra_paths.write().unwrap();
             let mut cache = state.cache.write().unwrap();
             *index = empty;
+            extra.clear();
+            state.filename_index_ready.store(false, Ordering::SeqCst);
             cache.clear();
             state.cache_generation.fetch_add(1, Ordering::SeqCst);
         }
@@ -5519,10 +5663,26 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         }
     };
     let indexed = opened.num_files() as u64;
+    let filename_extra_paths = match tgrep_core::path_index::read_extra_paths(index_dir) {
+        Ok(Some(paths)) => Some(paths.into_iter().collect()),
+        Ok(None) => {
+            eprintln!("[trace] warning: bootstrapped index has no filename sidecar");
+            None
+        }
+        Err(error) => {
+            eprintln!("[trace] warning: bootstrapped filename index failed to load: {error}");
+            None
+        }
+    };
     {
         let mut index = state.index.write().unwrap();
+        let mut extra = state.filename_extra_paths.write().unwrap();
         let mut cache = state.cache.write().unwrap();
         *index = opened;
+        if let Some(paths) = filename_extra_paths {
+            *extra = paths;
+            state.filename_index_ready.store(true, Ordering::SeqCst);
+        }
         cache.clear();
         state.cache_generation.fetch_add(1, Ordering::SeqCst);
     }
@@ -5915,6 +6075,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             max_file_size: state.max_file_size,
         },
     );
+    let listed_files = walk_meta.listed_files;
     let stamps: std::collections::HashMap<String, tgrep_core::meta::FileStamp> = {
         let indexed = {
             let index = state.index.read().unwrap();
@@ -5941,6 +6102,7 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // (not skip) until the flush publishes, after which it applies safely to
     // the newly published reader; no event is lost.
     let gate = state.snapshot_gate.write().unwrap();
+    replace_filename_extra_paths(state, &listed_files);
     state.flushing.store(true, Ordering::SeqCst);
 
     // Publish the stamps *before* clearing `indexing`, not after the flush.
@@ -6102,6 +6264,7 @@ fn flush_append_only_overlay_locked(
         num_files,
         &[],
         &std::collections::HashSet::new(),
+        None,
     )
     .is_published();
     eprintln!(
@@ -6143,7 +6306,23 @@ fn publish_staged_index(
     num_files: usize,
     invalidate_paths: &[String],
     preserve_overlay_paths: &std::collections::HashSet<String>,
+    filename_extra_paths: Option<&std::collections::HashSet<String>>,
 ) -> PublishStatus {
+    let filename_stage_result = if let Some(paths) = filename_extra_paths {
+        let mut paths: Vec<String> = paths.iter().cloned().collect();
+        paths.sort_unstable();
+        tgrep_core::path_index::write_extra_paths(staging_dir, &paths).map_err(Into::into)
+    } else if state.filename_index_ready.load(Ordering::SeqCst) {
+        stage_filename_extra_paths(state, staging_dir)
+    } else {
+        Ok(())
+    };
+    if let Err(error) = filename_stage_result {
+        eprintln!("[trace] warning: filename index staging failed: {error}");
+        let _ = std::fs::remove_dir_all(staging_dir);
+        return PublishStatus::Failed;
+    }
+
     // Held across move + open + swap so concurrent publishers (auto-save /
     // background-build / watcher reindex flush) cannot interleave renames
     // or swap readers out of order. Searches do not take this lock.
@@ -6179,6 +6358,10 @@ fn publish_staged_index(
     // observe the new posting set with bytes from the old cache generation.
     {
         let mut index = state.index.write().unwrap();
+        if let Some(paths) = filename_extra_paths {
+            *state.filename_extra_paths.write().unwrap() = paths.clone();
+            state.filename_index_ready.store(true, Ordering::SeqCst);
+        }
         let mut cache = state.cache.write().unwrap();
         index.swap_reader(new_reader);
         index.prune_persisted_entries_except(preserve_overlay_paths);
@@ -6205,6 +6388,19 @@ fn publish_reloaded_index(
     staging_dir: &Path,
     num_files: usize,
 ) -> bool {
+    let filename_extra_paths = match tgrep_core::path_index::read_extra_paths(staging_dir) {
+        Ok(Some(paths)) => paths.into_iter().collect(),
+        Ok(None) => {
+            eprintln!("[trace] warning: reloaded index has no filename sidecar");
+            let _ = std::fs::remove_dir_all(staging_dir);
+            return false;
+        }
+        Err(error) => {
+            eprintln!("[trace] warning: reloaded filename index failed to open: {error}");
+            let _ = std::fs::remove_dir_all(staging_dir);
+            return false;
+        }
+    };
     let _publish = state.publish_lock.lock().unwrap();
     let mut moved = match move_staged_files(staging_dir, index_dir) {
         Ok(moved) => moved,
@@ -6232,6 +6428,8 @@ fn publish_reloaded_index(
     // both in that order makes the complete reload visible as one generation.
     {
         let mut index = state.index.write().unwrap();
+        *state.filename_extra_paths.write().unwrap() = filename_extra_paths;
+        state.filename_index_ready.store(true, Ordering::SeqCst);
         let mut cache = state.cache.write().unwrap();
         index.swap_reader(new_reader);
         let mut reconciled = index.live.overlay_paths();
@@ -6306,6 +6504,7 @@ const INDEX_FILE_NAMES: &[&str] = &[
     "index.bin",
     "lookup.bin",
     "files.bin",
+    tgrep_core::path_index::EXTRA_PATHS_FILENAME,
     "filestamps.json",
     "meta.json",
 ];
@@ -6706,6 +6905,8 @@ mod tests {
         let hybrid = HybridIndex::open(index_dir, root).expect("open empty index");
         Arc::new(ServerState {
             index: RwLock::new(hybrid),
+            filename_extra_paths: RwLock::new(Default::default()),
+            filename_index_ready: std::sync::atomic::AtomicBool::new(false),
             cache: RwLock::new(ContentCache::new(
                 CACHE_CAPACITY,
                 CACHE_MAX_BYTES,
@@ -6756,6 +6957,70 @@ mod tests {
             .status()
             .expect("run git");
         assert!(status.success(), "git {args:?} failed");
+    }
+
+    #[test]
+    fn files_rpc_unions_content_and_filename_only_paths() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        let index_dir = temp.path().join("index");
+        std::fs::create_dir_all(&root).unwrap();
+        let state = test_server_state(&root, &index_dir);
+        state
+            .index
+            .write()
+            .unwrap()
+            .live
+            .upsert_file("src/main.rs", b"fn main() {}\n");
+        state
+            .filename_extra_paths
+            .write()
+            .unwrap()
+            .insert("asset.bin".to_string());
+        state.filename_index_ready.store(true, Ordering::SeqCst);
+
+        let response = process_request(r#"{"jsonrpc":"2.0","method":"files","id":1}"#, &state);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value.pointer("/result/files").unwrap(),
+            &serde_json::json!(["asset.bin", "src/main.rs"])
+        );
+    }
+
+    #[test]
+    fn watcher_keeps_binary_extensions_in_the_filename_index() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        let index_dir = temp.path().join("index");
+        std::fs::create_dir_all(&root).unwrap();
+        let state = test_server_state(&root, &index_dir);
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+        state.filename_index_ready.store(true, Ordering::SeqCst);
+
+        let asset = root.join("asset.bin");
+        std::fs::write(&asset, [1, 2, 3]).unwrap();
+        let create =
+            Event::new(EventKind::Create(notify::event::CreateKind::File)).add_path(asset.clone());
+        handle_fs_event(&state, &root, &create);
+        assert!(
+            state
+                .filename_extra_paths
+                .read()
+                .unwrap()
+                .contains("asset.bin")
+        );
+        assert!(state.index.read().unwrap().all_paths().is_empty());
+
+        std::fs::remove_file(&asset).unwrap();
+        let remove = Event::new(EventKind::Remove(notify::event::RemoveKind::File)).add_path(asset);
+        handle_fs_event(&state, &root, &remove);
+        assert!(
+            !state
+                .filename_extra_paths
+                .read()
+                .unwrap()
+                .contains("asset.bin")
+        );
     }
 
     /// A binary marker's offset is a position in the file, not in the repaired
@@ -10620,13 +10885,27 @@ mod tests {
         let staging = tmp.path().join("staging");
         let target = tmp.path().join("target");
         std::fs::create_dir_all(&staging).unwrap();
-        for name in ["index.bin", "lookup.bin", "files.bin", "meta.json"] {
+        for name in [
+            "index.bin",
+            "lookup.bin",
+            "files.bin",
+            tgrep_core::path_index::EXTRA_PATHS_FILENAME,
+            "filestamps.json",
+            "meta.json",
+        ] {
             write_file(&staging.join(name), name.as_bytes());
         }
         write_file(&staging.join("ignored.txt"), b"nope");
         let mut moved = move_staged_files(&staging, &target).unwrap();
         moved.commit();
-        for name in ["index.bin", "lookup.bin", "files.bin", "meta.json"] {
+        for name in [
+            "index.bin",
+            "lookup.bin",
+            "files.bin",
+            tgrep_core::path_index::EXTRA_PATHS_FILENAME,
+            "filestamps.json",
+            "meta.json",
+        ] {
             assert_eq!(std::fs::read(target.join(name)).unwrap(), name.as_bytes());
             assert!(
                 !staging.join(name).exists(),

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -5884,6 +5884,33 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
     true
 }
 
+fn complete_background_listed_files(
+    root: &Path,
+    phase_one_files: Vec<PathBuf>,
+    phase_one_errors: usize,
+    metadata_files: Vec<String>,
+    metadata_errors: usize,
+) -> Option<Vec<String>> {
+    if metadata_errors == 0 {
+        return Some(metadata_files);
+    }
+    if phase_one_errors > 0 {
+        return None;
+    }
+
+    Some(
+        phase_one_files
+            .into_iter()
+            .map(|path| {
+                path.strip_prefix(root)
+                    .unwrap_or(path.as_path())
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect(),
+    )
+}
+
 /// Walk the repo and populate the LiveIndex in batches in a background thread.
 /// Uses rayon for parallel trigram extraction. The bulk build is held entirely
 /// in the live overlay; only one final flush to disk happens once the walk
@@ -6157,7 +6184,27 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             max_file_size: state.max_file_size,
         },
     );
-    let listed_files = walk_meta.listed_files;
+    let metadata_errors = walk_meta.skipped_error;
+    let listed_files = complete_background_listed_files(
+        root,
+        walk.listed_files,
+        walk.skipped_error,
+        walk_meta.listed_files,
+        metadata_errors,
+    );
+    if metadata_errors > 0 {
+        if listed_files.is_some() {
+            eprintln!(
+                "[trace] warning: final metadata walk could not inspect {metadata_errors} \
+                 filesystem entries; preserving filename membership from the initial walk"
+            );
+        } else {
+            eprintln!(
+                "[trace] warning: neither background-build walk established complete filename \
+                 membership; leaving the prior filename membership unchanged"
+            );
+        }
+    }
     let stamps: std::collections::HashMap<String, tgrep_core::meta::FileStamp> = {
         let indexed = {
             let index = state.index.read().unwrap();
@@ -6184,7 +6231,9 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // (not skip) until the flush publishes, after which it applies safely to
     // the newly published reader; no event is lost.
     let gate = state.snapshot_gate.write().unwrap();
-    replace_filename_extra_paths(state, &listed_files);
+    if let Some(listed_files) = &listed_files {
+        replace_filename_extra_paths(state, listed_files);
+    }
     state.flushing.store(true, Ordering::SeqCst);
 
     // Publish the stamps *before* clearing `indexing`, not after the flush.
@@ -7046,6 +7095,29 @@ mod tests {
             .status()
             .expect("run git");
         assert!(status.success(), "git {args:?} failed");
+    }
+
+    #[test]
+    fn background_filename_membership_requires_one_complete_walk() {
+        let root = Path::new("repo");
+        let initial = vec![root.join("from-initial.bin")];
+        let metadata = vec!["from-metadata.bin".to_string()];
+
+        assert_eq!(
+            complete_background_listed_files(root, initial.clone(), 0, metadata.clone(), 0),
+            Some(metadata.clone()),
+            "a complete final metadata walk is the freshest authority"
+        );
+        assert_eq!(
+            complete_background_listed_files(root, initial.clone(), 0, metadata, 1),
+            Some(vec!["from-initial.bin".to_string()]),
+            "an incomplete final walk must preserve the complete initial membership"
+        );
+        assert_eq!(
+            complete_background_listed_files(root, initial, 1, Vec::new(), 1),
+            None,
+            "two incomplete walks cannot establish authoritative membership"
+        );
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -6988,6 +6988,34 @@ mod tests {
     }
 
     #[test]
+    fn reload_replaces_content_and_filename_paths_together() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        let index_dir = temp.path().join("index");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(root.join("new.bin"), [1, 2, 3]).unwrap();
+        let state = test_server_state(&root, &index_dir);
+        state
+            .filename_extra_paths
+            .write()
+            .unwrap()
+            .insert("removed.bin".to_string());
+
+        let response = handle_reload(Some(serde_json::json!(1)), &state);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(value.pointer("/result/status").unwrap(), "reloaded");
+        assert!(state.filename_index_ready.load(Ordering::SeqCst));
+
+        let response = handle_files(Some(serde_json::json!(2)), &state);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value.pointer("/result/files").unwrap(),
+            &serde_json::json!(["main.rs", "new.bin"])
+        );
+    }
+
+    #[test]
     fn watcher_keeps_binary_extensions_in_the_filename_index() {
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("root");

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -3612,8 +3612,18 @@ fn replay_deferred_events(state: &Arc<ServerState>, root: &Path) {
         if !is_real_dir(&path)
             && path.strip_prefix(root).is_ok_and(|rel| {
                 let rel = rel.to_string_lossy().replace('\\', "/");
-                let index = state.index.read().unwrap();
-                index.reader_has_descendant_path(&rel) || index.live.has_descendant_path(&rel)
+                let has_content_descendant = {
+                    let index = state.index.read().unwrap();
+                    index.reader_has_descendant_path(&rel) || index.live.has_descendant_path(&rel)
+                };
+                let prefix = format!("{rel}/");
+                has_content_descendant
+                    || state
+                        .filename_extra_paths
+                        .read()
+                        .unwrap()
+                        .iter()
+                        .any(|path| path.starts_with(&prefix))
             })
         {
             // A single directory removal/rename event names no descendants.
@@ -3986,28 +3996,29 @@ fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
 
 /// Move a listable path out of the content index.
 ///
-/// The extra-path insertion is the membership transition. Only that first
-/// transition creates a tombstone, so duplicate watcher notifications for a
-/// binary path do not repeatedly dirty the live overlay.
+/// Filename membership and content eviction are independent transitions. A new
+/// filename-only path that was never content-indexed needs no tombstone, while
+/// an already-known filename-only path must still evict content if stale
+/// postings are active for it.
 fn mark_filename_only(state: &ServerState, rel_path: &str) {
-    let inserted = {
+    let (inserted, removed_content) = {
         let mut index = state.index.write().unwrap();
         let mut extra = state.filename_extra_paths.write().unwrap();
-        if !extra.insert(rel_path.to_string()) {
-            false
-        } else {
-            if !index.live.is_deleted(rel_path) {
-                index.live.delete_file(rel_path);
-            }
+        let inserted = extra.insert(rel_path.to_string());
+        let removed_content = index.has_active_path(rel_path);
+        if removed_content {
+            index.live.delete_file(rel_path);
             invalidate_cached_paths_locked(state, std::iter::once(rel_path));
-            true
         }
+        (inserted, removed_content)
     };
-    if !inserted {
+    if inserted {
+        state.filename_index_dirty.store(true, Ordering::SeqCst);
+    }
+    if !inserted && !removed_content {
         return;
     }
 
-    state.filename_index_dirty.store(true, Ordering::SeqCst);
     state.file_stamps.write().unwrap().remove(rel_path);
 }
 
@@ -4683,6 +4694,35 @@ fn periodic_reconcile_loop(state: Arc<ServerState>, root: PathBuf, index_dir: Pa
     }
 }
 
+fn persist_pending_index_changes(state: &Arc<ServerState>) -> bool {
+    // Hold the gate through delta build -> publish -> prune so watcher mutations
+    // cannot race publication. Recheck after acquiring it: another publisher
+    // may have drained either source while we waited.
+    let _gate = state.snapshot_gate.write().unwrap();
+    if state.index.read().unwrap().live.has_pending_changes() {
+        let stamps = state.file_stamps.read().unwrap().clone();
+        return stream_merge_stale_changes(
+            state,
+            &[],
+            &[],
+            &[],
+            &stamps,
+            StaleMergePolicy {
+                preserved: &std::collections::HashSet::new(),
+                operation: "auto-save",
+                authoritative_membership: false,
+                authoritative_listed_files: None,
+            },
+        );
+    }
+    if state.filename_index_ready.load(Ordering::SeqCst)
+        && state.filename_index_dirty.load(Ordering::SeqCst)
+    {
+        return persist_filename_extra_paths(state, &state.index_dir);
+    }
+    true
+}
+
 fn auto_save_loop(state: Arc<ServerState>) {
     let mut last_save = Instant::now();
 
@@ -4701,34 +4741,20 @@ fn auto_save_loop(state: Arc<ServerState>) {
             let index = state.index.read().unwrap();
             index.live.dirty_count()
         };
+        let filename_dirty = state.filename_index_ready.load(Ordering::SeqCst)
+            && state.filename_index_dirty.load(Ordering::SeqCst);
 
         let elapsed = last_save.elapsed();
-        if dirty >= state.auto_save_mutations || (dirty > 0 && elapsed >= AUTO_SAVE_INTERVAL) {
+        if filename_dirty
+            || dirty >= state.auto_save_mutations
+            || (dirty > 0 && elapsed >= AUTO_SAVE_INTERVAL)
+        {
             let save_start = Instant::now();
-            eprintln!("[trace] auto-save: {dirty} mutations, saving...");
+            eprintln!(
+                "[trace] auto-save: {dirty} content mutations, filename index dirty={filename_dirty}, saving..."
+            );
 
-            // Hold the gate through delta build → publish → prune so watcher
-            // mutations cannot race publication. Recheck after acquiring it:
-            // another publisher may have drained the overlay while we waited.
-            let _gate = state.snapshot_gate.write().unwrap();
-            if !state.index.read().unwrap().live.has_pending_changes() {
-                continue;
-            }
-
-            let stamps = state.file_stamps.read().unwrap().clone();
-            if stream_merge_stale_changes(
-                &state,
-                &[],
-                &[],
-                &[],
-                &stamps,
-                StaleMergePolicy {
-                    preserved: &std::collections::HashSet::new(),
-                    operation: "auto-save",
-                    authoritative_membership: false,
-                    authoritative_listed_files: None,
-                },
-            ) {
+            if persist_pending_index_changes(&state) {
                 last_save = Instant::now();
                 eprintln!(
                     "[trace] auto-save complete in {:.1}s",
@@ -5214,6 +5240,12 @@ fn stream_merge_stale_changes(
                     .map(String::as_str),
             );
             content_paths.extend(delta.all_paths().iter().map(String::as_str));
+            content_paths.extend(
+                overlay_paths
+                    .iter()
+                    .filter(|path| preserve_overlay_paths.contains(path.as_str()))
+                    .map(String::as_str),
+            );
             listed_files
                 .iter()
                 .filter(|path| !content_paths.contains(path.as_str()))
@@ -7156,6 +7188,8 @@ mod tests {
             .unwrap()
             .insert("assets/missing.bin".to_string());
         state.filename_index_ready.store(true, Ordering::SeqCst);
+        tgrep_core::path_index::write_extra_paths(&index_dir, &["assets/missing.bin".to_string()])
+            .unwrap();
 
         sweep_removed_files(
             state.as_ref(),
@@ -7172,14 +7206,16 @@ mod tests {
                 .contains("assets/missing.bin")
         );
         assert!(
-            state
-                .index
-                .read()
-                .unwrap()
-                .live
-                .is_deleted("assets/missing.bin")
+            !state.index.read().unwrap().live.has_pending_changes(),
+            "removing a filename-only path must not create a content tombstone"
         );
         assert!(state.filename_index_dirty.load(Ordering::SeqCst));
+        assert!(persist_pending_index_changes(&state));
+        assert_eq!(
+            tgrep_core::path_index::read_extra_paths(&index_dir).unwrap(),
+            Some(Vec::new())
+        );
+        assert!(!state.filename_index_dirty.load(Ordering::SeqCst));
     }
 
     /// A binary marker's offset is a position in the file, not in the repaired
@@ -7713,6 +7749,7 @@ mod tests {
         }
         assert!(state.index.read().unwrap().live.has_path("raced.rs"));
         let stamps = state.file_stamps.read().unwrap().clone();
+        let listed_files = vec!["raced.rs".to_string()];
         std::fs::remove_file(&path).unwrap();
         {
             let _gate = state.snapshot_gate.write().unwrap();
@@ -7726,6 +7763,7 @@ mod tests {
                     preserved: &std::collections::HashSet::new(),
                     operation: "test stale check",
                     authoritative_membership: true,
+                    authoritative_listed_files: Some(&listed_files),
                 },
             ));
         }
@@ -7734,6 +7772,14 @@ mod tests {
             assert!(index.reader_has_path("raced.rs"));
             assert!(index.live.has_path("raced.rs"));
         }
+        assert!(
+            !state
+                .filename_extra_paths
+                .read()
+                .unwrap()
+                .contains("raced.rs"),
+            "a preserved active overlay must remain a content path, not enter the sidecar"
+        );
         assert!(state.unreadable.read().unwrap().contains_key("raced.rs"));
 
         // A later merge may still need to publish unrelated live work. The
@@ -7759,6 +7805,7 @@ mod tests {
                     preserved: &preserved,
                     operation: "test retry",
                     authoritative_membership: true,
+                    authoritative_listed_files: None,
                 },
             ));
         }
@@ -8528,6 +8575,54 @@ mod tests {
         assert!(
             result.contains("new_watched_marker"),
             "the replay must force the concrete event despite the later matching stamp: {result}"
+        );
+    }
+
+    #[test]
+    fn rpc_reload_replays_binary_filename_changes_received_after_extraction() {
+        let tmp = TempDir::new().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        test_git(&root, &["init", "--quiet"]);
+        let removed = root.join("removed.bin");
+        let added = root.join("added.bin");
+        std::fs::write(&removed, [1, 2, 3]).unwrap();
+        let state = test_server_state(&root, &root.join(".tgrep"));
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+
+        let hook_state = Arc::clone(&state);
+        let hook_removed = removed.clone();
+        let hook_added = added.clone();
+        *state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+            if matches!(phase, StaleRefreshPhase::AfterBuildBeforeStampPublish) {
+                std::fs::remove_file(&hook_removed).unwrap();
+                std::fs::write(&hook_added, [4, 5, 6]).unwrap();
+                assert!(defer_events_during_build(
+                    &hook_state,
+                    &Event {
+                        kind: EventKind::Remove(notify::event::RemoveKind::File),
+                        paths: vec![hook_removed.clone()],
+                        attrs: Default::default(),
+                    }
+                ));
+                assert!(defer_events_during_build(
+                    &hook_state,
+                    &Event {
+                        kind: EventKind::Create(notify::event::CreateKind::File),
+                        paths: vec![hook_added.clone()],
+                        attrs: Default::default(),
+                    }
+                ));
+            }
+        }));
+
+        let response = handle_reload(None, &state);
+        assert!(response.contains("\"status\":\"reloaded\""), "{response}");
+        let response = handle_files(None, &state);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(
+            value.pointer("/result/files").unwrap(),
+            &serde_json::json!(["added.bin"]),
+            "binary filename events must be replayed against the reloaded sidecar"
         );
     }
 
@@ -9712,6 +9807,53 @@ mod tests {
             !index.reader_has_path("removed/deep.rs") && !index.live.has_path("removed/deep.rs"),
             "the coalesced reconcile must retire descendants named by no removal event"
         );
+    }
+
+    #[test]
+    fn a_deferred_directory_rename_reconciles_filename_only_descendants() {
+        let tmp = TempDir::new().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let dir = root.join("removed");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("deep.bin"), [1, 2, 3]).unwrap();
+        let state = test_server_state(&root, &root.join(".tgrep"));
+        state.gitignore_pending.store(false, Ordering::SeqCst);
+        state
+            .filename_extra_paths
+            .write()
+            .unwrap()
+            .insert("removed/deep.bin".to_string());
+        state.filename_index_ready.store(true, Ordering::SeqCst);
+
+        state.indexing.store(true, Ordering::SeqCst);
+        std::fs::rename(&dir, root.join("moved")).unwrap();
+        handle_fs_event(
+            &state,
+            &root,
+            &Event {
+                kind: EventKind::Modify(notify::event::ModifyKind::Name(
+                    notify::event::RenameMode::From,
+                )),
+                paths: vec![dir],
+                attrs: Default::default(),
+            },
+        );
+        state.indexing.store(false, Ordering::SeqCst);
+        replay_deferred_events(&state, &root);
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while (state.ignore_refresh_scheduled.load(Ordering::SeqCst)
+            || state.ignore_rules_dirty.load(Ordering::SeqCst))
+            && Instant::now() < deadline
+        {
+            thread::sleep(Duration::from_millis(10));
+        }
+        let paths = state.filename_extra_paths.read().unwrap();
+        assert!(
+            !paths.contains("removed/deep.bin"),
+            "the coalesced reconcile must retire filename-only descendants"
+        );
+        assert!(paths.contains("moved/deep.bin"));
     }
 
     /// A file that cannot be opened right now is not a file that stopped

--- a/tgrep-cli/tests/indexed_files.rs
+++ b/tgrep-cli/tests/indexed_files.rs
@@ -1,0 +1,190 @@
+use assert_cmd::Command;
+use std::fs;
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+fn tgrep() -> Command {
+    Command::cargo_bin("tgrep").unwrap()
+}
+
+fn tgrep_bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("tgrep")
+}
+
+fn fixture() -> (TempDir, PathBuf, PathBuf) {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path().join("repo");
+    let index = temp.path().join("index");
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src").join("main.rs"), "fn main() {}\n").unwrap();
+    fs::write(root.join("src").join("notes.txt"), "notes\n").unwrap();
+    fs::write(root.join("asset.bin"), [1, 2, 3]).unwrap();
+    fs::write(root.join("binary.txt"), b"before\0after").unwrap();
+    (temp, root, index)
+}
+
+fn build_index(root: &Path, index: &Path) {
+    tgrep()
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+struct ServerGuard(Child);
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn start_server(root: &Path, index: &Path) -> ServerGuard {
+    let mut child = std::process::Command::new(tgrep_bin())
+        .args([
+            "serve",
+            "--no-watch",
+            "--index-path",
+            index.to_str().unwrap(),
+            root.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let serve_json = index.join("serve.json");
+    let started = Instant::now();
+
+    loop {
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "server did not start"
+        );
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "server exited before accepting connections"
+        );
+        if let Ok(data) = fs::read_to_string(&serve_json)
+            && let Ok(info) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(port) = info.get("port").and_then(serde_json::Value::as_u64)
+            && TcpStream::connect(("127.0.0.1", port as u16)).is_ok()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    ServerGuard(child)
+}
+
+fn output_lines(command: &mut Command) -> Vec<String> {
+    let output = command.assert().success().get_output().stdout.clone();
+    String::from_utf8(output)
+        .unwrap()
+        .lines()
+        .map(|line| line.replace('\\', "/"))
+        .collect()
+}
+
+#[test]
+fn indexed_files_include_non_content_paths_and_use_the_snapshot() {
+    let (_temp, root, index) = fixture();
+    build_index(&root, &index);
+    fs::write(root.join("created-after-index.rs"), "fn late() {}\n").unwrap();
+
+    let indexed = output_lines(tgrep().args([
+        "--files",
+        "--sort",
+        "path",
+        root.to_str().unwrap(),
+        "--index-path",
+        index.to_str().unwrap(),
+    ]));
+    assert!(indexed.iter().any(|path| path.ends_with("/src/main.rs")));
+    assert!(indexed.iter().any(|path| path.ends_with("/asset.bin")));
+    assert!(indexed.iter().any(|path| path.ends_with("/binary.txt")));
+    assert!(
+        !indexed
+            .iter()
+            .any(|path| path.ends_with("/created-after-index.rs")),
+        "the indexed path unexpectedly walked the live tree: {indexed:?}"
+    );
+
+    let walked = output_lines(tgrep().args([
+        "--files",
+        "--no-index",
+        root.to_str().unwrap(),
+        "--index-path",
+        index.to_str().unwrap(),
+    ]));
+    assert!(
+        walked
+            .iter()
+            .any(|path| path.ends_with("/created-after-index.rs"))
+    );
+}
+
+#[test]
+fn legacy_filename_index_falls_back_and_indexed_scope_still_filters() {
+    let (_temp, root, index) = fixture();
+    build_index(&root, &index);
+
+    let scoped = output_lines(tgrep().args([
+        "--files",
+        "--sort",
+        "path",
+        "-t",
+        "rust",
+        root.join("src").to_str().unwrap(),
+        "--index-path",
+        index.to_str().unwrap(),
+    ]));
+    assert_eq!(scoped.len(), 1, "unexpected scoped output: {scoped:?}");
+    assert!(scoped[0].ends_with("/src/main.rs"));
+
+    fs::remove_file(index.join(tgrep_core::path_index::EXTRA_PATHS_FILENAME)).unwrap();
+    fs::write(root.join("legacy-live.rs"), "fn legacy() {}\n").unwrap();
+    let fallback = output_lines(tgrep().args([
+        "--files",
+        root.to_str().unwrap(),
+        "--index-path",
+        index.to_str().unwrap(),
+    ]));
+    assert!(
+        fallback
+            .iter()
+            .any(|path| path.ends_with("/legacy-live.rs")),
+        "a legacy index did not fall back to walking: {fallback:?}"
+    );
+}
+
+#[test]
+fn files_uses_the_live_server_filename_index() {
+    let (_temp, root, index) = fixture();
+    build_index(&root, &index);
+    let _server = start_server(&root, &index);
+
+    // Make the local sidecar incomplete after the server has loaded its copy.
+    // The binary path below can therefore come only from the files RPC.
+    tgrep_core::path_index::write_extra_paths(&index, &[]).unwrap();
+    let listed = output_lines(tgrep().args([
+        "--files",
+        root.to_str().unwrap(),
+        "--index-path",
+        index.to_str().unwrap(),
+    ]));
+
+    assert!(
+        listed.iter().any(|path| path.ends_with("/asset.bin")),
+        "the client did not use the server's filename index: {listed:?}"
+    );
+}

--- a/tgrep-cli/tests/indexed_files.rs
+++ b/tgrep-cli/tests/indexed_files.rs
@@ -131,6 +131,20 @@ fn indexed_files_include_non_content_paths_and_use_the_snapshot() {
             .iter()
             .any(|path| path.ends_with("/created-after-index.rs"))
     );
+
+    let case_insensitive_ignore = output_lines(tgrep().args([
+        "--files",
+        "--ignore-file-case-insensitive",
+        root.to_str().unwrap(),
+        "--index-path",
+        index.to_str().unwrap(),
+    ]));
+    assert!(
+        case_insensitive_ignore
+            .iter()
+            .any(|path| path.ends_with("/created-after-index.rs")),
+        "the traversal-changing ignore flag unexpectedly used the snapshot"
+    );
 }
 
 #[test]

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -1,12 +1,13 @@
 /// Index builder: walks a repo, extracts trigrams, writes the on-disk index.
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::Path;
 
 use crate::external::{self, ExternalSorter, TrigramPosting};
 use crate::meta::{self, IndexMeta};
 use crate::ondisk::{self, LookupEntry, PostingEntry};
+use crate::path_index;
 use crate::reader::IndexReader;
 use crate::trigram::{self, TrigramMasks};
 use crate::walker;
@@ -604,6 +605,9 @@ pub fn build_index_with_options_and_ignorecase(
         None => root.join(INDEX_DIR_NAME),
     };
     std::fs::create_dir_all(&index_dir)?;
+    // A failed in-place rebuild must not leave a valid-looking sidecar from a
+    // previous generation. Its absence makes `--files` fall back to walking.
+    path_index::remove_extra_paths(&index_dir)?;
 
     eprintln!("Walking {}...", root.display());
     if let Some(hint) = gitignore_gate_hint(&root, opts) {
@@ -739,6 +743,19 @@ pub fn build_index_with_options_and_ignorecase(
     let all_walked = walked_paths_for_stamps(&root, &walk.files, &raced_too_large);
     let stamps = meta::collect_filestamps(&root, &all_walked);
     meta::write_filestamps(&stamps, &index_dir)?;
+
+    let indexed_paths: HashSet<&str> = file_id_map.iter().map(|(_, path)| path.as_str()).collect();
+    let mut extra_paths: Vec<String> = walk
+        .listed_files
+        .iter()
+        .filter_map(|path| path.strip_prefix(&root).ok())
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .filter(|path| !indexed_paths.contains(path.as_str()))
+        .collect();
+    extra_paths.sort_unstable();
+    path_index::write_extra_paths(&index_dir, &extra_paths)?;
+    // `meta.json` remains the final publication marker for in-place builds.
+    IndexMeta::load(&index_dir)?.save(&index_dir)?;
 
     eprintln!("Index built successfully at {}", index_dir.display());
     Ok(BuildOutcome {
@@ -1911,6 +1928,28 @@ mod tests {
             indexed,
             vec!["src/main.rs".to_string()],
             "a build destined for the server must skip dot-prefixed files"
+        );
+    }
+
+    #[test]
+    fn filename_sidecar_captures_paths_outside_the_content_index() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(repo.path().join("asset.bin"), [1, 2, 3]).unwrap();
+        std::fs::write(repo.path().join("binary.txt"), b"before\0after").unwrap();
+        let index = tempfile::tempdir().unwrap();
+
+        build_index_with_options(repo.path(), Some(index.path()), &BuildOptions::default())
+            .unwrap();
+
+        let reader = IndexReader::open(index.path()).unwrap();
+        assert_eq!(reader.all_paths(), &["main.rs".to_string()]);
+        let extras = crate::path_index::read_extra_paths(index.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            extras,
+            vec!["asset.bin".to_string(), "binary.txt".to_string()]
         );
     }
 

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -191,10 +191,7 @@ impl HybridIndex {
         if self.live.is_deleted(path) {
             return false;
         }
-        self.reader()
-            .all_paths()
-            .iter()
-            .any(|candidate| candidate == path)
+        self.reader().contains_path(path)
     }
 
     /// Execute a query plan against the hybrid index.

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -183,6 +183,20 @@ impl HybridIndex {
         paths
     }
 
+    /// Whether a path is active in either the reader or live overlay.
+    pub fn has_active_path(&self, path: &str) -> bool {
+        if self.live.has_path(path) {
+            return true;
+        }
+        if self.live.is_deleted(path) {
+            return false;
+        }
+        self.reader()
+            .all_paths()
+            .iter()
+            .any(|candidate| candidate == path)
+    }
+
     /// Execute a query plan against the hybrid index.
     pub fn execute_query(&self, plan: &QueryPlan) -> Vec<u32> {
         if plan.is_match_all() {

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -164,6 +164,25 @@ impl HybridIndex {
         ids
     }
 
+    /// Get every active content-indexed path from a consistent reader snapshot.
+    pub fn all_paths(&self) -> Vec<String> {
+        let reader = self.reader();
+        let mut paths: Vec<String> = reader
+            .all_paths()
+            .iter()
+            .enumerate()
+            .filter(|(file_id, _)| self.reader_entry_active(&reader, *file_id as u32))
+            .map(|(_, path)| path.clone())
+            .collect();
+        paths.extend(
+            self.live
+                .all_paths_ordered()
+                .into_iter()
+                .map(str::to_string),
+        );
+        paths
+    }
+
     /// Execute a query plan against the hybrid index.
     pub fn execute_query(&self, plan: &QueryPlan) -> Vec<u32> {
         if plan.is_match_all() {

--- a/tgrep-core/src/lib.rs
+++ b/tgrep-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod hybrid;
 pub mod live;
 pub mod meta;
 pub(crate) mod ondisk;
+pub mod path_index;
 pub mod query;
 pub mod reader;
 pub mod trigram;

--- a/tgrep-core/src/ondisk.rs
+++ b/tgrep-core/src/ondisk.rs
@@ -1,6 +1,8 @@
 /// On-disk binary format for the trigram index.
 ///
-/// Three files compose the index:
+/// Three files compose the searchable-content index. `files-extra.bin`, defined
+/// in [`crate::path_index`], complements `files.bin` with paths used only by
+/// `--files`.
 ///
 /// ## `lookup.bin` — sorted trigram → postings pointer
 /// Fixed-size 16-byte entries sorted by trigram hash for binary search.

--- a/tgrep-core/src/path_index.rs
+++ b/tgrep-core/src/path_index.rs
@@ -1,0 +1,147 @@
+//! Persisted paths that are listable by `--files` but absent from the content index.
+//!
+//! `files.bin` already stores every path that has searchable trigram postings.
+//! This sidecar stores only the remaining admitted paths (binary files, binary
+//! extensions, and files that could not be read while indexing), keeping both
+//! disk and resident-memory overhead proportional to that usually small delta.
+
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use crate::{Error, Result};
+
+pub const EXTRA_PATHS_FILENAME: &str = "files-extra.bin";
+
+const MAGIC: &[u8; 8] = b"TGRPXP01";
+const HEADER_LEN: usize = MAGIC.len() + size_of::<u64>();
+const PATH_LEN_SIZE: usize = size_of::<u32>();
+
+/// Write a complete filename-only path set.
+pub fn write_extra_paths(index_dir: &Path, paths: &[String]) -> Result<()> {
+    std::fs::create_dir_all(index_dir)?;
+    let mut writer = BufWriter::new(std::fs::File::create(index_dir.join(EXTRA_PATHS_FILENAME))?);
+    writer.write_all(MAGIC)?;
+    writer.write_all(&(paths.len() as u64).to_le_bytes())?;
+
+    for path in paths {
+        let bytes = path.as_bytes();
+        let len = u32::try_from(bytes.len()).map_err(|_| {
+            Error::IndexCorrupted(format!(
+                "path is too long for {EXTRA_PATHS_FILENAME} ({} bytes)",
+                bytes.len()
+            ))
+        })?;
+        writer.write_all(&len.to_le_bytes())?;
+        writer.write_all(bytes)?;
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read the filename-only path set.
+///
+/// `Ok(None)` identifies a legacy index that predates the sidecar. Callers can
+/// then preserve correctness by falling back to a filesystem walk.
+pub fn read_extra_paths(index_dir: &Path) -> Result<Option<Vec<String>>> {
+    let path = index_dir.join(EXTRA_PATHS_FILENAME);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let data = std::fs::read(path)?;
+    if data.len() < HEADER_LEN {
+        return Err(corrupted(format!(
+            "header is truncated ({} bytes, expected at least {HEADER_LEN})",
+            data.len()
+        )));
+    }
+    if &data[..MAGIC.len()] != MAGIC {
+        return Err(corrupted("invalid header".to_string()));
+    }
+
+    let count = u64::from_le_bytes(data[MAGIC.len()..HEADER_LEN].try_into().unwrap());
+    let max_records = (data.len() - HEADER_LEN) / PATH_LEN_SIZE;
+    if count > max_records as u64 {
+        return Err(corrupted(format!(
+            "declares {count} paths but the file can contain at most {max_records}"
+        )));
+    }
+
+    let mut paths = Vec::with_capacity(count as usize);
+    let mut pos = HEADER_LEN;
+    for index in 0..count {
+        if pos + PATH_LEN_SIZE > data.len() {
+            return Err(corrupted(format!("path {index} has a truncated length")));
+        }
+        let len = u32::from_le_bytes(data[pos..pos + PATH_LEN_SIZE].try_into().unwrap()) as usize;
+        pos += PATH_LEN_SIZE;
+        let end = pos
+            .checked_add(len)
+            .filter(|&end| end <= data.len())
+            .ok_or_else(|| corrupted(format!("path {index} exceeds the file bounds")))?;
+        let value = std::str::from_utf8(&data[pos..end])
+            .map_err(|_| corrupted(format!("path {index} is not valid UTF-8")))?;
+        paths.push(value.to_string());
+        pos = end;
+    }
+
+    if pos != data.len() {
+        return Err(corrupted(format!(
+            "{} trailing bytes after the declared path set",
+            data.len() - pos
+        )));
+    }
+    Ok(Some(paths))
+}
+
+/// Remove a previous sidecar before rebuilding in place.
+pub fn remove_extra_paths(index_dir: &Path) -> Result<()> {
+    match std::fs::remove_file(index_dir.join(EXTRA_PATHS_FILENAME)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn corrupted(message: String) -> Error {
+    Error::IndexCorrupted(format!("{EXTRA_PATHS_FILENAME}: {message}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_sidecar_identifies_a_legacy_index() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_extra_paths(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn round_trips_empty_and_nonempty_path_sets() {
+        let dir = tempfile::tempdir().unwrap();
+        write_extra_paths(dir.path(), &[]).unwrap();
+        assert_eq!(read_extra_paths(dir.path()).unwrap(), Some(Vec::new()));
+
+        let paths = vec![
+            "assets/image.bin".to_string(),
+            "name\nwith-newline.dat".to_string(),
+        ];
+        write_extra_paths(dir.path(), &paths).unwrap();
+        assert_eq!(read_extra_paths(dir.path()).unwrap(), Some(paths));
+    }
+
+    #[test]
+    fn rejects_truncated_and_trailing_data() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(EXTRA_PATHS_FILENAME), MAGIC).unwrap();
+        assert!(read_extra_paths(dir.path()).is_err());
+
+        write_extra_paths(dir.path(), &["one.bin".to_string()]).unwrap();
+        let path = dir.path().join(EXTRA_PATHS_FILENAME);
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes.push(0);
+        std::fs::write(path, bytes).unwrap();
+        assert!(read_extra_paths(dir.path()).is_err());
+    }
+}

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -70,6 +70,16 @@ fn should_skip_dir(entry: &ignore::DirEntry, exclude_dirs: &[String]) -> bool {
             .is_some_and(|name| exclude_dirs.iter().any(|d| d == name))
 }
 
+fn exceeds_size_limit<E>(
+    max_file_size: Option<u64>,
+    metadata_len: impl FnOnce() -> Result<u64, E>,
+) -> Result<bool, E> {
+    match max_file_size {
+        Some(limit) => metadata_len().map(|size| size > limit),
+        None => Ok(false),
+    }
+}
+
 pub struct WalkResult {
     pub files: Vec<PathBuf>,
     /// Files admitted by traversal rules and the size cap before binary
@@ -378,8 +388,15 @@ pub fn walk_dir_with_ignorecase(
             let path = entry.path();
 
             let binary_extension = !search_binary && is_binary_extension(path);
-            let too_large = max_file_size
-                .is_some_and(|limit| entry.metadata().is_ok_and(|meta| meta.len() > limit));
+            let too_large =
+                match exceeds_size_limit(max_file_size, || entry.metadata().map(|meta| meta.len()))
+                {
+                    Ok(too_large) => too_large,
+                    Err(_) => {
+                        skipped_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        return ignore::WalkState::Continue;
+                    }
+                };
             if !too_large {
                 listed_files.lock().unwrap().push(path.to_path_buf());
             }
@@ -616,8 +633,15 @@ pub fn walk_file_metadata_with_ignorecase(
             };
 
             if is_binary_extension(path) {
-                let too_large = max_file_size
-                    .is_some_and(|limit| entry.metadata().is_ok_and(|meta| meta.len() > limit));
+                let too_large = match exceeds_size_limit(max_file_size, || {
+                    entry.metadata().map(|meta| meta.len())
+                }) {
+                    Ok(too_large) => too_large,
+                    Err(_) => {
+                        skipped_error.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        return ignore::WalkState::Continue;
+                    }
+                };
                 if !too_large {
                     listed_files.lock().unwrap().push(rel_path);
                 }
@@ -739,6 +763,22 @@ mod tests {
         let result = walk_dir(&root, &WalkOptions::default());
         assert!(!sorted_filenames(&result, &root).contains(&"asset.bin".to_string()));
         assert!(sorted_listed_filenames(&result, &root).contains(&"asset.bin".to_string()));
+    }
+
+    #[test]
+    fn size_limit_requires_successful_metadata() {
+        assert_eq!(exceeds_size_limit(Some(10), || Ok::<_, ()>(11)), Ok(true));
+        assert_eq!(exceeds_size_limit(Some(10), || Ok::<_, ()>(10)), Ok(false));
+        assert_eq!(
+            exceeds_size_limit(Some(10), || Err::<u64, _>("metadata failed")),
+            Err("metadata failed")
+        );
+        assert_eq!(
+            exceeds_size_limit(None, || -> Result<u64, ()> {
+                panic!("an uncapped walk must not read metadata")
+            }),
+            Ok(false)
+        );
     }
 
     #[test]

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -72,6 +72,9 @@ fn should_skip_dir(entry: &ignore::DirEntry, exclude_dirs: &[String]) -> bool {
 
 pub struct WalkResult {
     pub files: Vec<PathBuf>,
+    /// Files admitted by traversal rules and the size cap before binary
+    /// extension filtering. This is the complete set used by `--files`.
+    pub listed_files: Vec<PathBuf>,
     pub gitignore_files: Vec<PathBuf>,
     /// `.ignore` files encountered during the walk. Kept separate from
     /// `gitignore_files` so a matcher can apply them last, giving them
@@ -257,6 +260,7 @@ pub fn walk_dir_with_ignorecase(
     ignorecase: Option<std::sync::Arc<crate::gitignore::CaseInsensitiveIgnore>>,
 ) -> WalkResult {
     let files = std::sync::Mutex::new(Vec::new());
+    let listed_files = std::sync::Mutex::new(Vec::new());
     let gitignore_files = std::sync::Mutex::new(Vec::new());
     let ignore_files = std::sync::Mutex::new(Vec::new());
     let skipped_binary = std::sync::atomic::AtomicUsize::new(0);
@@ -322,6 +326,7 @@ pub fn walk_dir_with_ignorecase(
     walker.run(|| {
         let exclude = exclude_dirs.clone();
         let files = &files;
+        let listed_files = &listed_files;
         let gitignore_files = &gitignore_files;
         let ignore_files = &ignore_files;
         let skipped_binary = &skipped_binary;
@@ -372,7 +377,14 @@ pub fn walk_dir_with_ignorecase(
 
             let path = entry.path();
 
-            if !search_binary && is_binary_extension(path) {
+            let binary_extension = !search_binary && is_binary_extension(path);
+            let too_large = max_file_size
+                .is_some_and(|limit| entry.metadata().is_ok_and(|meta| meta.len() > limit));
+            if !too_large {
+                listed_files.lock().unwrap().push(path.to_path_buf());
+            }
+
+            if binary_extension {
                 skipped_binary.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 return ignore::WalkState::Continue;
             }
@@ -380,10 +392,7 @@ pub fn walk_dir_with_ignorecase(
             // Size is checked independently of `search_binary` so `--text`
             // and `--max-filesize` stay orthogonal, the way ripgrep treats
             // `-a` and `--max-filesize`.
-            if let Some(limit) = max_file_size
-                && let Ok(meta) = entry.metadata()
-                && meta.len() > limit
-            {
+            if too_large {
                 skipped_too_large.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 return ignore::WalkState::Continue;
             }
@@ -395,6 +404,7 @@ pub fn walk_dir_with_ignorecase(
 
     WalkResult {
         files: files.into_inner().unwrap(),
+        listed_files: listed_files.into_inner().unwrap(),
         gitignore_files: gitignore_files.into_inner().unwrap(),
         ignore_files: ignore_files.into_inner().unwrap(),
         skipped_binary: skipped_binary.into_inner(),
@@ -453,6 +463,8 @@ pub struct FileMeta {
 /// second full-tree walk.
 pub struct MetaWalkResult {
     pub files: Vec<FileMeta>,
+    /// Root-relative files admitted before binary extension filtering.
+    pub listed_files: Vec<String>,
     pub gitignore_files: Vec<PathBuf>,
     pub ignore_files: Vec<PathBuf>,
     /// Entries or metadata reads the walk could not inspect.
@@ -523,6 +535,7 @@ pub fn walk_file_metadata_with_ignorecase(
     let no_ignore = opts.no_ignore;
     let max_file_size = opts.max_file_size;
     let results = std::sync::Mutex::new(Vec::new());
+    let listed_files = std::sync::Mutex::new(Vec::new());
     let gitignore_files = std::sync::Mutex::new(Vec::new());
     let ignore_files = std::sync::Mutex::new(Vec::new());
     let skipped_error = std::sync::atomic::AtomicUsize::new(0);
@@ -562,6 +575,7 @@ pub fn walk_file_metadata_with_ignorecase(
         let exclude = exclude.clone();
         let root = root.clone();
         let results = &results;
+        let listed_files = &listed_files;
         let gitignore_files = &gitignore_files;
         let ignore_files = &ignore_files;
         let skipped_error = &skipped_error;
@@ -596,15 +610,19 @@ pub fn walk_file_metadata_with_ignorecase(
             }
 
             let path = entry.path();
-
-            if is_binary_extension(path) {
-                return ignore::WalkState::Continue;
-            }
-
             let rel_path = match path.strip_prefix(&root) {
                 Ok(p) => p.to_string_lossy().replace('\\', "/"),
                 Err(_) => return ignore::WalkState::Continue,
             };
+
+            if is_binary_extension(path) {
+                let too_large = max_file_size
+                    .is_some_and(|limit| entry.metadata().is_ok_and(|meta| meta.len() > limit));
+                if !too_large {
+                    listed_files.lock().unwrap().push(rel_path);
+                }
+                return ignore::WalkState::Continue;
+            }
 
             let meta = match entry.metadata() {
                 Ok(meta) => meta,
@@ -616,6 +634,7 @@ pub fn walk_file_metadata_with_ignorecase(
             if max_file_size.is_some_and(|limit| meta.len() > limit) {
                 return ignore::WalkState::Continue;
             }
+            listed_files.lock().unwrap().push(rel_path.clone());
             let stamp = crate::meta::file_stamp(&meta);
             results.lock().unwrap().push(FileMeta {
                 relative_path: rel_path,
@@ -629,6 +648,7 @@ pub fn walk_file_metadata_with_ignorecase(
 
     MetaWalkResult {
         files: results.into_inner().unwrap(),
+        listed_files: listed_files.into_inner().unwrap(),
         gitignore_files: gitignore_files.into_inner().unwrap(),
         ignore_files: ignore_files.into_inner().unwrap(),
         skipped_error: skipped_error.into_inner(),
@@ -678,6 +698,21 @@ mod tests {
         names
     }
 
+    fn sorted_listed_filenames(result: &WalkResult, root: &Path) -> Vec<String> {
+        let mut names: Vec<String> = result
+            .listed_files
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
     #[test]
     fn walk_dir_no_excludes_returns_all_files() {
         let dir = setup_fixture();
@@ -693,6 +728,17 @@ mod tests {
                 "vendor/dep.rs"
             ]
         );
+    }
+
+    #[test]
+    fn walk_dir_retains_binary_extensions_for_file_listing() {
+        let dir = setup_fixture();
+        let root = dir.path().join("testdata");
+        fs::write(root.join("asset.bin"), [0, 1, 2]).unwrap();
+
+        let result = walk_dir(&root, &WalkOptions::default());
+        assert!(!sorted_filenames(&result, &root).contains(&"asset.bin".to_string()));
+        assert!(sorted_listed_filenames(&result, &root).contains(&"asset.bin".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route `--files` through the live server or local index instead of walking the repository
- add a compact `files-extra.bin` sidecar for binary and other listable paths absent from the content index
- preserve legacy/corrupt-index and traversal-option filesystem fallbacks
- keep filename state current through watcher, reconciliation, and publication flows

## Testing
- `cargo test --workspace --quiet`
- `cargo clippy --workspace --benches -- -D warnings`
- `cargo fmt --all -- --check`

Closes #123