### PR TITLE
Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,12 @@ cd tgrep
 cargo install --path tgrep-cli --locked
 ```
 
+### Homebrew (Linux, macOS)
+
+```bash
+brew install tgrep
+```
+
 ### Pre-built binaries
 
 Download from [GitHub Releases](https://github.com/microsoft/tgrep/releases)


### PR DESCRIPTION
tgrep is now [available](https://github.com/Homebrew/homebrew-core/commit/c88969ee64e7281c4008a1e0ff24ae2299fcfcc4) to install via [Homebrew](https://brew.sh).