### PR TITLE
Coalesce duplicate file watcher events

### DIFF
--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2045,10 +2045,6 @@ struct FsEventBurst {
 }
 
 impl FsEventBurst {
-    fn new(first: Event) -> Self {
-        Self::with_limits(first, WATCHER_BURST_EVENT_CAP, WATCHER_BURST_PATH_CAP)
-    }
-
     fn with_limits(first: Event, event_cap: usize, path_cap: usize) -> Self {
         let mut burst = Self {
             paths: Vec::new(),
@@ -2118,6 +2114,80 @@ fn event_introduces_dir(kind: &EventKind) -> bool {
     )
 }
 
+#[derive(Clone, Copy)]
+struct WatcherReceiveOptions {
+    idle: Duration,
+    quiet: Duration,
+    max: Duration,
+    event_cap: usize,
+    path_cap: usize,
+}
+
+const WATCHER_RECEIVE_OPTIONS: WatcherReceiveOptions = WatcherReceiveOptions {
+    idle: WATCHER_IDLE_POLL,
+    quiet: WATCHER_BURST_QUIET,
+    max: WATCHER_BURST_MAX,
+    event_cap: WATCHER_BURST_EVENT_CAP,
+    path_cap: WATCHER_BURST_PATH_CAP,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+enum WatcherReceive {
+    Idle,
+    Disconnected,
+    Burst {
+        paths: Vec<CoalescedFsEvent>,
+        disconnected: bool,
+    },
+}
+
+/// Receive one bounded native-event burst, preserving a cap-rejected event for
+/// the next call rather than dropping or reordering it.
+fn receive_watcher_burst(
+    rx: &std::sync::mpsc::Receiver<Event>,
+    pending_event: &mut Option<Event>,
+    options: WatcherReceiveOptions,
+) -> WatcherReceive {
+    let first = match pending_event.take() {
+        Some(event) => event,
+        None => match rx.recv_timeout(options.idle) {
+            Ok(event) => event,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => return WatcherReceive::Idle,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return WatcherReceive::Disconnected;
+            }
+        },
+    };
+
+    let started = Instant::now();
+    let mut burst = FsEventBurst::with_limits(first, options.event_cap, options.path_cap);
+    let mut disconnected = false;
+    loop {
+        let remaining = options.max.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            break;
+        }
+        match rx.recv_timeout(std::cmp::min(options.quiet, remaining)) {
+            Ok(event) => {
+                if let Err(event) = burst.try_push(event) {
+                    *pending_event = Some(event);
+                    break;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                disconnected = true;
+                break;
+            }
+        }
+    }
+
+    WatcherReceive::Burst {
+        paths: burst.into_paths(),
+        disconnected,
+    }
+}
+
 fn recover_watcher_overflow(
     state: &Arc<ServerState>,
     root: &Path,
@@ -2140,7 +2210,7 @@ fn recover_watcher_overflow(
 }
 
 fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) -> bool {
-    use std::sync::mpsc::{RecvTimeoutError, TrySendError};
+    use std::sync::mpsc::TrySendError;
 
     let root_path = root.to_path_buf();
 
@@ -2263,38 +2333,12 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
                         );
                     }
                 }
