### PR TITLE
Refactor duplicated search and index logic

### DIFF
--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -161,6 +161,30 @@ impl SortMode {
             paths.reverse();
         }
     }
+
+    /// Sort index-backed entries by search-relative paths, looking up metadata
+    /// at their actual locations. `PathBuf` keeps ordering component-wise, as
+    /// in the filesystem walk, rather than comparing raw path strings.
+    fn apply_indexed<T>(
+        &self,
+        entries: &mut [T],
+        index_root: &Path,
+        scope: &IndexScope,
+        relative_path: impl Fn(&T) -> &str,
+    ) {
+        entries.sort_by_cached_key(|entry| {
+            let rel = relative_path(entry);
+            let time = if self.key == SortKey::Path {
+                None
+            } else {
+                time_key(&scope.full_path(index_root, rel), self.key)
+            };
+            (time, PathBuf::from(rel))
+        });
+        if self.reverse {
+            entries.reverse();
+        }
+    }
 }
 
 /// Read the timestamp `--sort` selected, if the platform records it.
@@ -558,17 +582,7 @@ fn write_indexed_file_paths(
         .collect();
 
     if let Some(sort) = opts.sort {
-        paths.sort_by_cached_key(|path| {
-            let time = if sort.key == SortKey::Path {
-                None
-            } else {
-                time_key(&scope.full_path(index_root, path), sort.key)
-            };
-            (time, PathBuf::from(path))
-        });
-        if sort.reverse {
-            paths.reverse();
-        }
+        sort.apply_indexed(&mut paths, index_root, scope, String::as_str);
     }
 
     let mut writer = OutputWriter::new(opts.make_output_config());
@@ -904,7 +918,7 @@ fn search_via_server(
     let matches = match opts.sort {
         None => matches,
         Some(sort) => {
-            let mut ranked: Vec<(Option<std::time::SystemTime>, PathBuf, String)> = Vec::new();
+            let mut ranked = Vec::new();
             let mut seen = std::collections::HashSet::new();
             for m in matches {
                 let Some(rel) = m.get("file").and_then(|f| f.as_str()) else {
@@ -913,21 +927,13 @@ fn search_via_server(
                 if !seen.insert(rel.to_string()) {
                     continue;
                 }
-                let t = if sort.key == SortKey::Path {
-                    None
-                } else {
-                    time_key(&scope.full_path(index_root, rel), sort.key)
-                };
-                ranked.push((t, PathBuf::from(rel), rel.to_string()));
+                ranked.push(rel.to_string());
             }
-            ranked.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-            if sort.reverse {
-                ranked.reverse();
-            }
+            sort.apply_indexed(&mut ranked, index_root, scope, String::as_str);
             let rank: std::collections::HashMap<&str, usize> = ranked
                 .iter()
                 .enumerate()
-                .map(|(i, (_, _, f))| (f.as_str(), i))
+                .map(|(i, file)| (file.as_str(), i))
                 .collect();
 
             let mut rows = matches.clone();
@@ -1155,30 +1161,8 @@ fn search_local_index(
         })
         .collect();
 
-    // `--sort` has to apply here too, otherwise it would silently do nothing on
-    // the default (indexed) code path. The key is a `PathBuf` so the order
-    // matches the brute-force walk, which compares paths component-wise; a raw
-    // string compare would sort `src.rs` before `src/lib.rs`.
     if let Some(sort) = opts.sort {
-        let mut keyed: Vec<_> = candidates
-            .into_iter()
-            .map(|(fid, rel)| {
-                let t = if sort.key == SortKey::Path {
-                    None
-                } else {
-                    time_key(&scope.full_path(&index_root, &rel), sort.key)
-                };
-                (t, PathBuf::from(&rel), fid, rel)
-            })
-            .collect();
-        keyed.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-        if sort.reverse {
-            keyed.reverse();
-        }
-        candidates = keyed
-            .into_iter()
-            .map(|(_, _, fid, rel)| (fid, rel))
-            .collect();
+        sort.apply_indexed(&mut candidates, &index_root, &scope, |(_, rel)| rel);
     }
 
     if opts.stats {
@@ -1209,26 +1193,11 @@ fn search_local_index(
             Err(_) => continue,
         };
 
-        let outcome = search_decoded_file(&read, &matcher, rel_path, opts, &mut *writer, explicit)?;
-        match outcome {
-            FileOutcome::Matched => {
-                if !opts.files_without_match {
-                    had_matches = true;
-                    if opts.quiet {
-                        break;
-                    }
-                }
+        if search_file(&read, &matcher, rel_path, opts, writer, explicit)? {
+            had_matches = true;
+            if opts.quiet {
+                break;
             }
-            FileOutcome::NoMatch if opts.files_without_match => {
-                if !opts.quiet {
-                    writer.write_file(rel_path)?;
-                }
-                had_matches = true;
-                if opts.quiet {
-                    break;
-                }
-            }
-            FileOutcome::NoMatch | FileOutcome::Skipped => {}
         }
     }
 
@@ -1339,22 +1308,7 @@ fn brute_force_search(
             && !exceeds_max_filesize(root, opts, true)
         {
             let read = read_text_lossy(root, opts.encoding)?;
-            let outcome =
-                search_decoded_file(&read, &matcher, &rel_path, opts, &mut *writer, true)?;
-            match outcome {
-                FileOutcome::Matched => {
-                    if !opts.files_without_match {
-                        had_matches = true;
-                    }
-                }
-                FileOutcome::NoMatch if opts.files_without_match => {
-                    if !opts.quiet {
-                        writer.write_file(&rel_path)?;
-                    }
-                    had_matches = true;
-                }
-                FileOutcome::NoMatch | FileOutcome::Skipped => {}
-            }
+            had_matches = search_file(&read, &matcher, &rel_path, opts, writer, true)?;
         }
 
         if opts.stats {
@@ -1390,26 +1344,11 @@ fn brute_force_search(
             Err(_) => continue,
         };
 
-        let outcome = search_decoded_file(&read, &matcher, &rel_path, opts, &mut *writer, false)?;
-        match outcome {
-            FileOutcome::Matched => {
-                if !opts.files_without_match {
-                    had_matches = true;
-                    if opts.quiet {
-                        break;
-                    }
-                }
+        if search_file(&read, &matcher, &rel_path, opts, writer, false)? {
+            had_matches = true;
+            if opts.quiet {
+                break;
             }
-            FileOutcome::NoMatch if opts.files_without_match => {
-                if !opts.quiet {
-                    writer.write_file(&rel_path)?;
-                }
-                had_matches = true;
-                if opts.quiet {
-                    break;
-                }
-            }
-            FileOutcome::NoMatch | FileOutcome::Skipped => {}
         }
     }
 
@@ -1664,6 +1603,28 @@ enum FileOutcome {
     Matched,
     NoMatch,
     Skipped,
+}
+
+/// Whether a searched file satisfies the requested mode. Skipped files are
+/// never selected, even by `--files-without-match`.
+fn search_file(
+    read: &FileRead,
+    matcher: &SearchMatcher,
+    rel_path: &str,
+    opts: &SearchOptions,
+    writer: &mut OutputWriter,
+    explicit: bool,
+) -> Result<bool> {
+    match search_decoded_file(read, matcher, rel_path, opts, writer, explicit)? {
+        FileOutcome::Matched => Ok(!opts.files_without_match),
+        FileOutcome::NoMatch if opts.files_without_match => {
+            if !opts.quiet {
+                writer.write_file(rel_path)?;
+            }
+            Ok(true)
+        }
+        FileOutcome::NoMatch | FileOutcome::Skipped => Ok(false),
+    }
 }
 
 /// Search one file's decoded text, mapping reported offsets back to the bytes
@@ -1922,6 +1883,107 @@ fn plan_summary(plan: &QueryPlan) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn indexed_sort_preserves_entries_and_component_order() {
+        let entries = [
+            (1, "src.rs"),
+            (2, "src/lib.rs"),
+            (3, "a.rs"),
+            (4, "src/lib.rs"),
+        ];
+        for (reverse, expected) in [(false, [3, 2, 4, 1]), (true, [1, 4, 2, 3])] {
+            let mut sorted = entries;
+            SortMode {
+                key: SortKey::Path,
+                reverse,
+            }
+            .apply_indexed(
+                &mut sorted,
+                Path::new("unused-index-root"),
+                &IndexScope::Whole,
+                |(_, rel)| rel,
+            );
+            assert_eq!(sorted.map(|(id, _)| id), expected);
+        }
+    }
+
+    #[test]
+    fn indexed_sort_uses_scoped_timestamps_and_orders_missing_metadata() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let subtree = dir.path().join("nested");
+        std::fs::create_dir(&subtree).unwrap();
+        for (name, seconds) in [("new.txt", 60), ("z-old.txt", 0), ("a-old.txt", 0)] {
+            let time =
+                std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000 + seconds);
+            std::fs::File::create(subtree.join(name))
+                .unwrap()
+                .set_modified(time)
+                .unwrap();
+        }
+
+        for reverse in [false, true] {
+            let mut paths = ["new.txt", "z-old.txt", "missing.txt", "a-old.txt"];
+            SortMode {
+                key: SortKey::Modified,
+                reverse,
+            }
+            .apply_indexed(
+                &mut paths,
+                dir.path(),
+                &IndexScope::Subtree("nested/".to_string()),
+                |path| path,
+            );
+            let mut expected = ["missing.txt", "a-old.txt", "z-old.txt", "new.txt"];
+            if reverse {
+                expected.reverse();
+            }
+            assert_eq!(paths, expected);
+        }
+    }
+
+    #[test]
+    fn quiet_file_selection_distinguishes_nonmatching_and_skipped_files() {
+        let matcher = SearchMatcher::Standard(regex::Regex::new("needle").unwrap());
+        for (content, explicit, binary, matched, without_match) in [
+            ("needle\n", false, false, true, false),
+            ("other\n", false, false, false, true),
+            ("", false, false, false, true),
+            ("needle\0\n", false, false, false, false),
+            ("other\0\n", false, false, false, false),
+            ("needle\0\n", true, false, true, false),
+            ("other\0\n", true, false, false, true),
+            ("needle\0\n", false, true, true, false),
+            ("other\0\n", false, true, false, true),
+        ] {
+            let read = FileRead {
+                text: FileText::Owned(content.to_string()),
+                fixups: Default::default(),
+                first_nul: content.find('\0'),
+            };
+            for files_without_match in [false, true] {
+                let opts = SearchOptions {
+                    quiet: true,
+                    files_without_match,
+                    binary,
+                    ..Default::default()
+                };
+                let mut writer = new_writer(&opts);
+                let selected =
+                    search_file(&read, &matcher, "file.txt", &opts, &mut writer, explicit).unwrap();
+                let expected = if files_without_match {
+                    without_match
+                } else {
+                    matched
+                };
+                assert_eq!(
+                    selected, expected,
+                    "content={content:?}, explicit={explicit}, binary={binary}, \
+                     files_without_match={files_without_match}"
+                );
+            }
+        }
+    }
 
     // --- fused UTF-8 validation and NUL scan --------------------------------
     //

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1223,6 +1223,33 @@ fn publish_ignore_matcher(
     newly_watched
 }
 
+/// Publish the sources collected by an index build or path walk, using the
+/// walk's tracked-membership snapshot. Build inside the before/after stamp
+/// checks in `publish_ignore_matcher`, not before them.
+#[must_use = "newly watched directories need a recovery scan or writes race the subscription"]
+fn publish_collected_ignore_matcher(
+    state: &Arc<ServerState>,
+    root: &Path,
+    gitignore_files: &[PathBuf],
+    ignore_files: &[PathBuf],
+    ignorecase: Option<Arc<tgrep_core::gitignore::CaseInsensitiveIgnore>>,
+) -> Vec<PathBuf> {
+    publish_ignore_matcher(
+        state,
+        root,
+        ignore_sources_of(root, gitignore_files, ignore_files, state.no_require_git),
+        || {
+            tgrep_core::walker::build_gitignore_matcher_from_files_with_ignorecase(
+                root,
+                gitignore_files,
+                ignore_files,
+                state.no_require_git,
+                ignorecase,
+            )
+        },
+    )
+}
+
 fn handle_connection(stream: TcpStream, state: &Arc<ServerState>) -> Result<()> {
     let mut reader = BufReader::new(stream.try_clone()?);
     let mut writer = stream;
@@ -1296,16 +1323,19 @@ struct SearchRequest {
 /// Parse and validate all search parameters from a JSON-RPC request.
 /// Returns Err(String) with an error message suitable for json_rpc_error on failure.
 fn parse_search_params(params: &serde_json::Value) -> std::result::Result<SearchRequest, String> {
+    let str_array = |key: &str| -> Vec<String> {
+        params
+            .get(key)
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
     let pattern = params.get("pattern").and_then(|p| p.as_str()).unwrap_or("");
-    let extra_patterns: Vec<String> = params
-        .get("extra_patterns")
-        .and_then(|e| e.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
+    let extra_patterns = str_array("extra_patterns");
     let case_insensitive = params
         .get("case_insensitive")
         .and_then(|c| c.as_bool())
@@ -1322,24 +1352,8 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
         .get("max_count")
         .and_then(|m| m.as_u64())
         .map(|m| m as usize);
-    let glob_filter_strs: Vec<String> = params
-        .get("glob")
-        .and_then(|g| g.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
-    let iglob_strs: Vec<String> = params
-        .get("iglob")
-        .and_then(|g| g.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
+    let glob_filter_strs = str_array("glob");
+    let iglob_strs = str_array("iglob");
     let glob_case_insensitive = params
         .get("glob_case_insensitive")
         .and_then(|g| g.as_bool())
@@ -1347,17 +1361,6 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
     let glob_filter =
         crate::glob_filter::GlobFilter::new(&glob_filter_strs, &iglob_strs, glob_case_insensitive)
             .map_err(|e| format!("{e}"))?;
-    let str_array = |key: &str| -> Vec<String> {
-        params
-            .get(key)
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect()
-            })
-            .unwrap_or_default()
-    };
     // The client sends the raw `-t`/`-T`/`--type-add`/`--type-clear` values and
     // the server rebuilds the filter with the same shared helper, so both sides
     // are guaranteed to derive an identical definition table.
@@ -2071,24 +2074,12 @@ fn handle_reload(id: Option<serde_json::Value>, state: &Arc<ServerState>) -> Str
     let newly_watched = if state.no_ignore {
         Vec::new()
     } else {
-        publish_ignore_matcher(
+        publish_collected_ignore_matcher(
             state,
             &state.root,
-            ignore_sources_of(
-                &state.root,
-                &outcome.gitignore_files,
-                &outcome.ignore_files,
-                state.no_require_git,
-            ),
-            || {
-                tgrep_core::walker::build_gitignore_matcher_from_files_with_ignorecase(
-                    &state.root,
-                    &outcome.gitignore_files,
-                    &outcome.ignore_files,
-                    state.no_require_git,
-                    ignorecase,
-                )
-            },
+            &outcome.gitignore_files,
+            &outcome.ignore_files,
+            ignorecase,
         )
     };
     #[cfg(test)]
@@ -6243,24 +6234,12 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         // than skipped: the scan waits out `indexing` and then costs one
         // `metadata` call per file, since the stamps this build just wrote
         // describe the index exactly.
-        newly_watched = publish_ignore_matcher(
+        newly_watched = publish_collected_ignore_matcher(
             state,
             root,
-            ignore_sources_of(
-                root,
-                &outcome.gitignore_files,
-                &outcome.ignore_files,
-                state.no_require_git,
-            ),
-            || {
-                tgrep_core::walker::build_gitignore_matcher_from_files_with_ignorecase(
-                    root,
-                    &outcome.gitignore_files,
-                    &outcome.ignore_files,
-                    state.no_require_git,
-                    ignorecase,
-                )
-            },
+            &outcome.gitignore_files,
+            &outcome.ignore_files,
+            ignorecase,
         );
         let found = state.gitignore.read().unwrap().is_some();
         eprintln!(
@@ -6418,24 +6397,12 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         // the build's results nor any event. The scan waits for the build to
         // finish before looking, because until then the stamps describe
         // nothing and every file would read as changed.
-        newly_watched = publish_ignore_matcher(
+        newly_watched = publish_collected_ignore_matcher(
             state,
             root,
-            ignore_sources_of(
-                root,
-                &walk.gitignore_files,
-                &walk.ignore_files,
-                state.no_require_git,
-            ),
-            || {
-                walker::build_gitignore_matcher_from_files_with_ignorecase(
-                    root,
-                    &walk.gitignore_files,
-                    &walk.ignore_files,
-                    state.no_require_git,
-                    ignorecase,
-                )
-            },
+            &walk.gitignore_files,
+            &walk.ignore_files,
+            ignorecase,
         );
         let has_matcher = state.gitignore.read().unwrap().is_some();
         eprintln!(
@@ -11979,6 +11946,58 @@ mod tests {
         );
     }
 
+    #[test]
+    fn collected_ignore_matcher_publishes_both_source_kinds() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let mut state = test_server_state(root, &root.join(".tgrep"));
+        Arc::get_mut(&mut state).unwrap().no_require_git = true;
+        let gitignore = root.join(".gitignore");
+        let ignore = root.join(".ignore");
+        std::fs::write(&gitignore, "build/\n").unwrap();
+        std::fs::write(&ignore, "vendor/\n").unwrap();
+
+        let _gate = state.snapshot_gate.write().unwrap();
+        let newly_watched = publish_collected_ignore_matcher(
+            &state,
+            root,
+            std::slice::from_ref(&gitignore),
+            std::slice::from_ref(&ignore),
+            None,
+        );
+        assert!(newly_watched.is_empty());
+        assert!(!state.gitignore_pending.load(Ordering::SeqCst));
+        assert!(!state.ignore_rules_dirty.load(Ordering::SeqCst));
+        {
+            let sources = state.ignore_sources.read().unwrap();
+            assert!(sources.contains(&gitignore));
+            assert!(sources.contains(&ignore));
+        }
+        {
+            let stamps = state.ignore_source_stamps.read().unwrap();
+            assert_eq!(
+                stamps.get(".gitignore").copied(),
+                ignore_digest_of(&gitignore)
+            );
+            assert_eq!(stamps.get(".ignore").copied(), ignore_digest_of(&ignore));
+        }
+        let matcher = state.gitignore.read().unwrap();
+        let matcher = matcher
+            .as_ref()
+            .expect("collected rules should be published");
+        assert!(should_skip_watcher_path(
+            "build/output.rs",
+            &[],
+            Some(matcher)
+        ));
+        assert!(should_skip_watcher_path(
+            "vendor/dependency.rs",
+            &[],
+            Some(matcher)
+        ));
+        assert!(!should_skip_watcher_path("src/kept.rs", &[], Some(matcher)));
+    }
+
     /// The matcher reads its sources itself, inside the build. A replace that
     /// lands while it is reading leaves it enforcing the old rules, and stamps
     /// taken afterwards describe the new file — so pathname, timestamp and
@@ -12424,6 +12443,66 @@ mod tests {
             state.index.read().unwrap().live.is_deleted("grows.rs"),
             "content past the cap must not stay searchable"
         );
+    }
+
+    #[test]
+    fn search_params_string_arrays_keep_valid_entries_and_pattern_order() {
+        let request = parse_search_params(&serde_json::json!({
+            "pattern": "base",
+            "extra_patterns": [null, "a", 42, "ab", false, {}, ["nested"]],
+            "glob": ["*.rs", null, false, "!skip.rs", 42],
+            "iglob": [false, "*.TXT", {}],
+            "type_add": [null, "custom:*.special", false],
+            "type_clear": [42, "rust"],
+            "types": [null, "custom"],
+            "types_not": [false, "json"]
+        }))
+        .unwrap();
+
+        assert!(request.matcher.is_match("base").unwrap());
+        assert_eq!(request.matcher.find_first_span("ab").unwrap(), Some((0, 1)));
+        assert!(!request.matcher.is_match("42").unwrap());
+        assert!(!request.matcher.is_match("nested").unwrap());
+        assert!(request.glob_filter.matches("source.rs"));
+        assert!(!request.glob_filter.matches("skip.rs"));
+        assert!(request.glob_filter.matches("notes.txt"));
+        assert!(!request.glob_filter.matches("source.py"));
+        assert!(request.type_filter.matches("source.special"));
+        assert!(!request.type_filter.matches("source.rs"));
+        assert!(!request.type_filter.matches("data.json"));
+    }
+
+    #[test]
+    fn search_params_missing_or_non_array_string_options_are_empty() {
+        for value in [
+            None,
+            Some(serde_json::json!(null)),
+            Some(serde_json::json!(false)),
+            Some(serde_json::json!(42)),
+            Some(serde_json::json!("malformed[")),
+            Some(serde_json::json!({})),
+            Some(serde_json::json!([])),
+        ] {
+            let mut params = serde_json::json!({"pattern": "needle"});
+            if let Some(value) = value {
+                for key in [
+                    "extra_patterns",
+                    "glob",
+                    "iglob",
+                    "type_add",
+                    "type_clear",
+                    "types",
+                    "types_not",
+                ] {
+                    params[key] = value.clone();
+                }
+            }
+            let request = parse_search_params(&params).unwrap();
+            assert!(request.matcher.is_match("needle").unwrap());
+            assert!(!request.matcher.is_match("malformed").unwrap());
+            assert!(request.glob_filter.is_empty());
+            assert!(request.type_filter.is_empty());
+        }
     }
 
     #[test]

--- a/tgrep-cli/tests/indexed_files.rs
+++ b/tgrep-cli/tests/indexed_files.rs
@@ -182,6 +182,80 @@ fn legacy_filename_index_falls_back_and_indexed_scope_still_filters() {
 }
 
 #[test]
+fn indexed_sort_agrees_for_scoped_search_and_file_listing() {
+    let (_temp, root, index) = fixture();
+    let subtree = root.join("src");
+    fs::write(subtree.join("lib.rs"), "fn lib() {}\n").unwrap();
+    fs::write(root.join("src.rs"), "fn outside() {}\n").unwrap();
+    for (name, seconds) in [("main.rs", 0), ("lib.rs", 60)] {
+        let time = std::time::UNIX_EPOCH + Duration::from_secs(1_700_000_000 + seconds);
+        fs::OpenOptions::new()
+            .write(true)
+            .open(subtree.join(name))
+            .unwrap()
+            .set_modified(time)
+            .unwrap();
+    }
+    build_index(&root, &index);
+
+    for via_server in [false, true] {
+        let _server = via_server.then(|| start_server(&root, &index));
+        for (key, names) in [
+            ("path", ["lib.rs", "main.rs"]),
+            ("modified", ["main.rs", "lib.rs"]),
+        ] {
+            for flag in ["--sort", "--sortr"] {
+                let mut expected: Vec<_> = names
+                    .iter()
+                    .map(|name| subtree.join(name).to_string_lossy().replace('\\', "/"))
+                    .collect();
+                if flag == "--sortr" {
+                    expected.reverse();
+                }
+
+                let listed = output_lines(tgrep().args([
+                    "--files",
+                    "-t",
+                    "rust",
+                    flag,
+                    key,
+                    subtree.to_str().unwrap(),
+                    "--index-path",
+                    index.to_str().unwrap(),
+                ]));
+                assert_eq!(listed, expected, "{flag} {key}, server={via_server}");
+
+                let output = tgrep()
+                    .args([
+                        "--stats",
+                        "-l",
+                        "-t",
+                        "rust",
+                        flag,
+                        key,
+                        "fn",
+                        subtree.to_str().unwrap(),
+                        "--index-path",
+                        index.to_str().unwrap(),
+                    ])
+                    .assert()
+                    .success()
+                    .get_output()
+                    .clone();
+                let searched: Vec<_> = String::from_utf8(output.stdout)
+                    .unwrap()
+                    .lines()
+                    .map(|line| line.replace('\\', "/"))
+                    .collect();
+                assert_eq!(searched, expected, "{flag} {key}, server={via_server}");
+                let stderr = String::from_utf8(output.stderr).unwrap();
+                assert_eq!(stderr.contains("(via server)"), via_server, "{stderr}");
+            }
+        }
+    }
+}
+
+#[test]
 fn files_uses_the_live_server_filename_index() {
     let (_temp, root, index) = fixture();
     build_index(&root, &index);

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -586,6 +586,38 @@ fn files_without_match_with_glob() {
     assert!(!stdout.contains("notes.txt"));
 }
 
+#[test]
+fn files_without_match_handles_explicit_files_and_quiet_mode() {
+    let dir = setup_fixture();
+    let root = dir.path().join("testdata");
+    fs::write(root.join("empty.txt"), "").unwrap();
+    fs::write(root.join("binary.txt"), b"other\0text\n").unwrap();
+
+    for (name, code) in [
+        ("hello.rs", 1),
+        ("notes.txt", 0),
+        ("empty.txt", 0),
+        ("binary.txt", 0),
+    ] {
+        let path = root.join(name);
+        for quiet in [false, true] {
+            let mut command = tgrep();
+            command
+                .args(["--no-index", "--files-without-match", "fn"])
+                .arg(&path);
+            if quiet {
+                command.arg("--quiet");
+            }
+            let result = command.assert().code(code);
+            if quiet || code == 1 {
+                result.stdout(predicate::str::is_empty());
+            } else {
+                result.stdout(format!("{}\n", path.display()));
+            }
+        }
+    }
+}
+
 // ─── -q / --quiet ───────────────────────────────────────────────────
 
 #[test]

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -6,7 +6,10 @@ use std::path::Path;
 
 use crate::external::{self, ExternalSorter, TrigramPosting};
 use crate::meta::{self, IndexMeta};
-use crate::ondisk::{self, LookupEntry, PostingEntry};
+use crate::ondisk::{
+    self, LOOKUP_WRITE_CHUNK_ENTRIES, LookupEntry, POSTING_WRITE_CHUNK_ENTRIES, PostingEntry,
+    flush_lookup_entries, write_lookup_entry, write_posting_entries,
+};
 use crate::path_index;
 use crate::reader::IndexReader;
 use crate::trigram::{self, TrigramMasks};
@@ -15,8 +18,6 @@ use crate::{Error, Result};
 
 const INDEX_DIR_NAME: &str = ".tgrep";
 const INDEX_BUILD_BATCH_SIZE: usize = 1024;
-const POSTING_WRITE_CHUNK_ENTRIES: usize = 8192;
-const LOOKUP_WRITE_CHUNK_ENTRIES: usize = 4096;
 
 /// Cumulative bytes allowed in one extraction batch.
 ///
@@ -951,45 +952,6 @@ fn write_index_files<'a>(
         sorted_trigrams.len(),
         complete,
     )
-}
-
-fn write_posting_entries(
-    writer: &mut impl Write,
-    entries: &[PostingEntry],
-    scratch: &mut Vec<u8>,
-) -> Result<()> {
-    for chunk in entries.chunks(POSTING_WRITE_CHUNK_ENTRIES) {
-        scratch.clear();
-        for entry in chunk {
-            scratch.extend_from_slice(&entry.file_id.to_le_bytes());
-            scratch.push(entry.loc_mask);
-            scratch.push(entry.next_mask);
-        }
-        writer.write_all(scratch)?;
-    }
-    Ok(())
-}
-
-fn write_lookup_entry(
-    writer: &mut impl Write,
-    entry: LookupEntry,
-    scratch: &mut Vec<u8>,
-) -> Result<()> {
-    if scratch.len() == scratch.capacity() {
-        flush_lookup_entries(writer, scratch)?;
-    }
-    scratch.extend_from_slice(&entry.trigram.to_le_bytes());
-    scratch.extend_from_slice(&entry.offset.to_le_bytes());
-    scratch.extend_from_slice(&entry.length.to_le_bytes());
-    Ok(())
-}
-
-fn flush_lookup_entries(writer: &mut impl Write, scratch: &mut Vec<u8>) -> Result<()> {
-    if !scratch.is_empty() {
-        writer.write_all(scratch)?;
-        scratch.clear();
-    }
-    Ok(())
 }
 
 fn write_index_files_from_postings<'a>(

--- a/tgrep-core/src/external.rs
+++ b/tgrep-core/src/external.rs
@@ -34,7 +34,10 @@ use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
-use crate::ondisk::{self, LookupEntry, PostingEntry};
+use crate::ondisk::{
+    self, LOOKUP_WRITE_CHUNK_ENTRIES, LookupEntry, POSTING_WRITE_CHUNK_ENTRIES, PostingEntry,
+    flush_lookup_entries, write_lookup_entry, write_posting_entries,
+};
 use crate::{Error, Result};
 
 /// A single (trigram, posting) pair prior to grouping.
@@ -60,9 +63,6 @@ const MIN_SEGMENT_BUFFER_BYTES: usize = 4 * 1024;
 
 /// Longest possible LEB128 encoding of a `u64`.
 const MAX_VARINT_LEN: usize = 10;
-
-const POSTING_WRITE_CHUNK_ENTRIES: usize = 8192;
-const LOOKUP_WRITE_CHUNK_ENTRIES: usize = 4096;
 
 /// Flush threshold for the encode scratch buffer while spilling a segment.
 const SPILL_SCRATCH_FLUSH_BYTES: usize = 128 * 1024;
@@ -334,32 +334,16 @@ impl IndexWriter {
             ))
         })?;
 
-        if self.lookup_scratch.len() == self.lookup_scratch.capacity() {
-            self.lookup.write_all(&self.lookup_scratch)?;
-            self.lookup_scratch.clear();
-        }
-        let lookup_entry = LookupEntry {
-            trigram,
-            offset: self.offset,
-            length,
-        };
-        self.lookup_scratch
-            .extend_from_slice(&lookup_entry.trigram.to_le_bytes());
-        self.lookup_scratch
-            .extend_from_slice(&lookup_entry.offset.to_le_bytes());
-        self.lookup_scratch
-            .extend_from_slice(&lookup_entry.length.to_le_bytes());
-
-        for chunk in entries.chunks(POSTING_WRITE_CHUNK_ENTRIES) {
-            self.posting_scratch.clear();
-            for entry in chunk {
-                self.posting_scratch
-                    .extend_from_slice(&entry.file_id.to_le_bytes());
-                self.posting_scratch.push(entry.loc_mask);
-                self.posting_scratch.push(entry.next_mask);
-            }
-            self.postings.write_all(&self.posting_scratch)?;
-        }
+        write_lookup_entry(
+            &mut self.lookup,
+            LookupEntry {
+                trigram,
+                offset: self.offset,
+                length,
+            },
+            &mut self.lookup_scratch,
+        )?;
+        write_posting_entries(&mut self.postings, entries, &mut self.posting_scratch)?;
 
         self.offset += length as u64 * ondisk::POSTING_ENTRY_SIZE as u64;
         self.trigram_count += 1;
@@ -367,10 +351,7 @@ impl IndexWriter {
     }
 
     fn finish(mut self) -> Result<usize> {
-        if !self.lookup_scratch.is_empty() {
-            self.lookup.write_all(&self.lookup_scratch)?;
-            self.lookup_scratch.clear();
-        }
+        flush_lookup_entries(&mut self.lookup, &mut self.lookup_scratch)?;
         self.postings.flush()?;
         self.lookup.flush()?;
         Ok(self.trigram_count)

--- a/tgrep-core/src/hybrid.rs
+++ b/tgrep-core/src/hybrid.rs
@@ -119,25 +119,13 @@ impl HybridIndex {
     /// Look up candidate file IDs for a trigram, merging reader + overlay.
     pub fn lookup_trigram(&self, trigram: u32) -> Vec<u32> {
         let reader = self.reader();
-        let mut reader_ids = reader.lookup_trigram(trigram);
-        let live_ids = self.live.lookup_trigram(trigram);
-
-        reader_ids.retain(|&fid| self.reader_entry_active(&reader, fid));
-
-        reader_ids.extend(live_ids);
-        reader_ids
+        self.lookup_trigram_using_reader(trigram, &reader)
     }
 
     /// Look up candidate posting entries with masks, merging reader + overlay.
     pub fn lookup_trigram_with_masks(&self, trigram: u32) -> Vec<PostingEntry> {
         let reader = self.reader();
-        let mut reader_entries = reader.lookup_trigram_with_masks(trigram);
-        let live_entries = self.live.lookup_trigram_with_masks(trigram);
-
-        reader_entries.retain(|e| self.reader_entry_active(&reader, e.file_id));
-
-        reader_entries.extend(live_entries);
-        reader_entries
+        self.lookup_trigram_with_masks_using_reader(trigram, &reader)
     }
 
     /// Resolve a file ID to a path (works for both reader and overlay IDs).
@@ -155,13 +143,7 @@ impl HybridIndex {
     /// Get all file IDs from both layers (overlay takes precedence).
     pub fn all_file_ids(&self) -> Vec<u32> {
         let reader = self.reader();
-        let mut ids: Vec<u32> = reader
-            .all_file_ids()
-            .into_iter()
-            .filter(|&fid| self.reader_entry_active(&reader, fid))
-            .collect();
-        ids.extend(self.live.all_file_ids());
-        ids
+        self.all_file_ids_using(&reader)
     }
 
     /// Get every active content-indexed path from a consistent reader snapshot.

--- a/tgrep-core/src/ondisk.rs
+++ b/tgrep-core/src/ondisk.rs
@@ -20,6 +20,8 @@
 /// Variable-length records: `file_id(u32 LE) + path_len(u16 LE) + path_bytes`.
 pub(crate) const LOOKUP_ENTRY_SIZE: usize = 16; // 4 + 8 + 4
 pub(crate) const POSTING_ENTRY_SIZE: usize = 6; // 4 + 1 + 1
+pub(crate) const POSTING_WRITE_CHUNK_ENTRIES: usize = 8192;
+pub(crate) const LOOKUP_WRITE_CHUNK_ENTRIES: usize = 4096;
 
 /// A single entry in `lookup.bin`.
 #[derive(Debug, Clone, Copy)]
@@ -75,6 +77,48 @@ impl LookupEntry {
             length: u32::from_le_bytes(buf[12..16].try_into().unwrap()),
         }
     }
+}
+
+pub(crate) fn write_posting_entries(
+    writer: &mut impl std::io::Write,
+    entries: &[PostingEntry],
+    scratch: &mut Vec<u8>,
+) -> crate::Result<()> {
+    for chunk in entries.chunks(POSTING_WRITE_CHUNK_ENTRIES) {
+        scratch.clear();
+        for entry in chunk {
+            scratch.extend_from_slice(&entry.file_id.to_le_bytes());
+            scratch.push(entry.loc_mask);
+            scratch.push(entry.next_mask);
+        }
+        writer.write_all(scratch)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn write_lookup_entry(
+    writer: &mut impl std::io::Write,
+    entry: LookupEntry,
+    scratch: &mut Vec<u8>,
+) -> crate::Result<()> {
+    if scratch.len() == scratch.capacity() {
+        flush_lookup_entries(writer, scratch)?;
+    }
+    scratch.extend_from_slice(&entry.trigram.to_le_bytes());
+    scratch.extend_from_slice(&entry.offset.to_le_bytes());
+    scratch.extend_from_slice(&entry.length.to_le_bytes());
+    Ok(())
+}
+
+pub(crate) fn flush_lookup_entries(
+    writer: &mut impl std::io::Write,
+    scratch: &mut Vec<u8>,
+) -> crate::Result<()> {
+    if !scratch.is_empty() {
+        writer.write_all(scratch)?;
+        scratch.clear();
+    }
+    Ok(())
 }
 
 /// Maximum supported path length (in bytes) for entries in `files.bin`.
@@ -270,5 +314,109 @@ mod tests {
         assert_eq!(decoded.file_id, entry.file_id);
         assert_eq!(decoded.loc_mask, entry.loc_mask);
         assert_eq!(decoded.next_mask, entry.next_mask);
+    }
+
+    #[test]
+    fn test_write_posting_entries_preserves_chunked_encoding() {
+        for count in [
+            0,
+            1,
+            POSTING_WRITE_CHUNK_ENTRIES,
+            POSTING_WRITE_CHUNK_ENTRIES + 1,
+        ] {
+            let entries: Vec<PostingEntry> = (0..count)
+                .map(|id| PostingEntry {
+                    file_id: id as u32,
+                    loc_mask: id as u8,
+                    next_mask: !(id as u8),
+                })
+                .collect();
+            let expected: Vec<u8> = entries.iter().flat_map(PostingEntry::encode).collect();
+            let mut bytes = Vec::new();
+            let mut scratch = Vec::with_capacity(POSTING_WRITE_CHUNK_ENTRIES * POSTING_ENTRY_SIZE);
+            let capacity = scratch.capacity();
+
+            write_posting_entries(&mut bytes, &entries, &mut scratch).unwrap();
+
+            assert_eq!(bytes, expected);
+            assert_eq!(scratch.capacity(), capacity);
+        }
+    }
+
+    #[test]
+    fn test_write_lookup_entries_flushes_at_capacity() {
+        let mut bytes = Vec::new();
+        let mut expected = Vec::new();
+        let mut scratch = Vec::with_capacity(LOOKUP_WRITE_CHUNK_ENTRIES * LOOKUP_ENTRY_SIZE);
+        let capacity = scratch.capacity();
+        for trigram in 0..LOOKUP_WRITE_CHUNK_ENTRIES as u32 {
+            let entry = LookupEntry {
+                trigram,
+                offset: u32::MAX as u64 + trigram as u64,
+                length: trigram + 1,
+            };
+            write_lookup_entry(&mut bytes, entry, &mut scratch).unwrap();
+            expected.extend_from_slice(&entry.encode());
+        }
+        assert!(bytes.is_empty());
+        assert_eq!(scratch.len(), capacity);
+
+        let next = LookupEntry {
+            trigram: LOOKUP_WRITE_CHUNK_ENTRIES as u32,
+            offset: u64::MAX,
+            length: u32::MAX,
+        };
+        write_lookup_entry(&mut bytes, next, &mut scratch).unwrap();
+        assert_eq!(bytes, expected);
+        assert_eq!(scratch, next.encode());
+        assert_eq!(scratch.capacity(), capacity);
+
+        expected.extend_from_slice(&next.encode());
+        flush_lookup_entries(&mut bytes, &mut scratch).unwrap();
+        assert_eq!(bytes, expected);
+        assert!(scratch.is_empty());
+        flush_lookup_entries(&mut bytes, &mut scratch).unwrap();
+        assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn test_buffered_writers_preserve_scratch_on_io_error() {
+        let mut writer: &mut [u8] = &mut [];
+        let posting = PostingEntry {
+            file_id: 42,
+            loc_mask: 0x12,
+            next_mask: 0x34,
+        };
+        let mut posting_scratch = Vec::new();
+        let err = write_posting_entries(&mut writer, &[posting], &mut posting_scratch).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::Io(err) if err.kind() == std::io::ErrorKind::WriteZero
+        ));
+        assert_eq!(posting_scratch, posting.encode());
+
+        let lookup = LookupEntry {
+            trigram: 123,
+            offset: 456,
+            length: 789,
+        };
+        let mut lookup_scratch = lookup.encode().to_vec();
+        let err = flush_lookup_entries(&mut writer, &mut lookup_scratch).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::Io(err) if err.kind() == std::io::ErrorKind::WriteZero
+        ));
+        assert_eq!(lookup_scratch, lookup.encode());
+
+        let next = LookupEntry {
+            trigram: 124,
+            ..lookup
+        };
+        let err = write_lookup_entry(&mut writer, next, &mut lookup_scratch).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::Io(err) if err.kind() == std::io::ErrorKind::WriteZero
+        ));
+        assert_eq!(lookup_scratch, lookup.encode());
     }
 }

--- a/tgrep-core/tests/snapshot_consistency.rs
+++ b/tgrep-core/tests/snapshot_consistency.rs
@@ -240,6 +240,61 @@ fn match_all_uses_consistent_snapshot() {
     }
 }
 
+#[test]
+fn direct_lookups_share_snapshot_overlay_precedence() {
+    let root = tempfile::tempdir().unwrap();
+    let index = build_test_index(
+        root.path(),
+        &[
+            ("kept.txt", b"abc"),
+            ("replaced.txt", b"abc"),
+            ("deleted.txt", b"abc"),
+            ("short.txt", b"a"),
+        ],
+    );
+    let mut hybrid = HybridIndex::open(index.path(), root.path()).unwrap();
+    hybrid.live.upsert_file("replaced.txt", b"xyz");
+    hybrid.live.delete_file("deleted.txt");
+    hybrid.live.upsert_file("new.txt", b"abc");
+    let new_id = hybrid.live.file_id_for_path("new.txt").unwrap();
+    let replacement_id = hybrid.live.file_id_for_path("replaced.txt").unwrap();
+    let tri = trigram::hash(b'a', b'b', b'c');
+
+    let ids = hybrid.lookup_trigram(tri);
+    assert_eq!(ids, vec![0, new_id]);
+    let entries = hybrid.lookup_trigram_with_masks(tri);
+    assert_eq!(
+        entries
+            .iter()
+            .map(|entry| entry.file_id)
+            .collect::<Vec<_>>(),
+        ids
+    );
+
+    let plan = query::build_literal_plan("abc", false);
+    assert_eq!(hybrid.execute_query(&plan), ids);
+    let (query_ids, snapshot) = hybrid.execute_query_with_masks(&plan);
+    assert_eq!(query_ids, ids);
+    assert_eq!(
+        entries[0].encode(),
+        snapshot.lookup_trigram_with_masks(tri)[0].encode()
+    );
+    assert_eq!(
+        entries[1].encode(),
+        hybrid.live.lookup_trigram_with_masks(tri)[0].encode()
+    );
+
+    let all_ids = hybrid.all_file_ids();
+    let (snapshot_ids, _) = hybrid.execute_query_with_masks(&query::QueryPlan::MatchAll);
+    assert_eq!(all_ids, snapshot_ids);
+    assert_eq!(&all_ids[..2], &[0, 3]);
+    let mut sorted_ids = all_ids;
+    sorted_ids.sort_unstable();
+    let mut expected = vec![0, 3, replacement_id, new_id];
+    expected.sort_unstable();
+    assert_eq!(sorted_ids, expected);
+}
+
 /// Concurrent reader swap during query execution: demonstrates that the
 /// snapshot-based API is safe while the old API would fail.
 #[test]


### PR DESCRIPTION
## Summary

- Share file-selection handling and scoped sorting across local, indexed, and server-backed searches.
- Reuse server string-array parsing and collected ignore-matcher publication without changing validation order, snapshot handling, or watcher recovery.
- Centralize buffered posting/lookup serialization and reuse existing snapshot-aware hybrid-index helpers.

Preserves public APIs, the on-disk format, buffer sizes, output, and error handling. Similar-looking paths with different semantics remain separate. Adds focused regression coverage for sorting, binary/nonmatching files, parser defaults, serialization boundaries and I/O failures, and overlay/snapshot consistency.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --benches -- -D warnings`
- Focused CLI sorting, file-selection, server parsing, ignore publication, watcher, and warm-start tests.
- Focused core builder, external-sort, and on-disk serialization tests, plus snapshot, case-insensitive round-trip, and corrupt-index integration tests.
- Final cross-component run: `cargo test -p tgrep-cli --test indexed_files --test concurrent_search`