### PR TITLE
Bump version to 1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Trigram-indexed grep with a client/server architecture for fast regex search
 in large codebases.
 
+**tgrep is integrated into [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+to power fast grep searches across large repositories.**
+
 ## Why?
 
 Tools like `grep` and `ripgrep` scan every file on every search — O(total bytes)

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -24,6 +24,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +69,21 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -81,6 +115,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -326,10 +369,14 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.1"
+version = "1.0.4"
 dependencies = [
  "anyhow",
+ "blake3",
+ "encoding_rs",
+ "globset",
  "ignore",
+ "memchr",
  "memmap2",
  "rayon",
  "regex",


### PR DESCRIPTION
## Summary
- bump `tgrep-cli` and `tgrep-core` to version 1.0.4
- refresh the workspace and fuzz lockfiles
- highlight the GitHub Copilot CLI integration for large-repository grep searches

## Validation
- `cargo check --workspace`
- `cargo check --manifest-path fuzz\Cargo.toml`
- `cargo fmt --all -- --check`