-                let received = match pending_event.take() {
-                    Some(event) => Ok(event),
-                    None => rx.recv_timeout(WATCHER_IDLE_POLL),
-                };
-                match received {
-                    Ok(event) => {
-                        let started = Instant::now();
-                        let mut burst = FsEventBurst::new(event);
-                        let mut disconnected = false;
-                        // A quiet gap normally closes a save burst. The hard
-                        // deadline and collection caps ensure continuous or
-                        // high-cardinality traffic is processed in slices.
-                        loop {
-                            let remaining = WATCHER_BURST_MAX.saturating_sub(started.elapsed());
-                            if remaining.is_zero() {
-                                break;
-                            }
-                            match rx.recv_timeout(std::cmp::min(WATCHER_BURST_QUIET, remaining)) {
-                                Ok(event) => {
-                                    if let Err(event) = burst.try_push(event) {
-                                        pending_event = Some(event);
-                                        break;
-                                    }
-                                }
-                                Err(RecvTimeoutError::Timeout) => break,
-                                Err(RecvTimeoutError::Disconnected) => {
-                                    disconnected = true;
-                                    break;
-                                }
-                            }
-                        }
-                        for event in burst.into_paths() {
+                match receive_watcher_burst(&rx, &mut pending_event, WATCHER_RECEIVE_OPTIONS) {
+                    WatcherReceive::Burst {
+                        paths,
+                        disconnected,
+                    } => {
+                        for event in paths {
                             handle_fs_event(&worker_state, &worker_root, &event.into_event());
                         }
                         if disconnected {
@@ -2304,7 +2348,7 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
                     // A fully idle interval proves the queued backlog has
                     // drained. Recover only here so an overflowing burst causes
                     // one stale check, not one after every capped batch.
-                    Err(RecvTimeoutError::Timeout) => {
+                    WatcherReceive::Idle => {
                         recover_watcher_overflow(
                             &worker_state,
                             &worker_root,
@@ -2314,7 +2358,7 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
                         );
                     }
                     // The watcher was dropped, so the server is shutting down.
-                    Err(RecvTimeoutError::Disconnected) => break,
+                    WatcherReceive::Disconnected => break,
                 }
             }
         })
@@ -7121,36 +7165,139 @@ mod tests {
         }
     }
 
+    fn watcher_receive_options(
+        max: Duration,
+        event_cap: usize,
+        path_cap: usize,
+    ) -> WatcherReceiveOptions {
+        WatcherReceiveOptions {
+            idle: Duration::ZERO,
+            quiet: Duration::ZERO,
+            max,
+            event_cap,
+            path_cap,
+        }
+    }
+
     #[test]
-    fn watcher_burst_coalesces_duplicate_paths() {
-        let mut burst = FsEventBurst::new(watcher_event(
+    fn watcher_receiver_coalesces_prequeued_duplicate_paths() {
+        let (tx, rx) = std::sync::mpsc::sync_channel(2);
+        tx.send(watcher_event(
             EventKind::Modify(notify::event::ModifyKind::Any),
             &["src/lib.rs"],
-        ));
-        burst
-            .try_push(watcher_event(
+        ))
+        .unwrap();
+        tx.send(watcher_event(
+            EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )),
+            &["src/lib.rs"],
+        ))
+        .unwrap();
+
+        let mut pending = None;
+        assert_eq!(
+            receive_watcher_burst(
+                &rx,
+                &mut pending,
+                watcher_receive_options(Duration::from_secs(1), 10, 10),
+            ),
+            WatcherReceive::Burst {
+                paths: vec![CoalescedFsEvent {
+                    path: PathBuf::from("src/lib.rs"),
+                    introduces_dir: false,
+                }],
+                disconnected: false,
+            }
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn watcher_receiver_preserves_cap_rejection_for_next_call() {
+        let (tx, rx) = std::sync::mpsc::sync_channel(3);
+        for path in ["a.rs", "b.rs", "c.rs"] {
+            tx.send(watcher_event(
                 EventKind::Modify(notify::event::ModifyKind::Data(
                     notify::event::DataChange::Content,
                 )),
-                &["src/lib.rs"],
+                &[path],
             ))
             .unwrap();
+        }
+        let options = watcher_receive_options(Duration::from_secs(1), 1, 10);
+        let mut pending = None;
 
         assert_eq!(
-            burst.into_paths(),
-            vec![CoalescedFsEvent {
-                path: PathBuf::from("src/lib.rs"),
-                introduces_dir: false,
-            }]
+            receive_watcher_burst(&rx, &mut pending, options),
+            WatcherReceive::Burst {
+                paths: vec![CoalescedFsEvent {
+                    path: PathBuf::from("a.rs"),
+                    introduces_dir: false,
+                }],
+                disconnected: false,
+            }
+        );
+        assert_eq!(pending.as_ref().unwrap().paths, [PathBuf::from("b.rs")]);
+        assert_eq!(
+            receive_watcher_burst(&rx, &mut pending, options),
+            WatcherReceive::Burst {
+                paths: vec![CoalescedFsEvent {
+                    path: PathBuf::from("b.rs"),
+                    introduces_dir: false,
+                }],
+                disconnected: false,
+            }
+        );
+        assert_eq!(pending.as_ref().unwrap().paths, [PathBuf::from("c.rs")]);
+    }
+
+    #[test]
+    fn watcher_receiver_zero_max_leaves_next_event_queued() {
+        let (tx, rx) = std::sync::mpsc::sync_channel(2);
+        for path in ["a.rs", "b.rs"] {
+            tx.send(watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Any),
+                &[path],
+            ))
+            .unwrap();
+        }
+        let options = watcher_receive_options(Duration::ZERO, 10, 10);
+        let mut pending = None;
+
+        assert_eq!(
+            receive_watcher_burst(&rx, &mut pending, options),
+            WatcherReceive::Burst {
+                paths: vec![CoalescedFsEvent {
+                    path: PathBuf::from("a.rs"),
+                    introduces_dir: false,
+                }],
+                disconnected: false,
+            }
+        );
+        assert!(pending.is_none());
+        assert_eq!(
+            receive_watcher_burst(&rx, &mut pending, options),
+            WatcherReceive::Burst {
+                paths: vec![CoalescedFsEvent {
+                    path: PathBuf::from("b.rs"),
+                    introduces_dir: false,
+                }],
+                disconnected: false,
+            }
         );
     }
 
     #[test]
     fn watcher_burst_preserves_distinct_path_order() {
-        let mut burst = FsEventBurst::new(watcher_event(
-            EventKind::Modify(notify::event::ModifyKind::Any),
-            &["src/b.rs", "src/a.rs"],
-        ));
+        let mut burst = FsEventBurst::with_limits(
+            watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Any),
+                &["src/b.rs", "src/a.rs"],
+            ),
+            WATCHER_BURST_EVENT_CAP,
+            WATCHER_BURST_PATH_CAP,
+        );
         burst
             .try_push(watcher_event(
                 EventKind::Create(notify::event::CreateKind::File),
@@ -7174,12 +7321,16 @@ mod tests {
 
     #[test]
     fn watcher_burst_preserves_directory_introduction() {
-        let mut burst = FsEventBurst::new(watcher_event(
-            EventKind::Modify(notify::event::ModifyKind::Data(
-                notify::event::DataChange::Any,
-            )),
-            &["vendor"],
-        ));
+        let mut burst = FsEventBurst::with_limits(
+            watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Any,
+                )),
+                &["vendor"],
+            ),
+            WATCHER_BURST_EVENT_CAP,
+            WATCHER_BURST_PATH_CAP,
+        );
         burst
             .try_push(watcher_event(
                 EventKind::Modify(notify::event::ModifyKind::Name(

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -52,6 +52,14 @@ const WATCHER_QUEUE_CAP: usize = 16_384;
 /// reconciling stale check runs.
 const WATCHER_IDLE_POLL: Duration = Duration::from_secs(1);
 
+/// Native backends commonly report one logical save as several adjacent
+/// notifications. Wait briefly for that burst to settle, but cap both its
+/// duration and size so unrelated sustained traffic keeps making progress.
+const WATCHER_BURST_QUIET: Duration = Duration::from_millis(25);
+const WATCHER_BURST_MAX: Duration = Duration::from_millis(100);
+const WATCHER_BURST_EVENT_CAP: usize = 1024;
+const WATCHER_BURST_PATH_CAP: usize = 4096;
+
 /// Git's index is hidden from the repository watcher. Poll its metadata only
 /// when the case-insensitive tracked-file exemption is active.
 const TRACKED_INDEX_POLL: Duration = Duration::from_secs(2);
@@ -1998,6 +2006,139 @@ fn handle_reload(id: Option<serde_json::Value>, state: &Arc<ServerState>) -> Str
     json_rpc_result(id, serde_json::json!({"status": "reloaded"}))
 }
 
+/// One final-state check for a path in a native notification burst.
+///
+/// `handle_fs_event` only needs to know whether an event kind could introduce
+/// a directory; it classifies removals from the filesystem. Keeping that bit
+/// lets create/rename notifications retain subtree handling while duplicate
+/// writes collapse to one forced read. Paths remain separate because an ignore
+/// rules path returns early from `handle_fs_event`.
+#[derive(Debug, PartialEq, Eq)]
+struct CoalescedFsEvent {
+    path: PathBuf,
+    introduces_dir: bool,
+}
+
+impl CoalescedFsEvent {
+    fn into_event(self) -> Event {
+        let kind = if self.introduces_dir {
+            EventKind::Create(notify::event::CreateKind::Any)
+        } else {
+            EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Any,
+            ))
+        };
+        Event {
+            kind,
+            paths: vec![self.path],
+            attrs: Default::default(),
+        }
+    }
+}
+
+struct FsEventBurst {
+    paths: Vec<CoalescedFsEvent>,
+    path_indices: std::collections::HashMap<PathBuf, usize>,
+    event_count: usize,
+    event_cap: usize,
+    path_cap: usize,
+}
+
+impl FsEventBurst {
+    fn new(first: Event) -> Self {
+        Self::with_limits(first, WATCHER_BURST_EVENT_CAP, WATCHER_BURST_PATH_CAP)
+    }
+
+    fn with_limits(first: Event, event_cap: usize, path_cap: usize) -> Self {
+        let mut burst = Self {
+            paths: Vec::new(),
+            path_indices: std::collections::HashMap::new(),
+            event_count: 0,
+            event_cap,
+            path_cap,
+        };
+        // One native event is indivisible. Accept it even if it alone exceeds
+        // the path cap; later events remain queued for the next bounded burst.
+        burst.push(first);
+        burst
+    }
+
+    fn try_push(&mut self, event: Event) -> Result<(), Event> {
+        if self.event_count >= self.event_cap {
+            return Err(event);
+        }
+
+        let additional_paths = event
+            .paths
+            .iter()
+            .filter(|path| !self.path_indices.contains_key(*path))
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        if self.paths.len().saturating_add(additional_paths) > self.path_cap {
+            return Err(event);
+        }
+
+        self.push(event);
+        Ok(())
+    }
+
+    fn push(&mut self, event: Event) {
+        self.event_count += 1;
+        if !matches!(
+            event.kind,
+            EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+        ) {
+            return;
+        }
+
+        let introduces_dir = event_introduces_dir(&event.kind);
+        for path in event.paths {
+            if let Some(index) = self.path_indices.get(&path).copied() {
+                self.paths[index].introduces_dir |= introduces_dir;
+            } else {
+                let index = self.paths.len();
+                self.path_indices.insert(path.clone(), index);
+                self.paths.push(CoalescedFsEvent {
+                    path,
+                    introduces_dir,
+                });
+            }
+        }
+    }
+
+    fn into_paths(self) -> Vec<CoalescedFsEvent> {
+        self.paths
+    }
+}
+
+fn event_introduces_dir(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Modify(notify::event::ModifyKind::Name(_))
+    )
+}
+
+fn recover_watcher_overflow(
+    state: &Arc<ServerState>,
+    root: &Path,
+    index_dir: &Path,
+    overflowed: &std::sync::atomic::AtomicBool,
+    queue_cap: usize,
+) {
+    if state.indexing.load(Ordering::SeqCst)
+        || state.gitignore_pending.load(Ordering::SeqCst)
+        || !overflowed.swap(false, Ordering::SeqCst)
+    {
+        return;
+    }
+
+    eprintln!("[trace] watcher queue overflowed (cap {queue_cap}); reconciling with a stale check");
+    if !background_refresh_stale(state, root, index_dir, false) {
+        overflowed.store(true, Ordering::SeqCst);
+        thread::sleep(Duration::from_secs(1));
+    }
+}
+
 fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) -> bool {
     use std::sync::mpsc::{RecvTimeoutError, TrySendError};
 
@@ -2104,6 +2245,7 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
         .name("tgrep-watcher".into())
         .spawn(move || {
             let mut last_tracked_index_poll = Instant::now();
+            let mut pending_event = None;
             loop {
                 if last_tracked_index_poll.elapsed() >= TRACKED_INDEX_POLL {
                     last_tracked_index_poll = Instant::now();
@@ -2121,38 +2263,63 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
                         );
                     }
                 }
-                match rx.recv_timeout(WATCHER_IDLE_POLL) {
-                    Ok(event) => handle_fs_event(&worker_state, &worker_root, &event),
-                    // A quiet interval means the burst has drained, so this is
-                    // the point to repair an overflow: reconciling earlier
-                    // would run a full stale check while events are still
-                    // queued behind it, and repeat for each one.
-                    Err(RecvTimeoutError::Timeout) => {
-                        if !overflowed.load(Ordering::SeqCst) {
-                            continue;
+                let received = match pending_event.take() {
+                    Some(event) => Ok(event),
+                    None => rx.recv_timeout(WATCHER_IDLE_POLL),
+                };
+                match received {
+                    Ok(event) => {
+                        let started = Instant::now();
+                        let mut burst = FsEventBurst::new(event);
+                        let mut disconnected = false;
+                        // A quiet gap normally closes a save burst. The hard
+                        // deadline and collection caps ensure continuous or
+                        // high-cardinality traffic is processed in slices.
+                        loop {
+                            let remaining = WATCHER_BURST_MAX.saturating_sub(started.elapsed());
+                            if remaining.is_zero() {
+                                break;
+                            }
+                            match rx.recv_timeout(std::cmp::min(WATCHER_BURST_QUIET, remaining)) {
+                                Ok(event) => {
+                                    if let Err(event) = burst.try_push(event) {
+                                        pending_event = Some(event);
+                                        break;
+                                    }
+                                }
+                                Err(RecvTimeoutError::Timeout) => break,
+                                Err(RecvTimeoutError::Disconnected) => {
+                                    disconnected = true;
+                                    break;
+                                }
+                            }
                         }
-                        // An index build or a pending matcher ends with its own
-                        // stale check, which reconciles the same drift. Leave
-                        // the flag set and let that run instead of racing it.
-                        if worker_state.indexing.load(Ordering::SeqCst)
-                            || worker_state.gitignore_pending.load(Ordering::SeqCst)
-                        {
-                            continue;
+                        for event in burst.into_paths() {
+                            handle_fs_event(&worker_state, &worker_root, &event.into_event());
                         }
-                        overflowed.store(false, Ordering::SeqCst);
-                        eprintln!(
-                            "[trace] watcher queue overflowed (cap {queue_cap}); \
-                             reconciling with a stale check"
-                        );
-                        if !background_refresh_stale(
+                        if disconnected {
+                            break;
+                        }
+                        // Do not require a fully idle second to repair dropped
+                        // events: sustained traffic may never provide one.
+                        recover_watcher_overflow(
                             &worker_state,
                             &worker_root,
                             &worker_index_dir,
-                            false,
-                        ) {
-                            overflowed.store(true, Ordering::SeqCst);
-                            thread::sleep(Duration::from_secs(1));
-                        }
+                            &overflowed,
+                            queue_cap,
+                        );
+                    }
+                    // A fully idle interval is another opportunity to repair
+                    // an overflow left pending by a build or matcher refresh.
+                    Err(RecvTimeoutError::Timeout) => {
+                        recover_watcher_overflow(
+                            &worker_state,
+                            &worker_root,
+                            &worker_index_dir,
+                            &overflowed,
+                            queue_cap,
+                        );
                     }
                     // The watcher was dropped, so the server is shutting down.
                     Err(RecvTimeoutError::Disconnected) => break,
@@ -3543,10 +3710,7 @@ fn defer_events_during_build(state: &ServerState, event: &Event) -> bool {
     }
     // Only these kinds can put a directory somewhere, and only they should
     // trigger a subtree walk on replay. See `ServerState::deferred_events`.
-    let introduces_dir = matches!(
-        event.kind,
-        EventKind::Create(_) | EventKind::Modify(notify::event::ModifyKind::Name(_))
-    );
+    let introduces_dir = event_introduces_dir(&event.kind);
     for path in &event.paths {
         // A path seen both ways keeps the stronger claim: a directory that was
         // created and then chmod'd still needs its subtree picked up.
@@ -3905,10 +4069,7 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
                 // on the single watcher worker, turning a linear operation into
                 // quadratic work. inotify announces a new directory as `Create`
                 // and one moved in as `Modify(Name)`; nothing else can.
-                let introduces_dir = matches!(
-                    event.kind,
-                    EventKind::Create(_) | EventKind::Modify(notify::event::ModifyKind::Name(_))
-                );
+                let introduces_dir = event_introduces_dir(&event.kind);
                 if introduces_dir {
                     // A directory that just appeared can already be full — a
                     // `mv` of a populated tree from outside the root, a
@@ -6959,6 +7120,139 @@ fn ctrlc_handler<F: Fn() + Send + Sync + 'static>(handler: F) {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn watcher_event(kind: EventKind, paths: &[&str]) -> Event {
+        Event {
+            kind,
+            paths: paths.iter().map(PathBuf::from).collect(),
+            attrs: Default::default(),
+        }
+    }
+
+    #[test]
+    fn watcher_burst_coalesces_duplicate_paths() {
+        let mut burst = FsEventBurst::new(watcher_event(
+            EventKind::Modify(notify::event::ModifyKind::Any),
+            &["src/lib.rs"],
+        ));
+        burst
+            .try_push(watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Data(
+                    notify::event::DataChange::Content,
+                )),
+                &["src/lib.rs"],
+            ))
+            .unwrap();
+
+        assert_eq!(
+            burst.into_paths(),
+            vec![CoalescedFsEvent {
+                path: PathBuf::from("src/lib.rs"),
+                introduces_dir: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn watcher_burst_preserves_distinct_path_order() {
+        let mut burst = FsEventBurst::new(watcher_event(
+            EventKind::Modify(notify::event::ModifyKind::Any),
+            &["src/b.rs", "src/a.rs"],
+        ));
+        burst
+            .try_push(watcher_event(
+                EventKind::Create(notify::event::CreateKind::File),
+                &["src/c.rs", "src/a.rs"],
+            ))
+            .unwrap();
+
+        assert_eq!(
+            burst
+                .into_paths()
+                .into_iter()
+                .map(|event| event.path)
+                .collect::<Vec<_>>(),
+            [
+                PathBuf::from("src/b.rs"),
+                PathBuf::from("src/a.rs"),
+                PathBuf::from("src/c.rs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn watcher_burst_preserves_directory_introduction() {
+        let mut burst = FsEventBurst::new(watcher_event(
+            EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Any,
+            )),
+            &["vendor"],
+        ));
+        burst
+            .try_push(watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Name(
+                    notify::event::RenameMode::To,
+                )),
+                &["vendor"],
+            ))
+            .unwrap();
+        burst
+            .try_push(watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Metadata(
+                    notify::event::MetadataKind::Any,
+                )),
+                &["vendor"],
+            ))
+            .unwrap();
+
+        assert_eq!(
+            burst.into_paths(),
+            vec![CoalescedFsEvent {
+                path: PathBuf::from("vendor"),
+                introduces_dir: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn watcher_burst_stops_at_configured_bounds_without_losing_next_event() {
+        let mut event_limited = FsEventBurst::with_limits(
+            watcher_event(EventKind::Modify(notify::event::ModifyKind::Any), &["a.rs"]),
+            2,
+            10,
+        );
+        event_limited
+            .try_push(watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Any),
+                &["b.rs"],
+            ))
+            .unwrap();
+        let rejected = event_limited
+            .try_push(watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Any),
+                &["c.rs"],
+            ))
+            .unwrap_err();
+        assert_eq!(rejected.paths, vec![PathBuf::from("c.rs")]);
+        assert_eq!(event_limited.into_paths().len(), 2);
+
+        let mut path_limited = FsEventBurst::with_limits(
+            watcher_event(EventKind::Modify(notify::event::ModifyKind::Any), &["a.rs"]),
+            10,
+            2,
+        );
+        let rejected = path_limited
+            .try_push(watcher_event(
+                EventKind::Modify(notify::event::ModifyKind::Any),
+                &["b.rs", "c.rs"],
+            ))
+            .unwrap_err();
+        assert_eq!(
+            rejected.paths,
+            [PathBuf::from("b.rs"), PathBuf::from("c.rs")]
+        );
+        assert_eq!(path_limited.into_paths().len(), 1);
+    }
 
     fn cached(len: usize) -> Arc<DecodedFile> {
         // `String::from_utf8` preserves the Vec's capacity, so `heap_bytes`

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2300,18 +2300,10 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
                         if disconnected {
                             break;
                         }
-                        // Do not require a fully idle second to repair dropped
-                        // events: sustained traffic may never provide one.
-                        recover_watcher_overflow(
-                            &worker_state,
-                            &worker_root,
-                            &worker_index_dir,
-                            &overflowed,
-                            queue_cap,
-                        );
                     }
-                    // A fully idle interval is another opportunity to repair
-                    // an overflow left pending by a build or matcher refresh.
+                    // A fully idle interval proves the queued backlog has
+                    // drained. Recover only here so an overflowing burst causes
+                    // one stale check, not one after every capped batch.
                     Err(RecvTimeoutError::Timeout) => {
                         recover_watcher_overflow(
                             &worker_state,

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2148,7 +2148,7 @@ fn receive_watcher_burst(
     pending_event: &mut Option<Event>,
     options: WatcherReceiveOptions,
 ) -> WatcherReceive {
-    let first = match pending_event.take() {
+    let mut first = match pending_event.take() {
         Some(event) => event,
         None => match rx.recv_timeout(options.idle) {
             Ok(event) => event,
@@ -2159,8 +2159,23 @@ fn receive_watcher_burst(
         },
     };
 
+    let path_cap = options.path_cap.max(1);
+    if first.paths.len() > path_cap {
+        let remainder_paths = first.paths.split_off(path_cap);
+        *pending_event = Some(Event {
+            kind: first.kind,
+            paths: remainder_paths,
+            attrs: first.attrs.clone(),
+        });
+        let burst = FsEventBurst::with_limits(first, options.event_cap, path_cap);
+        return WatcherReceive::Burst {
+            paths: burst.into_paths(),
+            disconnected: false,
+        };
+    }
+
     let started = Instant::now();
-    let mut burst = FsEventBurst::with_limits(first, options.event_cap, options.path_cap);
+    let mut burst = FsEventBurst::with_limits(first, options.event_cap, path_cap);
     let mut disconnected = false;
     loop {
         let remaining = options.max.saturating_sub(started.elapsed());
@@ -7250,6 +7265,43 @@ mod tests {
             }
         );
         assert_eq!(pending.as_ref().unwrap().paths, [PathBuf::from("c.rs")]);
+    }
+
+    #[test]
+    fn watcher_receiver_splits_oversized_first_event_without_path_loss() {
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        tx.send(watcher_event(
+            EventKind::Modify(notify::event::ModifyKind::Any),
+            &["a.rs", "b.rs", "c.rs", "d.rs", "e.rs"],
+        ))
+        .unwrap();
+        let options = watcher_receive_options(Duration::from_secs(1), 10, 2);
+        let mut pending = None;
+        let mut all_paths = Vec::new();
+
+        for expected in [
+            vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")],
+            vec![PathBuf::from("c.rs"), PathBuf::from("d.rs")],
+            vec![PathBuf::from("e.rs")],
+        ] {
+            let WatcherReceive::Burst { paths, .. } =
+                receive_watcher_burst(&rx, &mut pending, options)
+            else {
+                panic!("expected a burst");
+            };
+            let actual = paths
+                .into_iter()
+                .map(|event| event.path)
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected);
+            all_paths.extend(actual);
+        }
+
+        assert_eq!(
+            all_paths,
+            ["a.rs", "b.rs", "c.rs", "d.rs", "e.rs"].map(PathBuf::from)
+        );
+        assert!(pending.is_none());
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -33,6 +33,24 @@ const CACHE_MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GiB
 /// evict most of the cache to store itself, so it is read straight through
 /// instead. It is still searched - only the caching is skipped.
 const CACHE_MAX_ENTRY_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
+/// Paths that keep the exact bytes of their most recent live-overlay commit.
+///
+/// The evidence only has to outlive one editor save: a duplicate arrives
+/// milliseconds later, from the second notification for the same write. A few
+/// thousand paths covers a build or a branch switch touching many files at once
+/// while staying far smaller than the content cache's 50,000 entries, whose job
+/// is to serve queries rather than to compare one recent write.
+const RECENT_REINDEX_CAPACITY: usize = 4096;
+/// Total raw bytes the evidence cache may hold. Entry count alone bounds
+/// nothing: 4096 large sources would be gigabytes of retained `Vec<u8>`. This
+/// matches the largest single entry so one big file can use the whole budget,
+/// and the LRU gives it back as soon as other paths are written.
+const RECENT_REINDEX_MAX_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
+/// Largest single file whose bytes are retained, mirroring
+/// `CACHE_MAX_ENTRY_BYTES`. Anything larger is simply never suppressed: a
+/// duplicate save of a 64 MiB file re-commits, which is correct but slower, and
+/// is the right trade against pinning that much heap for one path.
+const RECENT_REINDEX_MAX_ENTRY_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
 /// Default mutation count that triggers a background save (override with
 /// `--auto-save-mutations`).
 const AUTO_SAVE_MUTATIONS: u32 = 5000;
@@ -158,6 +176,12 @@ fn try_acquire_server_lock(index_dir: &Path) -> Result<File> {
 ///   5. `filename_extra_paths` — guards paths omitted from the content index
 ///   6. `cache`         — guards the file content LRU cache
 ///   7. `file_stamps`   — guards per-file mtime/size stamps
+///   8. `recent_reindexes` — guards exact duplicate evidence
+///
+/// `recent_reindexes` is a leaf: it is taken last and, in practice, never held
+/// across another acquisition. `reindex_file` copies the candidate ID out from
+/// under it before touching `index`, and records new evidence only after every
+/// index, filename, cache and stamp lock has been released.
 ///
 /// `indexing` and `flushing` coordinate the handoff between bulk indexing and
 /// final flush with the auto-save loop; use sequentially consistent accesses
@@ -276,6 +300,92 @@ impl ContentCache {
     }
 }
 
+struct RecentReindex {
+    overlay_id: u32,
+    bytes: Vec<u8>,
+}
+
+/// Exact bytes that produced recent live-overlay entries.
+///
+/// This is evidence only when its overlay ID is still active for the path.
+/// Overlay IDs count up from zero within one `LiveIndex`, so they are unique
+/// for the life of that overlay — but replacing the whole `HybridIndex` starts
+/// a fresh one, and every record must be dropped with it (see
+/// [`forget_recent_reindexes`]).
+///
+/// Callers must release this lock before taking `index`, `cache`, or
+/// `file_stamps`; candidate lookup returns only the recorded ID for that reason.
+struct RecentReindexCache {
+    lru: LruCache<String, RecentReindex>,
+    bytes: u64,
+    max_bytes: u64,
+    max_entry_bytes: u64,
+}
+
+impl RecentReindexCache {
+    fn new(capacity: usize, max_bytes: u64, max_entry_bytes: u64) -> Self {
+        Self {
+            lru: LruCache::new(NonZeroUsize::new(capacity).unwrap()),
+            bytes: 0,
+            max_bytes,
+            max_entry_bytes,
+        }
+    }
+
+    fn matching_overlay_id(&mut self, key: &str, bytes: &[u8]) -> Option<u32> {
+        self.lru
+            .get(key)
+            .filter(|record| record.bytes == bytes)
+            .map(|record| record.overlay_id)
+    }
+
+    fn put(&mut self, key: String, overlay_id: u32, bytes: Vec<u8>) {
+        // Remove first even when the replacement is too large. Retaining the
+        // old bytes could suppress a later event against stale evidence.
+        self.pop(&key);
+        let size = bytes.len() as u64;
+        if size > self.max_entry_bytes || size > self.max_bytes {
+            return;
+        }
+        if let Some((_, evicted)) = self.lru.push(key, RecentReindex { overlay_id, bytes }) {
+            self.bytes = self.bytes.saturating_sub(evicted.bytes.len() as u64);
+        }
+        self.bytes = self.bytes.saturating_add(size);
+        while self.bytes > self.max_bytes {
+            match self.lru.pop_lru() {
+                Some((_, evicted)) => {
+                    self.bytes = self.bytes.saturating_sub(evicted.bytes.len() as u64);
+                }
+                None => {
+                    self.bytes = 0;
+                    break;
+                }
+            }
+        }
+    }
+
+    fn pop(&mut self, key: &str) {
+        if let Some(old) = self.lru.pop(key) {
+            self.bytes = self.bytes.saturating_sub(old.bytes.len() as u64);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.lru.clear();
+        self.bytes = 0;
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.lru.len()
+    }
+
+    #[cfg(test)]
+    fn byte_len(&self) -> u64 {
+        self.bytes
+    }
+}
+
 struct ServerState {
     index: RwLock<HybridIndex>,
     /// Paths admitted by traversal but deliberately absent from the content
@@ -290,6 +400,7 @@ struct ServerState {
     filename_index_dirty: std::sync::atomic::AtomicBool,
     cache: RwLock<ContentCache>,
     cache_generation: std::sync::atomic::AtomicU64,
+    recent_reindexes: Mutex<RecentReindexCache>,
     root: PathBuf,
     watcher_active: std::sync::atomic::AtomicBool,
     /// True while the initial index build is in progress.
@@ -697,6 +808,11 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
             CACHE_MAX_ENTRY_BYTES,
         )),
         cache_generation: std::sync::atomic::AtomicU64::new(0),
+        recent_reindexes: Mutex::new(RecentReindexCache::new(
+            RECENT_REINDEX_CAPACITY,
+            RECENT_REINDEX_MAX_BYTES,
+            RECENT_REINDEX_MAX_ENTRY_BYTES,
+        )),
         root: root.clone(),
         watcher_active: std::sync::atomic::AtomicBool::new(false),
         indexing: std::sync::atomic::AtomicBool::new(needs_build),
@@ -4170,6 +4286,18 @@ fn lock_reindex(state: &ServerState) -> std::sync::MutexGuard<'_, ()> {
     }
 }
 
+/// Discard every exact-bytes record because the overlay they refer to is gone.
+///
+/// Overlay IDs are unique only within one `LiveIndex`. Replacing the whole
+/// `HybridIndex` installs a fresh overlay whose IDs restart at zero, so a
+/// surviving record could later be revalidated against an unrelated entry that
+/// happens to have been given the same number. Call this under the same index
+/// write lock as the replacement — the lock order allows taking this leaf lock
+/// while `index` is held, never the reverse.
+fn forget_recent_reindexes(state: &ServerState) {
+    state.recent_reindexes.lock().unwrap().clear();
+}
+
 /// Drop everything the content and filename indexes hold for a path.
 ///
 /// A stamp is evidence, but not a precondition: `filestamps.json` may be missing
@@ -4181,6 +4309,11 @@ fn lock_reindex(state: &ServerState) -> std::sync::MutexGuard<'_, ()> {
 /// the caller's rather than this function's because `reindex_file` calls in
 /// while holding it, and a `Mutex` is not reentrant.
 fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
+    // Before any early return below: a path leaving the content index must not
+    // leave bytes behind that a later save could match, and the no-op returns
+    // (already tombstoned, never indexed) are exactly the states where an old
+    // record would otherwise sit unrefreshed.
+    state.recent_reindexes.lock().unwrap().pop(rel_path);
     let removed_extra = state.filename_extra_paths.write().unwrap().remove(rel_path);
     if removed_extra {
         state.filename_index_dirty.store(true, Ordering::SeqCst);
@@ -4213,6 +4346,9 @@ fn drop_indexed_file(state: &ServerState, rel_path: &str, reason: &str) {
 /// an already-known filename-only path must still evict content if stale
 /// postings are active for it.
 fn mark_filename_only(state: &ServerState, rel_path: &str) {
+    // As in `drop_indexed_file`, including the path that was already
+    // filename-only and changes nothing else.
+    state.recent_reindexes.lock().unwrap().pop(rel_path);
     let (inserted, removed_content) = {
         let mut index = state.index.write().unwrap();
         let mut extra = state.filename_extra_paths.write().unwrap();
@@ -4810,20 +4946,44 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
         }
     }
 
-    eprintln!("[trace] reindex: modified {rel_path}");
     let Some(per_tri) = per_tri else {
+        eprintln!("[trace] reindex: modified {rel_path}");
         mark_filename_only(state, rel_path);
         return;
     };
+
+    // Exact bytes are only a candidate here. The evidence lock is deliberately
+    // released before taking the index/cache locks; the overlay ID is then
+    // revalidated under the index write lock below.
+    let duplicate_overlay_id = state
+        .recent_reindexes
+        .lock()
+        .unwrap()
+        .matching_overlay_id(rel_path, &data);
+
     // Gate held by the caller — the commit + stamp update is processed
     // atomically with respect to flush/auto-save.
-    let removed_extra = {
+    let (removed_extra, committed_overlay_id) = {
         let mut index = state.index.write().unwrap();
         let mut extra = state.filename_extra_paths.write().unwrap();
-        index.live.commit_upsert(rel_path, per_tri);
+        let duplicate = duplicate_overlay_id
+            .is_some_and(|overlay_id| index.live.file_id_for_path(rel_path) == Some(overlay_id));
+        let committed_overlay_id = if duplicate {
+            None
+        } else {
+            index.live.commit_upsert(rel_path, per_tri);
+            Some(
+                index
+                    .live
+                    .file_id_for_path(rel_path)
+                    .expect("a committed overlay entry must have an ID"),
+            )
+        };
         let removed = extra.remove(rel_path);
+        // Even an exact duplicate may race a search that cached temporary
+        // bytes between our two verification reads. Always invalidate it.
         invalidate_cached_paths_locked(state, std::iter::once(rel_path));
-        removed
+        (removed, committed_overlay_id)
     };
     if removed_extra {
         state.filename_index_dirty.store(true, Ordering::SeqCst);
@@ -4833,6 +4993,14 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
         .write()
         .unwrap()
         .insert(rel_path.to_string(), current);
+    if let Some(overlay_id) = committed_overlay_id {
+        eprintln!("[trace] reindex: modified {rel_path}");
+        state
+            .recent_reindexes
+            .lock()
+            .unwrap()
+            .put(rel_path.to_string(), overlay_id, data);
+    }
 }
 
 fn retry_failed_forced_reindex(state: &Arc<ServerState>, rel_path: &str, reason: &str) {
@@ -5861,6 +6029,7 @@ fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
             let mut extra = state.filename_extra_paths.write().unwrap();
             let mut cache = state.cache.write().unwrap();
             *index = empty;
+            forget_recent_reindexes(state);
             extra.clear();
             state.filename_index_ready.store(false, Ordering::SeqCst);
             state.filename_index_dirty.store(false, Ordering::SeqCst);
@@ -5972,6 +6141,7 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         let mut extra = state.filename_extra_paths.write().unwrap();
         let mut cache = state.cache.write().unwrap();
         *index = opened;
+        forget_recent_reindexes(state);
         if let Some(paths) = filename_extra_paths {
             *extra = paths;
             state.filename_index_ready.store(true, Ordering::SeqCst);
@@ -7523,6 +7693,40 @@ mod tests {
         assert!(cache.peek("b").is_none());
     }
 
+    #[test]
+    fn recent_reindex_cache_bounds_bytes_capacity_and_oversized_replacements() {
+        let mut cache = RecentReindexCache::new(2, 6, 4);
+        cache.put("a".into(), 1, vec![b'a'; 3]);
+        cache.put("b".into(), 2, vec![b'b'; 3]);
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.byte_len(), 6);
+
+        cache.put("c".into(), 3, vec![b'c'; 3]);
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.byte_len(), 6);
+        assert_eq!(cache.matching_overlay_id("a", b"aaa"), None);
+
+        cache.put("b".into(), 4, vec![b'x'; 5]);
+        assert_eq!(
+            cache.len(),
+            1,
+            "oversized replacement retained old evidence"
+        );
+        assert_eq!(cache.byte_len(), 3);
+        assert_eq!(cache.matching_overlay_id("b", b"bbb"), None);
+
+        let mut byte_limited = RecentReindexCache::new(3, 5, 4);
+        byte_limited.put("a".into(), 1, vec![b'a'; 3]);
+        byte_limited.put("b".into(), 2, vec![b'b'; 3]);
+        assert_eq!(byte_limited.len(), 1);
+        assert_eq!(byte_limited.byte_len(), 3);
+        assert_eq!(byte_limited.matching_overlay_id("a", b"aaa"), None);
+
+        byte_limited.clear();
+        assert_eq!(byte_limited.len(), 0);
+        assert_eq!(byte_limited.byte_len(), 0);
+    }
+
     /// A `ServerState` over an empty index, for exercising the stale path
     /// directly. Mirrors the defaults `run` uses with a watcher and ignore
     /// rules enabled, which is the configuration `gitignore_pending` gates.
@@ -7540,6 +7744,11 @@ mod tests {
                 CACHE_MAX_ENTRY_BYTES,
             )),
             cache_generation: std::sync::atomic::AtomicU64::new(0),
+            recent_reindexes: Mutex::new(RecentReindexCache::new(
+                RECENT_REINDEX_CAPACITY,
+                RECENT_REINDEX_MAX_BYTES,
+                RECENT_REINDEX_MAX_ENTRY_BYTES,
+            )),
             root: root.to_path_buf(),
             watcher_active: std::sync::atomic::AtomicBool::new(false),
             indexing: std::sync::atomic::AtomicBool::new(false),
@@ -9254,6 +9463,13 @@ mod tests {
             let _gate = state.snapshot_gate.read().unwrap();
             reindex_file(&state, &path, "same.rs", false);
         }
+        let (old_id, old_dirty) = {
+            let index = state.index.read().unwrap();
+            (
+                index.live.file_id_for_path("same.rs").unwrap(),
+                index.live.dirty_count(),
+            )
+        };
         std::fs::write(&path, "fn new_marker() {}\n").unwrap();
         let current = tgrep_core::meta::collect_filestamps(&root, &["same.rs".to_string()])
             .remove("same.rs")
@@ -9292,6 +9508,198 @@ mod tests {
             repaired.contains("\"content\":\"fn new_marker"),
             "a concrete event must bypass the coarse matching stamp: {repaired}"
         );
+        let index = state.index.read().unwrap();
+        assert_ne!(index.live.file_id_for_path("same.rs"), Some(old_id));
+        assert_eq!(index.live.dirty_count(), old_dirty + 1);
+    }
+
+    #[test]
+    fn separate_forced_events_suppress_only_exact_current_overlay_duplicate() {
+        let tmp = TempDir::new().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let path = root.join("same.rs");
+        std::fs::write(&path, "fn unchanged_marker() {}\n").unwrap();
+        let state = test_server_state(&root, &root.join(".tgrep"));
+
+        {
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_file(&state, &path, "same.rs", true);
+        }
+        let (first_id, first_dirty) = {
+            let index = state.index.read().unwrap();
+            (
+                index.live.file_id_for_path("same.rs").unwrap(),
+                index.live.dirty_count(),
+            )
+        };
+        state
+            .cache
+            .write()
+            .unwrap()
+            .put("same.rs".to_string(), cached(32));
+        let generation = state.cache_generation.load(Ordering::SeqCst);
+        state.file_stamps.write().unwrap().insert(
+            "same.rs".to_string(),
+            tgrep_core::meta::FileStamp {
+                mtime: u64::MAX,
+                size: u64::MAX,
+            },
+        );
+
+        {
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_file(&state, &path, "same.rs", true);
+        }
+
+        let index = state.index.read().unwrap();
+        assert_eq!(index.live.file_id_for_path("same.rs"), Some(first_id));
+        assert_eq!(index.live.dirty_count(), first_dirty);
+        drop(index);
+        assert!(state.cache.read().unwrap().peek("same.rs").is_none());
+        assert!(state.cache_generation.load(Ordering::SeqCst) > generation);
+        assert_ne!(
+            state.file_stamps.read().unwrap().get("same.rs"),
+            Some(&tgrep_core::meta::FileStamp {
+                mtime: u64::MAX,
+                size: u64::MAX,
+            }),
+            "the successful duplicate read must replace a retry sentinel"
+        );
+    }
+
+    #[test]
+    fn exact_reindex_evidence_does_not_suppress_a_to_b_to_a() {
+        let tmp = TempDir::new().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let path = root.join("cycle.rs");
+        let state = test_server_state(&root, &root.join(".tgrep"));
+        let mut ids = Vec::new();
+
+        for (content, force) in [
+            ("fn exact_a_marker() {}\n", false),
+            ("fn exact_b_marker() {}\n", true),
+            ("fn exact_a_marker() {}\n", true),
+        ] {
+            std::fs::write(&path, content).unwrap();
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_file(&state, &path, "cycle.rs", force);
+            ids.push(
+                state
+                    .index
+                    .read()
+                    .unwrap()
+                    .live
+                    .file_id_for_path("cycle.rs")
+                    .unwrap(),
+            );
+        }
+
+        assert!(ids.windows(2).all(|pair| pair[0] != pair[1]));
+        assert_eq!(state.index.read().unwrap().live.dirty_count(), 3);
+        let result = handle_search(
+            None,
+            &serde_json::json!({"pattern": "exact_a_marker"}),
+            &state,
+        );
+        assert!(result.contains("\"content\":\"fn exact_a_marker"));
+        let old = handle_search(
+            None,
+            &serde_json::json!({"pattern": "exact_b_marker"}),
+            &state,
+        );
+        assert!(!old.contains("\"content\":\"fn exact_b_marker"));
+    }
+
+    #[test]
+    fn overlay_id_mismatch_prevents_exact_byte_suppression() {
+        let tmp = TempDir::new().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let path = root.join("token.rs");
+        let bytes = b"fn token_marker() {}\n";
+        std::fs::write(&path, bytes).unwrap();
+        let state = test_server_state(&root, &root.join(".tgrep"));
+
+        {
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_file(&state, &path, "token.rs", false);
+        }
+        let first_id = state
+            .index
+            .read()
+            .unwrap()
+            .live
+            .file_id_for_path("token.rs")
+            .unwrap();
+        let replaced_id = {
+            let mut index = state.index.write().unwrap();
+            index.live.upsert_file("token.rs", bytes);
+            index.live.file_id_for_path("token.rs").unwrap()
+        };
+        assert_ne!(first_id, replaced_id);
+        let dirty_before = state.index.read().unwrap().live.dirty_count();
+
+        {
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_file(&state, &path, "token.rs", true);
+        }
+        let index = state.index.read().unwrap();
+        assert_ne!(index.live.file_id_for_path("token.rs"), Some(replaced_id));
+        assert_eq!(index.live.dirty_count(), dirty_before + 1);
+    }
+
+    /// Overlay IDs restart at zero in a replacement index, so evidence that
+    /// outlived the overlay it was recorded against could be revalidated
+    /// against an unrelated entry holding a recycled ID.
+    #[test]
+    fn replacing_the_whole_index_forgets_exact_byte_evidence() {
+        let tmp = TempDir::new().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let path = root.join("recycled.rs");
+        let bytes = b"fn recycled_marker() {}\n";
+        std::fs::write(&path, bytes).unwrap();
+        let index_dir = root.join(".tgrep");
+        let state = test_server_state(&root, &index_dir);
+
+        {
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_file(&state, &path, "recycled.rs", false);
+        }
+        let first_id = state
+            .index
+            .read()
+            .unwrap()
+            .live
+            .file_id_for_path("recycled.rs")
+            .unwrap();
+        assert_eq!(
+            state
+                .recent_reindexes
+                .lock()
+                .unwrap()
+                .matching_overlay_id("recycled.rs", bytes),
+            Some(first_id)
+        );
+
+        reset_to_empty_index(&state, &root, &index_dir);
+        assert_eq!(state.recent_reindexes.lock().unwrap().len(), 0);
+
+        // The fresh overlay hands out the same first ID, and the file still has
+        // the recorded bytes: without the reset this is exactly the pair that
+        // would suppress a real commit.
+        {
+            let _gate = state.snapshot_gate.read().unwrap();
+            reindex_file(&state, &path, "recycled.rs", true);
+        }
+        let index = state.index.read().unwrap();
+        assert_eq!(index.live.file_id_for_path("recycled.rs"), Some(first_id));
+        assert_eq!(index.live.dirty_count(), 1);
+        drop(index);
+        let found = handle_search(
+            None,
+            &serde_json::json!({"pattern": "recycled_marker"}),
+            &state,
+        );
+        assert!(found.contains("\"content\":\"fn recycled_marker"));
     }
 
     #[test]

--- a/tgrep-core/src/live.rs
+++ b/tgrep-core/src/live.rs
@@ -196,6 +196,15 @@ impl LiveIndex {
         self.path_to_id.contains_key(path)
     }
 
+    /// Active live-overlay file ID for `path`.
+    ///
+    /// IDs change on every upsert and disappear when an entry is pruned, so
+    /// callers can use one as a lifetime token for facts derived from that
+    /// exact overlay entry.
+    pub fn file_id_for_path(&self, path: &str) -> Option<u32> {
+        self.path_to_id.get(path).copied()
+    }
+
     /// Whether the live overlay contains a path strictly below `directory`.
     pub fn has_descendant_path(&self, directory: &str) -> bool {
         if directory.is_empty() {


### PR DESCRIPTION
## Summary

- collect adjacent native watcher notifications into a 25 ms quiet-window burst with a 100 ms hard deadline
- deduplicate by path in first-seen order while retaining whether any event could introduce a directory
- emit one synthetic event per path so final filesystem classification still handles removals and forced reads still catch same-size/same-timestamp rewrites
- cap each burst at 1,024 events and 4,096 paths; split an oversized individual event into ordered pending chunks and carry any cap-rejected event into the next batch
- preserve idle-only queue-overflow recovery so a queued backlog triggers one stale reconcile after draining rather than one per capped batch
- suppress the remaining cross-burst duplicate: a save whose second notification lands after the burst closes no longer re-commits the identical bytes or logs a second `reindex: modified`

## Cross-burst duplicate suppression

Time-based coalescing cannot help when the two notifications for one save are separated by more than the burst window, which is what a Substrate repository save of `CertificateUtil.cs` showed. Every concrete watcher event still forces a reindex on purpose, because that is what catches a same-size, same-coarse-timestamp rewrite, so the second event repeats the full overlay remove/reinsert and the log line.

The fix suppresses only a provable no-op, and never weakens the forced read:

- `RecentReindexCache` (`tgrep-cli/src/serve.rs`) keeps, per normalized rel path, the exact raw `Vec<u8>` of the last successful commit together with the live-overlay ID that commit produced. It is bounded three ways — 4,096 entries, 64 MiB total, 64 MiB per entry — with exact byte accounting across replacement, LRU count eviction, byte-budget eviction, explicit pop and clear. A replacement that cannot be admitted still evicts the previous record for that key, so oversized writes can never leave stale bytes behind.
- `LiveIndex::file_id_for_path` (`tgrep-core/src/live.rs`) is the only new core API: a read of the active overlay ID. IDs are minted per upsert, so any direct or bulk upsert, delete/recreate, prune, reconcile or later commit invalidates a record automatically. No trigram-map comparator is involved. Replacing the whole `HybridIndex` restarts the ID space, so both replacement sites clear the cache under the index write lock.
- `reindex_file` is unchanged through open, containment-safe fresh read, decode, trigram computation and the final `file_still_has_bytes` byte/version verification. Only after all of that does it look up a candidate, copying the recorded ID out from under the evidence lock. Under the index write lock it revalidates that ID against `index.live.file_id_for_path(rel_path)`. `commit_upsert` and the `reindex: modified` line are skipped only when the bytes are exactly equal **and** the ID still matches.
- A skip is not a no-op elsewhere: the filename-only marker is still removed (and the sidecar marked dirty if it was), the decoded content cache is invalidated and its generation advanced unconditionally (an A → temporary B search → A sequence can leave B cached), and the read-bound `FileStamp` is written, replacing any retry sentinel. Real commits record fresh evidence after every index, filename, cache and stamp lock is released; drops and filename-only transitions forget it, including on their no-op early returns.
- Lock order is documented: `recent_reindexes` is a leaf, taken last and never held while acquiring `index`, `filename_extra_paths`, `cache` or `file_stamps`.

Nothing trusts `FileVersion`, `FileStamp`, a hash, decoded text or the trigram representation as content identity, and `force=false` is never substituted. Different bytes of the same length, with a manually matched coarse stamp, still commit and become searchable.

## Tests

- deterministic production-path receiver coverage for prequeued duplicate collapse, cap-rejected pending rollover, oversized-event ordered chunking without path loss, and zero-max-duration queue preservation
- unit coverage for distinct path ordering, directory-introduction preservation, and event/path caps
- `separate_forced_events_suppress_only_exact_current_overlay_duplicate`: two separate forced reindexes of unchanged bytes preserve the overlay ID and dirty count, while a deliberately stale `DecodedFile` planted in the content cache is evicted with a generation bump and a `{u64::MAX, u64::MAX}` stamp sentinel is replaced by the real stamp
- `concrete_event_reindexes_equal_length_rewrite_with_matching_stamp`: strengthened to assert a new overlay ID and an incremented dirty count for equal-length different bytes under a matching persisted stamp
- `exact_reindex_evidence_does_not_suppress_a_to_b_to_a`: three distinct overlay IDs, three dirty increments, and only the final content searchable
- `overlay_id_mismatch_prevents_exact_byte_suppression`: a direct `live.upsert_file` after the record is written makes the next forced reindex commit rather than trust the stale ID
- `replacing_the_whole_index_forgets_exact_byte_evidence`: after an index replacement recycles the first overlay ID, the same bytes still commit
- `recent_reindex_cache_bounds_bytes_capacity_and_oversized_replacements`: capacity eviction, byte-budget eviction and an unadmitted oversized replacement all leave exact accounting and no usable stale record
- mutation controls: removing the duplicate-path merge produced two outputs; dropping a cap-rejected pending event failed next-invocation ordering; disabling oversized-event splitting returned all paths in the first burst; forcing the exact-match skip to `false` failed the cross-burst test with `left: Some(2147483649)` vs `right: Some(2147483648)`, i.e. a second overlay entry was created — restored and re-run green
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
