### PR TITLE
Stop rejecting .svg and .raw by extension

### DIFF
--- a/tgrep-cli/tests/ripgrep_parity.rs
+++ b/tgrep-cli/tests/ripgrep_parity.rs
@@ -705,6 +705,79 @@ fn binary_flag_includes_extension_rejected_files() {
     );
 }
 
+// Extension is not a binary signal on its own. Verified against rg 15.2.0 in a
+// directory holding drawing.svg (XML), notes.raw (text) and photo.raw (NUL at
+// offset 6):
+//   rg needle .        -> drawing.svg and notes.raw match, photo.raw is silent
+//   rg -t svg needle . -> drawing.svg matches
+#[test]
+fn svg_and_raw_are_classified_by_content_on_both_search_paths() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("drawing.svg"),
+        "<svg><text>needle</text></svg>\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("notes.raw"), "needle in plain text\n").unwrap();
+    fs::write(
+        dir.path().join("photo.raw"),
+        b"needle\x00\x01binary\n".as_slice(),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("image.png"),
+        "needle behind a binary extension\n",
+    )
+    .unwrap();
+
+    let idx = dir.path().join("idx").to_str().unwrap().to_string();
+    tgrep()
+        .args(["index", dir.path().to_str().unwrap(), "--index-path", &idx])
+        .assert()
+        .success();
+
+    let run = |mode: &[&str]| -> String {
+        let mut args: Vec<&str> = mode.to_vec();
+        args.extend_from_slice(&["--no-heading", "needle", "."]);
+        stdout_of(tgrep().current_dir(dir.path()).args(&args))
+    };
+
+    for (path, out) in [
+        ("brute force", run(&["--no-index"])),
+        ("index", run(&["--index-path", &idx])),
+    ] {
+        assert!(
+            out.contains("drawing.svg"),
+            "{path}: an SVG is XML and must be searched: {out:?}"
+        );
+        assert!(
+            out.contains("notes.raw"),
+            "{path}: text in a .raw file must be searched: {out:?}"
+        );
+        assert!(
+            !out.contains("photo.raw"),
+            "{path}: content detection must still hide a binary .raw: {out:?}"
+        );
+        assert!(
+            !out.contains("image.png"),
+            "{path}: extensions still on the list must stay rejected: {out:?}"
+        );
+    }
+
+    let typed = stdout_of(tgrep().current_dir(dir.path()).args([
+        "--no-index",
+        "--no-heading",
+        "-t",
+        "svg",
+        "needle",
+        ".",
+    ]));
+    assert!(
+        typed.contains("drawing.svg"),
+        "the builtin svg type must be able to match: {typed:?}"
+    );
+}
+
 #[test]
 fn indexed_and_brute_force_agree_on_binary_visibility() {
     let dir = binary_fixture();

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -44,12 +44,12 @@ pub const DEFAULT_MAX_FILE_SIZE: Option<u64> = Some(64 * 1024 * 1024);
 
 /// Binary extensions that can be rejected without reading file content.
 const BINARY_EXTENSIONS: &[&str] = &[
-    "png", "jpg", "jpeg", "gif", "bmp", "ico", "webp", "svg", "tiff", "tif", "psd", "raw", "mp3",
-    "mp4", "avi", "mkv", "mov", "wav", "flac", "ogg", "wma", "aac", "m4a", "webm", "zip", "tar",
-    "gz", "bz2", "xz", "zst", "7z", "rar", "lz4", "lzma", "cab", "exe", "dll", "so", "dylib",
-    "obj", "o", "a", "lib", "pdb", "wasm", "class", "jar", "pyc", "pyo", "beam", "pdf", "doc",
-    "docx", "xls", "xlsx", "ppt", "pptx", "ttf", "otf", "woff", "woff2", "eot", "bin", "dat", "db",
-    "sqlite", "sqlite3",
+    "png", "jpg", "jpeg", "gif", "bmp", "ico", "webp", "tiff", "tif", "psd", "mp3", "mp4", "avi",
+    "mkv", "mov", "wav", "flac", "ogg", "wma", "aac", "m4a", "webm", "zip", "tar", "gz", "bz2",
+    "xz", "zst", "7z", "rar", "lz4", "lzma", "cab", "exe", "dll", "so", "dylib", "obj", "o", "a",
+    "lib", "pdb", "wasm", "class", "jar", "pyc", "pyo", "beam", "pdf", "doc", "docx", "xls",
+    "xlsx", "ppt", "pptx", "ttf", "otf", "woff", "woff2", "eot", "bin", "dat", "db", "sqlite",
+    "sqlite3",
 ];
 
 /// Number of parallel walker threads (capped at 12 to avoid diminishing returns).


### PR DESCRIPTION
The walk rejects a list of binary extensions before reading file contents.
`filetypes.rs` defines `svg` as a builtin file type, so `tgrep -t svg needle .`
cannot match while `rg -t svg needle .` does. This removes `.svg` and `.raw`
from that list. The other 65 entries are still rejected on traversal.

`svg_and_raw_are_classified_by_content_on_both_search_paths` in
`tgrep-cli/tests/ripgrep_parity.rs` pins this on the indexed and brute-force
paths, and includes a `.raw` fixture containing a NUL that stays invisible on
traversal. Behaviour was compared against rg 15.2.0.
