### PR TITLE
Fix passthru output when no lines match

### DIFF
--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -266,7 +266,10 @@ impl SearchOptions {
     }
 
     fn effective_passthru(&self) -> bool {
+        // ripgrep treats `-m 0` as suppressing all search output, including
+        // passthru context.
         self.passthru
+            && self.max_count != Some(0)
             && !self.files_only
             && !self.files_without_match
             && !self.count

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -265,6 +265,15 @@ impl SearchOptions {
         self.only_matching && !self.json
     }
 
+    fn effective_passthru(&self) -> bool {
+        self.passthru
+            && !self.files_only
+            && !self.files_without_match
+            && !self.count
+            && !self.count_matches
+            && !self.quiet
+    }
+
     fn match_options(&self) -> crate::matching::MatchOptions {
         crate::matching::MatchOptions {
             invert_match: self.invert_match,
@@ -282,12 +291,7 @@ impl SearchOptions {
             // `--passthru` prints the whole file, so it cannot also stop early
             // at a match limit, and it is meaningless when only file names or
             // counts are printed.
-            passthru: self.passthru
-                && !self.files_only
-                && !self.files_without_match
-                && !self.count
-                && !self.count_matches
-                && !self.quiet,
+            passthru: self.effective_passthru(),
             replace: self.replace.clone(),
             stop_on_nonmatch: self.stop_on_nonmatch,
             vimgrep: self.vimgrep,
@@ -934,7 +938,9 @@ fn search_via_server(
         }
     };
 
-    let had_matches = !matches.is_empty();
+    let had_matches = matches
+        .iter()
+        .any(|m| m.get("type").and_then(|t| t.as_str()).unwrap_or("match") != "context");
 
     if opts.quiet {
         writer.flush()?;
@@ -1104,14 +1110,15 @@ fn search_local_index(
 
     let matcher = opts.matcher(ci)?;
 
-    // Narrow candidates using every pattern, not just the primary one. A
+    // Narrow candidates using every pattern, not just the primary one.
+    // `--passthru` must visit files without any pattern trigrams, while a
     // non-default `--encoding` re-decodes files into text the index never saw,
-    // so the trigram plan cannot be trusted to find them.
+    // so neither can use the trigram plan.
     //
     // A PCRE-style pattern is not parseable by `regex-syntax`, but relaxing it
     // (dropping lookarounds and the like) yields one that is, and that matches a
     // superset — so its trigrams remain mandatory for the original.
-    let plan = if opts.encoding.may_differ_from_index() {
+    let plan = if opts.effective_passthru() || opts.encoding.may_differ_from_index() {
         QueryPlan::MatchAll
     } else if matcher.is_standard() || opts.fixed_string {
         query::build_multi_pattern_plan(&opts.all_patterns()?, opts.fixed_string, ci)
@@ -1707,14 +1714,19 @@ fn search_decoded_file(
     let match_opts = opts.match_options();
     let found = crate::matching::FileMatches::find(content, matcher, &match_opts)?;
 
-    if found.is_empty() {
+    let has_matches = !found.is_empty();
+    if !has_matches {
         // `--include-zero` still reports files that were searched but had no
         // match, which is the only way to tell them apart from files that were
         // never looked at.
         if opts.include_zero && (opts.count || opts.count_matches) && !opts.quiet {
             writer.write_count(rel_path, 0)?;
         }
-        return Ok(FileOutcome::NoMatch);
+        // Passthru still emits every line of a text file when none matched, but
+        // ripgrep does not expose a binary file merely because passthru is set.
+        if !match_opts.passthru || binary_offset.is_some() {
+            return Ok(FileOutcome::NoMatch);
+        }
     }
 
     // For quiet/files_without_match, we only need the outcome.
@@ -1798,7 +1810,11 @@ fn search_decoded_file(
         Ok(())
     })?;
 
-    Ok(FileOutcome::Matched)
+    Ok(if has_matches {
+        FileOutcome::Matched
+    } else {
+        FileOutcome::NoMatch
+    })
 }
 
 /// Path to print for a file the user named directly on the command line.

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -672,6 +672,7 @@ pub fn run(
     // never reports.
     if !opts.no_index
         && !bypass_index
+        && !opts.effective_passthru()
         && !opts.files_without_match
         && !opts.include_zero
         && let Ok(info) = ServerInfo::load(&index_dir)
@@ -941,9 +942,7 @@ fn search_via_server(
         }
     };
 
-    let had_matches = matches
-        .iter()
-        .any(|m| m.get("type").and_then(|t| t.as_str()).unwrap_or("match") != "context");
+    let had_matches = !matches.is_empty();
 
     if opts.quiet {
         writer.flush()?;

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1364,18 +1364,18 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
     )
     .map_err(|e| format!("{e}"))?;
 
-    // Build query plan from every pattern for index filtering. `-v` inverts at
-    // the line level, so a file matches when some line does *not* match; the
-    // trigram plan would select exactly the wrong candidates. A non-default
-    // `--encoding` is unsound for the same reason: the index holds trigrams of
-    // the BOM-sniffed text, so a re-decoded file can match bytes that were
-    // never indexed.
+    // Build query plan from every pattern for index filtering. `--passthru`
+    // needs files without any pattern trigrams. `-v` inverts at the line level,
+    // so a file matches when some line does *not* match; the trigram plan would
+    // select exactly the wrong candidates. A non-default `--encoding` is
+    // unsound for the same reason: the index holds trigrams of the BOM-sniffed
+    // text, so a re-decoded file can match bytes that were never indexed.
     //
     // A PCRE-style pattern cannot be parsed by `regex-syntax` at all, but it can
     // usually be *relaxed* into one that can (dropping lookarounds and the like).
     // The relaxed pattern matches a superset, so its trigrams are still mandatory
     // for the original and the candidate set stays sound.
-    let plan = if invert_match || encoding.may_differ_from_index() {
+    let plan = if passthru || invert_match || encoding.may_differ_from_index() {
         query::QueryPlan::MatchAll
     } else if matcher.is_standard() || fixed_string {
         query::build_multi_pattern_plan(&all_patterns, fixed_string, case_insensitive)?
@@ -1703,7 +1703,7 @@ fn search_file_matches(
     };
 
     let found = FileMatches::find(content, matcher, &match_opts)?;
-    if found.is_empty() {
+    if found.is_empty() && (!match_opts.passthru || binary_offset.is_some()) {
         return Ok(Vec::new());
     }
 

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1364,18 +1364,18 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
     )
     .map_err(|e| format!("{e}"))?;
 
-    // Build query plan from every pattern for index filtering. `--passthru`
-    // needs files without any pattern trigrams. `-v` inverts at the line level,
-    // so a file matches when some line does *not* match; the trigram plan would
-    // select exactly the wrong candidates. A non-default `--encoding` is
-    // unsound for the same reason: the index holds trigrams of the BOM-sniffed
-    // text, so a re-decoded file can match bytes that were never indexed.
+    // Build query plan from every pattern for index filtering. `-v` inverts at
+    // the line level, so a file matches when some line does *not* match; the
+    // trigram plan would select exactly the wrong candidates. A non-default
+    // `--encoding` is unsound for the same reason: the index holds trigrams of
+    // the BOM-sniffed text, so a re-decoded file can match bytes that were
+    // never indexed.
     //
     // A PCRE-style pattern cannot be parsed by `regex-syntax` at all, but it can
     // usually be *relaxed* into one that can (dropping lookarounds and the like).
     // The relaxed pattern matches a superset, so its trigrams are still mandatory
     // for the original and the candidate set stays sound.
-    let plan = if passthru || invert_match || encoding.may_differ_from_index() {
+    let plan = if invert_match || encoding.may_differ_from_index() {
         query::QueryPlan::MatchAll
     } else if matcher.is_standard() || fixed_string {
         query::build_multi_pattern_plan(&all_patterns, fixed_string, case_insensitive)?
@@ -1703,7 +1703,7 @@ fn search_file_matches(
     };
 
     let found = FileMatches::find(content, matcher, &match_opts)?;
-    if found.is_empty() && (!match_opts.passthru || binary_offset.is_some()) {
+    if found.is_empty() {
         return Ok(Vec::new());
     }
 

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -2581,9 +2581,8 @@ fn indexed_basic_search() {
 }
 
 #[test]
-fn indexed_passthru_prints_explicit_no_match_and_exits_one() {
+fn indexed_passthru_prints_no_match_and_exits_one() {
     let (dir, idx) = setup_indexed_fixture();
-    let path = dir.path().join("testdata").join("hello.rs");
 
     tgrep()
         .args([
@@ -2592,12 +2591,16 @@ fn indexed_passthru_prints_explicit_no_match_and_exits_one() {
             "--no-heading",
             "--no-filename",
             "--passthru",
+            "--stats",
+            "-g",
+            "hello.rs",
             "does-not-exist",
-            path.to_str().unwrap(),
+            &indexed_fixture_path(&dir),
         ])
         .assert()
         .code(1)
-        .stdout("fn main() {\n    println!(\"hello world\");\n}\n");
+        .stdout("fn main() {\n    println!(\"hello world\");\n}\n")
+        .stderr(predicate::str::contains("Query plan: MatchAll"));
 }
 
 #[test]
@@ -2710,12 +2713,13 @@ fn start_passthru_server(root: &std::path::Path, index_dir: &std::path::Path) ->
 }
 
 #[test]
-fn server_passthru_prints_explicit_no_match_and_exits_one() {
+fn passthru_bypasses_server_for_scoped_no_match() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().join("testdata");
-    fs::create_dir_all(&root).unwrap();
-    let path = root.join("plain.txt");
-    fs::write(&path, "alpha\nbeta\n").unwrap();
+    let scope = root.join("scope");
+    fs::create_dir_all(&scope).unwrap();
+    fs::write(scope.join("plain.txt"), "alpha\nbeta\n").unwrap();
+    fs::write(root.join("outside.txt"), "must stay outside scope\n").unwrap();
     let index_dir = dir.path().join("idx");
     let _server = start_passthru_server(&root, &index_dir);
 
@@ -2726,12 +2730,15 @@ fn server_passthru_prints_explicit_no_match_and_exits_one() {
             "--no-heading",
             "--no-filename",
             "--passthru",
+            "--stats",
             "does-not-exist",
-            path.to_str().unwrap(),
+            scope.to_str().unwrap(),
         ])
         .assert()
         .code(1)
         .stdout("alpha\nbeta\n")
+        .stderr(predicate::str::contains("Query plan: MatchAll"))
+        .stderr(predicate::str::contains("(via server)").not())
         .stderr(predicate::str::contains("Server unreachable").not());
 }
 
@@ -2739,8 +2746,7 @@ fn server_passthru_prints_explicit_no_match_and_exits_one() {
 fn passthru_max_count_zero_matches_ripgrep_across_search_paths() {
     let (dir, idx) = setup_indexed_fixture();
     let root = dir.path().join("testdata");
-    let path = root.join("hello.rs");
-    let path = path.to_str().unwrap();
+    let root = root.to_str().unwrap();
 
     let run = |index: Option<&str>, pattern: &str| {
         let mut cmd = tgrep();
@@ -2749,9 +2755,19 @@ fn passthru_max_count_zero_matches_ripgrep_across_search_paths() {
         } else {
             cmd.arg("--no-index");
         }
-        cmd.args(["--no-heading", "--passthru", "-m", "0", pattern, path])
-            .output()
-            .unwrap()
+        cmd.args([
+            "--no-heading",
+            "--passthru",
+            "--stats",
+            "-g",
+            "hello.rs",
+            "-m",
+            "0",
+            pattern,
+            root,
+        ])
+        .output()
+        .unwrap()
     };
 
     for pattern in ["fn main", "does-not-exist"] {
@@ -2762,16 +2778,20 @@ fn passthru_max_count_zero_matches_ripgrep_across_search_paths() {
         let indexed = run(Some(&idx), pattern);
         assert_eq!(indexed.status.code(), direct.status.code());
         assert_eq!(indexed.stdout, direct.stdout);
+        assert!(
+            String::from_utf8_lossy(&indexed.stderr).contains("Query plan:"),
+            "search did not use the local index: {indexed:?}"
+        );
     }
 
-    let _server = start_passthru_server(&root, std::path::Path::new(&idx));
+    let _server = start_passthru_server(std::path::Path::new(root), std::path::Path::new(&idx));
     for pattern in ["fn main", "does-not-exist"] {
         let server = run(Some(&idx), pattern);
         assert_eq!(server.status.code(), Some(1));
         assert!(server.stdout.is_empty(), "server output: {server:?}");
         assert!(
-            !String::from_utf8_lossy(&server.stderr).contains("Server unreachable"),
-            "search fell back from the server: {server:?}"
+            String::from_utf8_lossy(&server.stderr).contains("(via server)"),
+            "search did not use the server: {server:?}"
         );
     }
 }

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -2581,6 +2581,161 @@ fn indexed_basic_search() {
 }
 
 #[test]
+fn indexed_passthru_prints_explicit_no_match_and_exits_one() {
+    let (dir, idx) = setup_indexed_fixture();
+    let path = dir.path().join("testdata").join("hello.rs");
+
+    tgrep()
+        .args([
+            "--index-path",
+            &idx,
+            "--no-heading",
+            "--no-filename",
+            "--passthru",
+            "does-not-exist",
+            path.to_str().unwrap(),
+        ])
+        .assert()
+        .code(1)
+        .stdout("fn main() {\n    println!(\"hello world\");\n}\n");
+}
+
+#[test]
+fn indexed_passthru_emits_filtered_no_hit_files_beside_a_match() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    let scope = root.join("scope");
+    fs::create_dir_all(&scope).unwrap();
+    fs::write(root.join(".ignore"), "scope/ignored.rs\n").unwrap();
+    fs::write(scope.join("hit.rs"), "actual needle\n").unwrap();
+    fs::write(scope.join("miss.rs"), "eligible no hit\n").unwrap();
+    fs::write(scope.join("ignored.rs"), "ignored no hit\n").unwrap();
+    fs::write(scope.join("globbed.rs"), "glob no hit\n").unwrap();
+    fs::write(scope.join("typed.txt"), "typed no hit\n").unwrap();
+    fs::write(root.join("outside.rs"), "outside no hit\n").unwrap();
+
+    let index_dir = dir.path().join("idx");
+    tgrep()
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    tgrep()
+        .args([
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--no-heading",
+            "--passthru",
+            "-t",
+            "rust",
+            "-g",
+            "!globbed.rs",
+            "needle",
+            scope.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("actual needle"))
+        .stdout(predicate::str::contains("eligible no hit"))
+        .stdout(predicate::str::contains("ignored no hit").not())
+        .stdout(predicate::str::contains("glob no hit").not())
+        .stdout(predicate::str::contains("typed no hit").not())
+        .stdout(predicate::str::contains("outside no hit").not());
+}
+
+struct PassthruServer(std::process::Child);
+
+impl Drop for PassthruServer {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn start_passthru_server(root: &std::path::Path, index_dir: &std::path::Path) -> PassthruServer {
+    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin("tgrep"))
+        .args([
+            "serve",
+            root.to_str().unwrap(),
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--no-watch",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to start tgrep serve");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let serve_json = index_dir.join("serve.json");
+    let port = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!("tgrep serve exited before becoming ready: {status}");
+        }
+        assert!(
+            Instant::now() < deadline,
+            "tgrep serve did not become ready"
+        );
+        if let Ok(data) = fs::read_to_string(&serve_json)
+            && let Ok(info) = serde_json::from_str::<serde_json::Value>(&data)
+            && let Some(port) = info.get("port").and_then(|v| v.as_u64())
+            && TcpStream::connect(format!("127.0.0.1:{port}")).is_ok()
+        {
+            break port as u16;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    };
+
+    loop {
+        assert!(
+            Instant::now() < deadline,
+            "tgrep serve did not finish indexing"
+        );
+        if let Ok(response) =
+            send_rpc_request(port, r#"{"jsonrpc":"2.0","method":"status","id":0}"#)
+            && let Ok(status) = serde_json::from_str::<serde_json::Value>(&response)
+            && status.pointer("/result/indexing").and_then(|v| v.as_bool()) == Some(false)
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    PassthruServer(child)
+}
+
+#[test]
+fn server_passthru_prints_explicit_no_match_and_exits_one() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    fs::create_dir_all(&root).unwrap();
+    let path = root.join("plain.txt");
+    fs::write(&path, "alpha\nbeta\n").unwrap();
+    let index_dir = dir.path().join("idx");
+    let _server = start_passthru_server(&root, &index_dir);
+
+    tgrep()
+        .args([
+            "--index-path",
+            index_dir.to_str().unwrap(),
+            "--no-heading",
+            "--no-filename",
+            "--passthru",
+            "does-not-exist",
+            path.to_str().unwrap(),
+        ])
+        .assert()
+        .code(1)
+        .stdout("alpha\nbeta\n")
+        .stderr(predicate::str::contains("Server unreachable").not());
+}
+
+#[test]
 fn indexed_case_insensitive() {
     let (dir, idx) = setup_indexed_fixture();
     // "FN" should not match without -i
@@ -4550,6 +4705,44 @@ fn passthru_prints_every_line() {
 }
 
 #[test]
+fn passthru_prints_explicit_no_match_and_exits_one() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("plain.txt");
+    fs::write(&path, "alpha\nbeta\n").unwrap();
+
+    tgrep()
+        .args([
+            "--no-index",
+            "--no-heading",
+            "--no-filename",
+            "--passthru",
+            "does-not-exist",
+            path.to_str().unwrap(),
+        ])
+        .assert()
+        .code(1)
+        .stdout("alpha\nbeta\n");
+}
+
+#[test]
+fn passthru_no_match_keeps_binary_files_silent() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("binary.bin");
+    fs::write(&path, b"alpha\n\0beta\n").unwrap();
+
+    tgrep()
+        .args([
+            "--no-index",
+            "--passthru",
+            "does-not-exist",
+            path.to_str().unwrap(),
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
 fn stop_on_nonmatch_halts_at_the_first_gap() {
     let dir = TempDir::new().unwrap();
     let sub = dir.path().join("testdata");
@@ -4932,6 +5125,7 @@ fn new_flags_agree_across_search_paths() {
     let cases: &[&[&str]] = &[
         &["--no-heading", "-r", "REP", "hello"],
         &["--no-heading", "--passthru", "hello"],
+        &["--no-heading", "--passthru", "zzz_no_such_passthru_pattern"],
         &["--no-heading", "--column", "-b", "hello"],
         &["--no-heading", "-x", "}"],
         &["--no-heading", "--count-matches", "n"],

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -2736,6 +2736,47 @@ fn server_passthru_prints_explicit_no_match_and_exits_one() {
 }
 
 #[test]
+fn passthru_max_count_zero_matches_ripgrep_across_search_paths() {
+    let (dir, idx) = setup_indexed_fixture();
+    let root = dir.path().join("testdata");
+    let path = root.join("hello.rs");
+    let path = path.to_str().unwrap();
+
+    let run = |index: Option<&str>, pattern: &str| {
+        let mut cmd = tgrep();
+        if let Some(index) = index {
+            cmd.args(["--index-path", index]);
+        } else {
+            cmd.arg("--no-index");
+        }
+        cmd.args(["--no-heading", "--passthru", "-m", "0", pattern, path])
+            .output()
+            .unwrap()
+    };
+
+    for pattern in ["fn main", "does-not-exist"] {
+        let direct = run(None, pattern);
+        assert_eq!(direct.status.code(), Some(1));
+        assert!(direct.stdout.is_empty(), "direct output: {direct:?}");
+
+        let indexed = run(Some(&idx), pattern);
+        assert_eq!(indexed.status.code(), direct.status.code());
+        assert_eq!(indexed.stdout, direct.stdout);
+    }
+
+    let _server = start_passthru_server(&root, std::path::Path::new(&idx));
+    for pattern in ["fn main", "does-not-exist"] {
+        let server = run(Some(&idx), pattern);
+        assert_eq!(server.status.code(), Some(1));
+        assert!(server.stdout.is_empty(), "server output: {server:?}");
+        assert!(
+            !String::from_utf8_lossy(&server.stderr).contains("Server unreachable"),
+            "search fell back from the server: {server:?}"
+        );
+    }
+}
+
+#[test]
 fn indexed_case_insensitive() {
     let (dir, idx) = setup_indexed_fixture();
     // "FN" should not match without -i


### PR DESCRIPTION
## Summary
- route effective `--passthru` searches through every eligible indexed file
- emit no-hit text files through the existing context-line path in local and server-backed searches
- preserve exit status 1 when there are no actual matches, including server responses containing only context rows
- retain binary-file and output-only mode behavior

## Testing
- `cargo test --test ripgrep_compat passthru -- --nocapture`
- `cargo test --test ripgrep_compat new_flags_agree_across_search_paths -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #126