### PR TITLE
Fall back to polling when native watch capacity is exhausted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ tgrep <pattern> ---TCP---> tgrep serve (multi-client)
   using rayon; queries are served immediately from partial data
 - **Periodic Flush** — every 50K files or 5 minutes, the in-memory index is
   flushed to disk and the reader is swapped, keeping memory bounded
-- **File Watcher** — `notify` crate watches the repo; updates LiveIndex in
-  real time
+- **Automatic refresh** — native `notify` subscriptions update LiveIndex in
+  real time when available; budget or registration failures switch to polling
 - **Filename Index** — `--files` unions content-index paths with a compact
   sidecar containing only admitted paths that have no searchable content
 - **TCP Server** — JSON-RPC 2.0 over newline-delimited TCP; each connection
@@ -276,7 +276,10 @@ unaffected.
 ```bash
 tgrep serve .                          # start server (auto-builds index if missing)
 tgrep serve . --index-path /tmp/idx    # custom index location
-tgrep serve . --no-watch               # skip file watcher (saves memory)
+tgrep serve . --watch-mode poll        # poll without any native subscriptions
+tgrep serve . --poll-interval 60       # polling cadence after fallback
+tgrep serve . --watch-budget 4096      # lower this process's native watch ceiling
+tgrep serve . --no-watch              # disable all automatic refresh
 tgrep serve . --exclude node_modules   # exclude directories from indexing
 ```
 
@@ -296,20 +299,63 @@ Resource use during that initial build can be tuned. These apply to both
 
 #### Staying in step with the filesystem
 
-Once the index is built, everything that changes it arrives as an OS
-notification, and a notification can go missing — a queue overflow, a network
-or virtualised filesystem that declines to report a change, a tree replaced
-wholesale by a branch switch or a build. Overflow is detected and repaired at
-once; the rest is silent, and nothing else in the server revisits a file it
-believes it already knows. A missed change would otherwise last until that
-file happened to change again, which for a deleted file is never.
+Automatic refresh has two modes, configured on `tgrep serve`:
 
-So a watching server also reconciles on a timer: about once an hour it walks
-the tree and compares it against the index, which finds any drift regardless
-of what the watcher heard. It waits for a two-minute gap in queries first, and
-gives up waiting after four hours so a continuously busy server still
-reconciles. On an unchanged tree it finds nothing and leaves the index alone.
-`--no-watch` turns it off along with the watcher.
+| Flag | Default | Effect |
+|------|---------|--------|
+| `--watch-mode <auto\|poll>` | `auto` | Prefer native notifications with polling fallback, or use polling only |
+| `--poll-interval <SECONDS>` | `120` | Wait after each polling reconciliation completes; range 1-86400 |
+| `--watch-budget <N>` | `8192` | Conservative process-local native watch ceiling; range 1-4294967295 |
+| `--no-watch` | off | Disable all automatic refresh: native watching, polling, and periodic reconciliation |
+
+In `auto` mode, exceeding the watch budget, exhausting OS watch capacity, or
+another error preventing complete native coverage switches the **whole
+process** to polling. Status retains the specific fallback reason. This fallback
+is sticky until the server restarts: it releases only this process's native watches and
+does not keep retrying native registration. `poll` mode starts with **zero
+native subscriptions**, including on Linux. It uses tgrep's metadata
+reconciliation, not a second native watcher or `notify::PollWatcher`.
+
+The default budget of 8192 is a conservative ceiling, **not an estimate of
+free per-user capacity**. On Linux the inotify quota is shared with other
+processes running as the same user; they may consume capacity before this
+server reaches its budget. Raising the budget does not raise that shared quota.
+tgrep does not probe the configured Linux quota: it uses this fixed ceiling
+and authoritative OS registration errors. The budget counts one subscription
+per admitted directory on Linux/Android; recursive backends count their single
+root subscription as one.
+
+The event buffer controlled by `--watcher-queue-cap` is separate: queue overflow
+triggers recovery reconciliation, not watch-budget fallback.
+
+Polling walks the admitted tree and checks metadata for additions, changes,
+and deletions. Its default cadence is completion-based: the next poll waits
+120 seconds after the previous reconciliation finishes. Actual freshness also
+includes scan/update time (and any in-progress indexing or save); it is not a
+120-second hard freshness guarantee. Searches do not defer polling, and slow
+scans do not cause overlapping polls or catch-up storms.
+Fallback does not hide failures: a failed polling reconciliation or unreadable
+input remains unhealthy and is reported in status.
+
+Native notifications can also go missing, for example on a network or
+virtualised filesystem. Native mode therefore retains its safety
+reconciliation: about once an hour it walks the tree and compares it against
+the index, waiting for a two-minute gap in queries and deferring no longer than
+four hours. `--poll-interval` sets the polling cadence, not this native safety
+cadence.
+
+No-change metadata scans leave the index untouched; they do not rewrite it.
+A changed delta merge may still rewrite the whole on-disk index. On Linux,
+nanosecond mtime and ctime plus file identity detect ordinary writes even when
+the modification timestamp is restored. Other OS/filesystem metadata
+limitations remain: changes that preserve all available evidence may be
+missed. A scan and its updates do not provide an atomic filesystem snapshot.
+
+`--no-watch` still permits the initial build/startup reconciliation, but turns
+off all subsequent automatic refresh. It cannot be combined explicitly with
+`--watch-mode`, `--poll-interval`, or `--watch-budget`. Explicit
+`--watch-mode poll` also rejects `--watch-budget`, since polling uses no native
+watches. Inherited default values do not cause conflicts.
 
 On Linux and Android, tgrep registers only the non-ignored directories with
 inotify, avoiding watch-descriptor growth beneath ignored trees. This guarantee
@@ -375,8 +421,26 @@ Server status for /src/my-monorepo
   Trigrams:   12265
   Cache:      2/50000
   Watcher:    active
+  Watch mode: native (requested: auto)
+  Watch budget: 8192
+  Poll interval: 120s (after completion)
+  Reconcile:  idle
+  Last successful reconcile: 2m ago
+  Reconcile pending: no
+  Reconcile overdue: no
+  Last reconcile duration: 42ms
   Indexing:   complete
 ```
+
+Status retains the native `Watcher` indicator and reports the requested mode
+(`auto`, `poll`, or `disabled`) and active mode (`native`, `poll`, `disabled`,
+or `starting`). A polling server normally shows an inactive native watcher.
+Fallback reasons, the last successful reconciliation, the latest attempt's
+duration/error, and whether reconciliation is running, pending, or overdue help
+distinguish a healthy polling server from one that has stopped refreshing.
+Pending means catch-up work is requested; overdue means that work is pending
+or the polling interval/native safety deadline has elapsed since completion.
+Older servers without these fields still display their existing status.
 
 ### Count files
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "blake3",

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -19,9 +19,10 @@ mod walkcount;
 use std::path::PathBuf;
 use std::process;
 use std::sync::atomic::AtomicBool;
+use std::time::Duration;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use output::ColorMode;
 use tgrep_core::builder;
 
@@ -618,9 +619,31 @@ enum Command {
         #[arg(default_value = ".")]
         path: PathBuf,
 
-        /// Disable the file system watcher (saves memory on large repos).
-        #[arg(long)]
+        /// Disable all automatic refresh, including watching and polling.
+        #[arg(long, conflicts_with_all = ["watch_mode", "poll_interval", "watch_budget"])]
         no_watch: bool,
+
+        /// Use native notifications with automatic polling fallback, or polling only.
+        #[arg(long, value_enum, default_value = "auto", value_name = "MODE")]
+        watch_mode: serve::WatchMode,
+
+        /// Seconds to wait after a polling reconciliation completes (1-86400).
+        #[arg(
+            long,
+            default_value_t = 120,
+            value_name = "SECONDS",
+            value_parser = clap::value_parser!(u64).range(1..=86400)
+        )]
+        poll_interval: u64,
+
+        /// Process-local native watch ceiling, not available shared OS capacity.
+        #[arg(
+            long,
+            default_value_t = 8192,
+            value_name = "N",
+            value_parser = clap::value_parser!(u32).range(1..)
+        )]
+        watch_budget: u32,
 
         /// Maximum memory budget in megabytes for the in-memory index built
         /// during the initial scan. When the indexer's working set exceeds
@@ -693,6 +716,30 @@ enum Command {
 }
 
 impl Cli {
+    fn try_parse_args_from<I, T>(args: I) -> std::result::Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<std::ffi::OsString> + Clone,
+    {
+        let mut command = Self::command();
+        let matches = command.try_get_matches_from_mut(args)?;
+        // Clap conflicts are unconditional; this one depends on the mode's
+        // value and must not treat the inherited budget as an explicit flag.
+        if let Some(("serve", serve)) = matches.subcommand()
+            && serve.get_one::<serve::WatchMode>("watch_mode") == Some(&serve::WatchMode::Poll)
+            && serve.value_source("watch_budget") == Some(clap::parser::ValueSource::CommandLine)
+        {
+            return Err(command
+                .find_subcommand_mut("serve")
+                .expect("serve subcommand exists")
+                .error(
+                    clap::error::ErrorKind::ArgumentConflict,
+                    "--watch-budget cannot be used with --watch-mode poll",
+                ));
+        }
+        Self::from_arg_matches(&matches)
+    }
+
     /// Resolve `--max-filesize` once, so a malformed value is reported instead
     /// of silently falling back to a different limit than the user asked for.
     ///
@@ -1010,7 +1057,7 @@ fn main() {
 }
 
 fn run_cli() {
-    let cli = Cli::parse();
+    let cli = Cli::try_parse_args_from(std::env::args_os()).unwrap_or_else(|error| error.exit());
     let no_ignore = cli.no_ignore || cli.unrestricted >= 1;
 
     // Handle --type-list. It reflects --type-add/--type-clear so users can
@@ -1091,6 +1138,9 @@ fn run_cli() {
         Some(Command::Serve {
             path,
             no_watch,
+            watch_mode,
+            poll_interval,
+            watch_budget,
             max_memory_mb,
             max_cpu_percent,
             exclude,
@@ -1106,6 +1156,9 @@ fn run_cli() {
                 cli.index_path.as_deref(),
                 serve::ServeOptions {
                     no_watch,
+                    watch_mode,
+                    poll_interval: Duration::from_secs(poll_interval),
+                    watch_budget: watch_budget as usize,
                     exclude_dirs: &exclude,
                     memory_cap_bytes: memory_cap,
                     index_threads,
@@ -1328,4 +1381,137 @@ fn run_search(
         process::exit(2);
     }
     process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> std::result::Result<Cli, clap::Error> {
+        let args: Vec<String> = std::iter::once("tgrep")
+            .chain(args.iter().copied())
+            .map(String::from)
+            .collect();
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || Cli::try_parse_args_from(args))
+            .unwrap()
+            .join()
+            .unwrap()
+    }
+
+    #[test]
+    fn refresh_defaults_and_explicit_modes() {
+        for (args, expected_mode, expected_no_watch) in [
+            (vec!["serve"], serve::WatchMode::Auto, false),
+            (
+                vec!["serve", "--watch-mode", "auto"],
+                serve::WatchMode::Auto,
+                false,
+            ),
+            (
+                vec!["serve", "--watch-mode", "poll"],
+                serve::WatchMode::Poll,
+                false,
+            ),
+            (vec!["serve", "--no-watch"], serve::WatchMode::Auto, true),
+        ] {
+            let Some(Command::Serve {
+                no_watch,
+                watch_mode,
+                poll_interval,
+                watch_budget,
+                ..
+            }) = parse(&args).unwrap().command
+            else {
+                panic!("expected serve");
+            };
+            assert_eq!(no_watch, expected_no_watch);
+            assert_eq!(watch_mode, expected_mode);
+            assert_eq!(poll_interval, 120);
+            assert_eq!(watch_budget, 8192);
+        }
+    }
+
+    #[test]
+    fn refresh_explicit_values_and_boundaries() {
+        for (interval, budget) in [("1", "1"), ("120", "8192"), ("86400", "4294967295")] {
+            let Some(Command::Serve {
+                poll_interval,
+                watch_budget,
+                ..
+            }) = parse(&[
+                "serve",
+                "--poll-interval",
+                interval,
+                "--watch-budget",
+                budget,
+            ])
+            .unwrap()
+            .command
+            else {
+                panic!("expected serve");
+            };
+            assert_eq!(poll_interval, interval.parse::<u64>().unwrap());
+            assert_eq!(watch_budget, budget.parse::<u32>().unwrap());
+        }
+        assert!(parse(&["serve", "--watch-mode", "auto", "--watch-budget", "8192"]).is_ok());
+        assert!(parse(&["serve", "--watch-mode", "poll", "--poll-interval", "1"]).is_ok());
+        assert!(parse(&["serve", "--no-watch", "--watcher-queue-cap", "1"]).is_ok());
+    }
+
+    #[test]
+    fn refresh_explicit_conflicts_include_default_values() {
+        for args in [
+            vec!["--watch-mode", "auto"],
+            vec!["--watch-mode", "poll"],
+            vec!["--poll-interval", "120"],
+            vec!["--poll-interval", "1"],
+            vec!["--watch-budget", "8192"],
+            vec!["--watch-budget", "1"],
+        ] {
+            for no_watch_first in [true, false] {
+                let mut command = vec!["serve"];
+                if no_watch_first {
+                    command.push("--no-watch");
+                }
+                command.extend(&args);
+                if !no_watch_first {
+                    command.push("--no-watch");
+                }
+                let error = parse(&command).err().expect("explicit flags conflict");
+                assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+            }
+        }
+        for args in [
+            ["serve", "--watch-mode", "poll", "--watch-budget", "8192"],
+            ["serve", "--watch-budget", "1", "--watch-mode", "poll"],
+        ] {
+            let error = parse(&args)
+                .err()
+                .expect("poll does not use native watches");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+            assert!(error.to_string().contains("--watch-budget"));
+        }
+    }
+
+    #[test]
+    fn refresh_rejects_invalid_values() {
+        for (flag, values) in [
+            ("--watch-mode", vec!["native", "disabled", "AUTO", ""]),
+            ("--poll-interval", vec!["0", "86401", "-1", "1.5", "bad"]),
+            (
+                "--watch-budget",
+                vec!["0", "4294967296", "-1", "1.5", "bad"],
+            ),
+        ] {
+            for value in values {
+                assert!(
+                    parse(&["serve", &format!("{flag}={value}")]).is_err(),
+                    "{flag}={value} should be rejected"
+                );
+            }
+            assert!(parse(&["serve", flag]).is_err());
+        }
+    }
 }

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -674,6 +674,7 @@ struct ServerState {
 #[cfg(test)]
 #[derive(Clone, Copy)]
 enum StaleRefreshPhase {
+    BeforeRefreshLock,
     BeforeWalk,
     AfterBuildBeforeStampPublish,
     AfterConcreteRead,
@@ -5343,6 +5344,17 @@ fn periodic_reconcile_loop(state: Arc<ServerState>, root: PathBuf, index_dir: Pa
     }
 }
 
+fn scheduled_reconcile_due(state: &ServerState, status: &ReconcileStatus) -> bool {
+    let busy = state.indexing.load(Ordering::SeqCst)
+        || state.flushing.load(Ordering::SeqCst)
+        || status.running;
+    if state.refresh.polling.load(Ordering::SeqCst) {
+        !busy && (status.catch_up || status.finished.elapsed() >= state.refresh.poll_interval)
+    } else {
+        reconcile_due(status.finished.elapsed(), state.quiet_for(), busy)
+    }
+}
+
 fn scheduled_reconcile(state: &Arc<ServerState>, root: &Path, index_dir: &Path) -> Option<bool> {
     if !state.watch_enabled {
         return None;
@@ -5351,21 +5363,23 @@ fn scheduled_reconcile(state: &Arc<ServerState>, root: &Path, index_dir: &Path) 
         stop_native_watcher(state);
     }
     {
-        let mut status = state.refresh.status.lock().unwrap();
-        let busy = state.indexing.load(Ordering::SeqCst)
-            || state.flushing.load(Ordering::SeqCst)
-            || status.running;
-        let due = if state.refresh.polling.load(Ordering::SeqCst) {
-            !busy && (status.catch_up || status.finished.elapsed() >= state.refresh.poll_interval)
-        } else {
-            reconcile_due(status.finished.elapsed(), state.quiet_for(), busy)
-        };
-        if !due {
+        let status = state.refresh.status.lock().unwrap();
+        if !scheduled_reconcile_due(state, &status) {
             return None;
         }
-        status.catch_up = false;
     }
-    Some(background_refresh_stale(state, root, index_dir, false))
+    #[cfg(test)]
+    run_stale_refresh_hook(state, StaleRefreshPhase::BeforeRefreshLock);
+    let refresh = state.stale_refresh_lock.lock().unwrap();
+    let status = state.refresh.status.lock().unwrap();
+    // Startup or another refresh may have satisfied this tick while we waited.
+    // Keep both locks through the claim so catch-up is consumed only by a scan.
+    if !scheduled_reconcile_due(state, &status) {
+        return None;
+    }
+    Some(background_refresh_stale_locked(
+        state, root, index_dir, false, refresh, status,
+    ))
 }
 
 fn record_reconcile(state: &ServerState, start: Instant, ok: bool) {
@@ -6127,15 +6141,34 @@ fn background_refresh_stale(
     index_dir: &Path,
     compare_index_membership: bool,
 ) -> bool {
+    #[cfg(test)]
+    run_stale_refresh_hook(state, StaleRefreshPhase::BeforeRefreshLock);
     let refresh = state.stale_refresh_lock.lock().unwrap();
+    let status = state.refresh.status.lock().unwrap();
+    background_refresh_stale_locked(
+        state,
+        root,
+        index_dir,
+        compare_index_membership,
+        refresh,
+        status,
+    )
+}
+
+fn background_refresh_stale_locked(
+    state: &Arc<ServerState>,
+    root: &Path,
+    index_dir: &Path,
+    compare_index_membership: bool,
+    refresh: std::sync::MutexGuard<'_, ()>,
+    mut status: std::sync::MutexGuard<'_, ReconcileStatus>,
+) -> bool {
     let attempt = Instant::now();
-    {
-        let mut status = state.refresh.status.lock().unwrap();
-        status.running = true;
-        if state.refresh.polling.load(Ordering::SeqCst) {
-            status.catch_up = false;
-        }
+    status.running = true;
+    if state.refresh.polling.load(Ordering::SeqCst) {
+        status.catch_up = false;
     }
+    drop(status);
     if state.refresh.polling.load(Ordering::SeqCst) {
         state.ignore_rules_dirty.store(false, Ordering::SeqCst);
     }
@@ -6199,7 +6232,22 @@ fn background_refresh_stale(
 fn startup_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &Path) -> bool {
     let mut retry_delay = Duration::from_secs(1);
     loop {
-        let ok = background_refresh_stale(state, root, index_dir, false);
+        #[cfg(test)]
+        run_stale_refresh_hook(state, StaleRefreshPhase::BeforeRefreshLock);
+        let refresh = state.stale_refresh_lock.lock().unwrap();
+        let status = state.refresh.status.lock().unwrap();
+        if state.watch_enabled
+            && state.refresh.polling.load(Ordering::SeqCst)
+            && !scheduled_reconcile_due(state, &status)
+        {
+            // A previous polling attempt owns the retry cadence even if it
+            // failed. Do not report that failed or still-deferred work as fresh.
+            return !status.catch_up
+                && status.finished.elapsed() < state.refresh.poll_interval
+                && status.last_success.is_some()
+                && status.error.is_none();
+        }
+        let ok = background_refresh_stale_locked(state, root, index_dir, false, refresh, status);
         if ok || state.refresh.polling.load(Ordering::SeqCst) {
             return ok;
         }
@@ -9536,6 +9584,7 @@ mod tests {
                         after_publish_release.wait();
                     }
                 }
+                StaleRefreshPhase::BeforeRefreshLock => {}
                 StaleRefreshPhase::AfterBuildBeforeStampPublish => {}
                 StaleRefreshPhase::AfterConcreteRead => {}
                 StaleRefreshPhase::BeforeConcreteCommit => {}
@@ -9675,6 +9724,7 @@ mod tests {
                         test_git(&root, &["add", "--", "src/lib.rs"]);
                     }
                 }
+                StaleRefreshPhase::BeforeRefreshLock => {}
                 StaleRefreshPhase::AfterBuildBeforeStampPublish => {}
                 StaleRefreshPhase::AfterConcreteRead => {}
                 StaleRefreshPhase::BeforeConcreteCommit => {}
@@ -9848,6 +9898,7 @@ mod tests {
                         after_publish_release.wait();
                     }
                 }
+                StaleRefreshPhase::BeforeRefreshLock => {}
                 StaleRefreshPhase::AfterBuildBeforeStampPublish => {}
                 StaleRefreshPhase::AfterConcreteRead => {}
                 StaleRefreshPhase::BeforeConcreteCommit => {}

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -24,6 +24,10 @@ use tgrep_core::builder;
 use tgrep_core::hybrid::HybridIndex;
 use tgrep_core::query;
 
+#[cfg(test)]
+#[path = "serve/poll_tests.rs"]
+mod poll_tests;
+
 const CACHE_CAPACITY: usize = 50_000;
 /// Total decoded bytes the content cache may hold. The entry-count limit above
 /// says nothing about memory; without this a handful of large files can pin
@@ -112,6 +116,55 @@ const RECONCILE_QUIET_PERIOD: Duration = Duration::from_secs(120);
 /// queried steadily every minute would otherwise never see one, and would
 /// never reconcile at all — which is the failure this exists to prevent.
 const RECONCILE_DEADLINE: Duration = Duration::from_secs(4 * 3600);
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum WatchMode {
+    #[default]
+    Auto,
+    Poll,
+}
+
+struct RefreshControl {
+    requested: WatchMode,
+    poll_interval: Duration,
+    watch_budget: usize,
+    polling: Arc<std::sync::atomic::AtomicBool>,
+    status: Mutex<ReconcileStatus>,
+    wake: std::sync::Condvar,
+}
+
+struct ReconcileStatus {
+    catch_up: bool,
+    finished: Instant,
+    last_success: Option<u64>,
+    duration_ms: Option<u64>,
+    error: Option<String>,
+    running: bool,
+    fallback_reason: Option<String>,
+}
+
+impl RefreshControl {
+    fn new(requested: WatchMode, poll_interval: Duration, watch_budget: usize) -> Self {
+        Self {
+            requested,
+            poll_interval,
+            watch_budget,
+            polling: Arc::new(std::sync::atomic::AtomicBool::new(
+                requested == WatchMode::Poll,
+            )),
+            status: Mutex::new(ReconcileStatus {
+                catch_up: requested == WatchMode::Poll,
+                finished: Instant::now(),
+                last_success: None,
+                duration_ms: None,
+                error: None,
+                running: false,
+                fallback_reason: None,
+            }),
+            wake: std::sync::Condvar::new(),
+        }
+    }
+}
 
 /// Server discovery info, written to `serve.json`.
 #[derive(Debug, Serialize, Deserialize)]
@@ -509,6 +562,7 @@ struct ServerState {
     index_total: std::sync::atomic::AtomicU64,
     /// True when file watching is enabled for this server.
     watch_enabled: bool,
+    refresh: RefreshControl,
     /// The live watcher and the directories it is subscribed to.
     ///
     /// Held here rather than by `run` because the subscription set is not
@@ -705,6 +759,9 @@ impl SearchOpts {
 
 pub struct ServeOptions<'a> {
     pub no_watch: bool,
+    pub watch_mode: WatchMode,
+    pub poll_interval: Duration,
+    pub watch_budget: usize,
     pub exclude_dirs: &'a [String],
     pub memory_cap_bytes: u64,
     pub index_threads: usize,
@@ -722,6 +779,9 @@ pub struct ServeOptions<'a> {
 pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) -> Result<()> {
     let ServeOptions {
         no_watch,
+        watch_mode,
+        poll_interval,
+        watch_budget,
         exclude_dirs,
         memory_cap_bytes,
         index_threads,
@@ -831,6 +891,7 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
         index_progress: std::sync::atomic::AtomicU64::new(0),
         index_total: std::sync::atomic::AtomicU64::new(0),
         watch_enabled: !no_watch,
+        refresh: RefreshControl::new(watch_mode, poll_interval, watch_budget),
         watch_registry: Mutex::new(None),
         exclude_dirs: exclude_dirs.to_vec(),
         no_ignore,
@@ -909,22 +970,17 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
             // during the gap: it compares the whole tree against the index,
             // so any edit that landed while the matcher was still building is
             // picked up here.
-            let mut retry_delay = Duration::from_secs(1);
-            while !background_refresh_stale(&stale_state, &stale_root, &stale_index_dir, false) {
-                eprintln!(
-                    "[trace] stale check: retrying in {:.0}s",
-                    retry_delay.as_secs_f64()
-                );
-                thread::sleep(retry_delay);
-                retry_delay = (retry_delay * 2).min(Duration::from_secs(30));
-            }
+            startup_refresh_stale(&stale_state, &stale_root, &stale_index_dir);
         });
     }
 
     // Start file watcher (unless --no-watch)
     if no_watch {
         eprintln!("[trace] file watcher disabled (--no-watch)");
+    } else if watch_mode == WatchMode::Poll {
+        eprintln!("[trace] refresh mode: poll (no native watcher), interval={poll_interval:?}");
     } else {
+        eprintln!("[trace] refresh mode: auto, native watch budget={watch_budget}");
         let watcher_state = Arc::clone(&state);
         let watcher_root = root.clone();
         start_file_watcher(watcher_state, &watcher_root, watcher_queue_cap);
@@ -1955,6 +2011,7 @@ fn collect_match_rows(
 }
 
 fn handle_status(id: Option<serde_json::Value>, state: &ServerState) -> String {
+    let refresh = state.refresh.status.lock().unwrap();
     let index = state.index.read().unwrap();
     let cache = state.cache.read().unwrap();
     let indexing = state.indexing.load(Ordering::SeqCst);
@@ -1967,6 +2024,17 @@ fn handle_status(id: Option<serde_json::Value>, state: &ServerState) -> String {
         "cache_bytes": cache.byte_len(),
         "cache_max_bytes": CACHE_MAX_BYTES,
         "watcher_active": state.watcher_active.load(std::sync::atomic::Ordering::Relaxed),
+        "watch_mode_requested": if !state.watch_enabled { "disabled" } else if state.refresh.requested == WatchMode::Poll { "poll" } else { "auto" },
+        "watch_mode_active": if !state.watch_enabled { "disabled" } else if state.refresh.polling.load(Ordering::SeqCst) { "poll" } else if state.watcher_active.load(Ordering::SeqCst) { "native" } else { "starting" },
+        "watch_fallback_reason": refresh.fallback_reason,
+        "watch_budget": state.refresh.watch_budget,
+        "poll_interval_secs": state.refresh.poll_interval.as_secs(),
+        "last_reconcile_at": refresh.last_success,
+        "last_reconcile_duration_ms": refresh.duration_ms,
+        "last_reconcile_error": refresh.error,
+        "reconcile_running": refresh.running,
+        "reconcile_pending": refresh.catch_up,
+        "reconcile_overdue": state.watch_enabled && (refresh.catch_up || refresh.finished.elapsed() >= if state.refresh.polling.load(Ordering::SeqCst) { state.refresh.poll_interval } else { RECONCILE_DEADLINE }),
         "indexing": indexing,
         "index_progress": state.index_progress.load(std::sync::atomic::Ordering::Relaxed),
         "index_total": state.index_total.load(std::sync::atomic::Ordering::Relaxed),
@@ -2092,7 +2160,7 @@ fn handle_reload(id: Option<serde_json::Value>, state: &Arc<ServerState>) -> Str
     replay_deferred_events(state, &state.root);
     schedule_pending_ignore_refresh(state);
 
-    if !state.watch_enabled {
+    if !native_watching(state) {
         #[cfg(test)]
         if membership_changed {
             run_stale_refresh_hook(state, StaleRefreshPhase::BeforeWalk);
@@ -2108,7 +2176,7 @@ fn handle_reload(id: Option<serde_json::Value>, state: &Arc<ServerState>) -> Str
         }
         membership_changed = tracked_membership_changed(state);
     }
-    if state.watch_enabled {
+    if native_watching(state) {
         spawn_recovery_scan(state, &state.root, newly_watched, since);
     }
     schedule_tracked_membership_correction(state, &state.root, membership_changed);
@@ -2319,7 +2387,8 @@ fn recover_watcher_overflow(
     overflowed: &std::sync::atomic::AtomicBool,
     queue_cap: usize,
 ) {
-    if state.indexing.load(Ordering::SeqCst)
+    if !native_watching(state)
+        || state.indexing.load(Ordering::SeqCst)
         || state.gitignore_pending.load(Ordering::SeqCst)
         || !overflowed.swap(false, Ordering::SeqCst)
     {
@@ -2333,9 +2402,82 @@ fn recover_watcher_overflow(
     }
 }
 
+fn native_watching(state: &ServerState) -> bool {
+    state.watch_enabled && !state.refresh.polling.load(Ordering::SeqCst)
+}
+
+fn request_polling(state: &ServerState, reason: String) {
+    if !state.watch_enabled {
+        return;
+    }
+    let mut status = state.refresh.status.lock().unwrap();
+    if state.refresh.polling.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    state.watcher_active.store(false, Ordering::SeqCst);
+    eprintln!(
+        "[trace] switching entirely to polling: {reason}; native watching will not be retried"
+    );
+    status.fallback_reason = Some(reason);
+    status.catch_up = true;
+    state.refresh.wake.notify_all();
+}
+
+fn stop_native_watcher(state: &ServerState) {
+    // Never destroy notify under the registry lock. Its callback only touches
+    // atomics/the bounded channel, so teardown also cannot wait on snapshot_gate.
+    let retired = state.watch_registry.lock().unwrap().take();
+    drop(retired);
+    state.watcher_active.store(false, Ordering::SeqCst);
+}
+
+fn native_capacity_error(error: &notify::Error) -> bool {
+    match &error.kind {
+        notify::ErrorKind::MaxFilesWatch => true,
+        notify::ErrorKind::Io(error) => {
+            #[cfg(unix)]
+            if matches!(
+                error.raw_os_error(),
+                Some(libc::ENOSPC | libc::EMFILE | libc::ENFILE | libc::ENOMEM)
+            ) {
+                return true;
+            }
+            #[cfg(windows)]
+            if matches!(error.raw_os_error(), Some(4 | 8 | 14 | 1450 | 1816)) {
+                return true;
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn watch_failure_reason(error: &notify::Error) -> String {
+    let kind = if native_capacity_error(error) {
+        "native watch capacity exhausted"
+    } else {
+        "native coverage unavailable"
+    };
+    format!("{kind}: {error}")
+}
+
 fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) -> bool {
+    start_file_watcher_using(state, root, queue_cap, notify::recommended_watcher)
+}
+
+fn start_file_watcher_using(
+    state: Arc<ServerState>,
+    root: &Path,
+    queue_cap: usize,
+    create_watcher: impl FnOnce(
+        Box<dyn FnMut(notify::Result<Event>) + Send>,
+    ) -> notify::Result<RecommendedWatcher>,
+) -> bool {
     use std::sync::mpsc::TrySendError;
 
+    if !native_watching(&state) {
+        return false;
+    }
     let root_path = root.to_path_buf();
 
     // Hand events to a worker thread instead of indexing inside the callback.
@@ -2349,45 +2491,54 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
 
     let callback_overflow = Arc::clone(&overflowed);
     let callback_state = Arc::clone(&state);
-    let mut watcher = match notify::recommended_watcher(
-        move |result: std::result::Result<Event, notify::Error>| match result {
-            Ok(event) => match tx.try_send(event) {
-                Ok(()) => {}
-                // Don't block the notification thread waiting for room —
-                // that's the stall this hand-off exists to avoid. Drop the
-                // event and note that we did; the worker reconciles with a
-                // stale check, which is cheaper and more reliable than
-                // trying to replay an unknown number of lost events.
-                Err(TrySendError::Full(_)) => {
+    let mut watcher = match create_watcher(Box::new(
+        move |result: std::result::Result<Event, notify::Error>| {
+            if !native_watching(&callback_state) {
+                return;
+            }
+            match result {
+                Ok(event) => match tx.try_send(event) {
+                    Ok(()) => {}
+                    // Don't block the notification thread waiting for room —
+                    // that's the stall this hand-off exists to avoid. Drop the
+                    // event and note that we did; the worker reconciles with a
+                    // stale check, which is cheaper and more reliable than
+                    // trying to replay an unknown number of lost events.
+                    Err(TrySendError::Full(_)) => {
+                        callback_overflow.store(true, Ordering::SeqCst);
+                        callback_state
+                            .watch_resubscribe
+                            .store(true, Ordering::SeqCst);
+                    }
+                    Err(TrySendError::Disconnected(_)) => {}
+                },
+                // A native drop is the same loss as a full channel, and the OS
+                // will not say what it lost — inotify's `IN_Q_OVERFLOW` and a
+                // dropped `ReadDirectoryChangesW` buffer both arrive here with no
+                // paths attached. Reconcile on them too: reporting without
+                // recovering left exactly one of the two overflow paths handled,
+                // and it was the one the kernel does not use.
+                //
+                // Surfaced as well. A dropped buffer looks exactly like "the
+                // watcher stopped working" from the outside, and silence makes it
+                // impossible to tell apart from a bug in our own filtering.
+                Err(e) => {
+                    eprintln!("[trace] warning: file watcher error: {e}");
+                    if native_capacity_error(&e) {
+                        request_polling(&callback_state, watch_failure_reason(&e));
+                        return;
+                    }
                     callback_overflow.store(true, Ordering::SeqCst);
                     callback_state
                         .watch_resubscribe
                         .store(true, Ordering::SeqCst);
                 }
-                Err(TrySendError::Disconnected(_)) => {}
-            },
-            // A native drop is the same loss as a full channel, and the OS
-            // will not say what it lost — inotify's `IN_Q_OVERFLOW` and a
-            // dropped `ReadDirectoryChangesW` buffer both arrive here with no
-            // paths attached. Reconcile on them too: reporting without
-            // recovering left exactly one of the two overflow paths handled,
-            // and it was the one the kernel does not use.
-            //
-            // Surfaced as well. A dropped buffer looks exactly like "the
-            // watcher stopped working" from the outside, and silence makes it
-            // impossible to tell apart from a bug in our own filtering.
-            Err(e) => {
-                eprintln!("[trace] warning: file watcher error: {e}");
-                callback_overflow.store(true, Ordering::SeqCst);
-                callback_state
-                    .watch_resubscribe
-                    .store(true, Ordering::SeqCst);
             }
         },
-    ) {
+    )) {
         Ok(w) => w,
         Err(e) => {
-            eprintln!("[trace] warning: failed to start file watcher: {e}");
+            request_polling(&state, watch_failure_reason(&e));
             return false;
         }
     };
@@ -2401,8 +2552,11 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
     } else {
         RecursiveMode::Recursive
     };
+    if !native_watching(&state) {
+        return false;
+    }
     if let Err(e) = watcher.watch(root, root_mode) {
-        eprintln!("[trace] warning: failed to watch directory: {e}");
+        request_polling(&state, watch_failure_reason(&e));
         return false;
     }
 
@@ -2410,6 +2564,11 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
         watcher,
         root: root.to_path_buf(),
         watched: std::iter::once(root.to_path_buf()).collect(),
+        budget: state.refresh.watch_budget,
+        failure: None,
+        #[cfg(test)]
+        fail_after: None,
+        polling: Arc::clone(&state.refresh.polling),
     });
 
     // Subscribing to the descendants needs the ignore matcher, and on a warm
@@ -2432,6 +2591,10 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
         spawn_recovery_scan(&state, root, newly_watched, since);
     }
 
+    if !native_watching(&state) {
+        stop_native_watcher(&state);
+        return false;
+    }
     let worker_state = Arc::clone(&state);
     let worker_root = root_path;
     let worker_index_dir = state.index_dir.clone();
@@ -2441,6 +2604,10 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
             let mut last_tracked_index_poll = Instant::now();
             let mut pending_event = None;
             loop {
+                if !native_watching(&worker_state) {
+                    stop_native_watcher(&worker_state);
+                    break;
+                }
                 if last_tracked_index_poll.elapsed() >= TRACKED_INDEX_POLL {
                     last_tracked_index_poll = Instant::now();
                     let changed = poll_tracked_membership_changed(&worker_state);
@@ -2488,17 +2655,17 @@ fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) ->
         })
         .is_err()
     {
-        eprintln!("[trace] warning: failed to start the watcher worker thread");
-        *state.watch_registry.lock().unwrap() = None;
+        request_polling(&state, "failed to start the watcher worker thread".into());
+        stop_native_watcher(&state);
         return false;
     }
 
-    state
-        .watcher_active
-        .store(true, std::sync::atomic::Ordering::Relaxed);
-    eprintln!("[trace] file watcher started");
-
-    true
+    let active = native_watching(&state)
+        && (!PER_DIRECTORY_WATCHES || !state.gitignore_pending.load(Ordering::SeqCst))
+        && state.watch_registry.lock().unwrap().is_some();
+    state.watcher_active.store(active, Ordering::SeqCst);
+    eprintln!("[trace] file watcher worker started (complete native coverage: {active})");
+    active
 }
 
 /// Detect a tracked-file exemption change without subscribing to `.git`.
@@ -2750,6 +2917,11 @@ struct WatchRegistry {
     /// [`WatchRegistry::contained`].
     root: PathBuf,
     watched: std::collections::HashSet<PathBuf>,
+    budget: usize,
+    failure: Option<String>,
+    #[cfg(test)]
+    fail_after: Option<usize>,
+    polling: Arc<std::sync::atomic::AtomicBool>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2784,11 +2956,8 @@ impl WatchRegistry {
     /// Subscribe to every directory in `desired` that is not already
     /// subscribed, leaving existing subscriptions alone.
     ///
-    /// Returns the directories that were newly subscribed to. A single
-    /// directory that cannot be subscribed is reported and skipped rather than
-    /// failing the whole call: the watcher is still useful for everything
-    /// else, and giving up on the entire tree is exactly the failure mode this
-    /// registration exists to avoid.
+    /// Returns newly subscribed directories. On failure registration stops;
+    /// the owner retires the entire registry and requests polling.
     fn add_all<'a>(&mut self, desired: impl IntoIterator<Item = &'a PathBuf>) -> Vec<PathBuf> {
         self.subscribe(desired, false)
     }
@@ -2838,18 +3007,48 @@ impl WatchRegistry {
         desired: impl IntoIterator<Item = &'a PathBuf>,
         force: bool,
     ) -> Vec<PathBuf> {
+        if self.failure.is_some() || self.polling.load(Ordering::SeqCst) {
+            return Vec::new();
+        }
+        let desired: Vec<_> = desired.into_iter().collect();
+        let additional = desired
+            .iter()
+            .filter(|dir| !self.watched.contains(dir.as_path()))
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        if self.watched.len().saturating_add(additional) > self.budget {
+            self.failure = Some(format!(
+                "native watch budget {} exceeded ({} desired subscriptions)",
+                self.budget,
+                self.watched.len().saturating_add(additional)
+            ));
+            return Vec::new();
+        }
         let mut added = Vec::new();
-        let mut failures = 0;
         // Iterating `desired` and testing membership is deliberate: a
         // `difference` would be proportional to the whole watched set, and
         // this runs per newly created directory on repositories where that set
         // is tens of thousands of entries.
         for dir in desired {
+            if self.polling.load(Ordering::SeqCst) {
+                break;
+            }
             let known = self.watched.contains(dir);
             if known && !force {
                 continue;
             }
-            match self.watcher.watch(dir, RecursiveMode::NonRecursive) {
+            #[cfg(test)]
+            let result = if self.fail_after == Some(0) {
+                Err(notify::Error::new(notify::ErrorKind::MaxFilesWatch))
+            } else {
+                if let Some(remaining) = self.fail_after.as_mut() {
+                    *remaining -= 1;
+                }
+                self.watcher.watch(dir, RecursiveMode::NonRecursive)
+            };
+            #[cfg(not(test))]
+            let result = self.watcher.watch(dir, RecursiveMode::NonRecursive);
+            match result {
                 Ok(()) => {
                     // notify's inotify backend registers without
                     // `IN_DONT_FOLLOW`, so the descriptor lands on whatever the
@@ -2891,21 +3090,11 @@ impl WatchRegistry {
                     if known {
                         self.watched.remove(dir);
                     }
-                    // One line per call, not per directory: exhausting the
-                    // inotify budget fails thousands of these at once.
-                    if failures == 0 {
-                        eprintln!(
-                            "[trace] warning: could not watch {}: {e} \
-                             (continuing with the directories that succeeded)",
-                            dir.display()
-                        );
-                    }
-                    failures += 1;
+                    self.failure =
+                        Some(format!("{} ({})", watch_failure_reason(&e), dir.display()));
+                    break;
                 }
             }
-        }
-        if failures > 1 {
-            eprintln!("[trace] warning: {failures} directories could not be watched");
         }
         added
     }
@@ -3132,15 +3321,15 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
     // Before the early returns as well as the walk: a caller that gets no
     // directories back still gets a usable bound.
     let since = SystemTime::now();
-    if !PER_DIRECTORY_WATCHES {
+    if !native_watching(state) || !PER_DIRECTORY_WATCHES {
         return (Vec::new(), since);
     }
-    let mut registry = state.watch_registry.lock().unwrap();
-    let Some(registry) = registry.as_mut() else {
+    let registry = state.watch_registry.lock().unwrap();
+    if registry.is_none() {
         // The watcher has not started yet. It syncs once as it comes up, so
         // there is nothing to do and nothing to remember.
         return (Vec::new(), since);
-    };
+    }
 
     let start = Instant::now();
     let mut desired = {
@@ -3151,11 +3340,59 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
         let sources = state.ignore_sources.read().unwrap();
         desired.dirs.extend(ignore_target_dirs(root, &sources));
     }
+    // Hold the registry through enumeration and application. Startup does not
+    // hold snapshot_gate, and an older complete scan must not prune watches
+    // established by a newer matcher publication or subtree registration.
+    (
+        apply_watch_registrations_locked(state, &desired, start, registry),
+        since,
+    )
+}
+
+#[cfg(test)]
+fn apply_watch_registrations(
+    state: &ServerState,
+    desired: &WatchableDirs,
+    start: Instant,
+) -> Vec<PathBuf> {
+    let registry = state.watch_registry.lock().unwrap();
+    apply_watch_registrations_locked(state, desired, start, registry)
+}
+
+fn apply_watch_registrations_locked(
+    state: &ServerState,
+    desired: &WatchableDirs,
+    start: Instant,
+    mut guard: std::sync::MutexGuard<'_, Option<WatchRegistry>>,
+) -> Vec<PathBuf> {
+    if !native_watching(state) {
+        drop(guard);
+        stop_native_watcher(state);
+        return Vec::new();
+    }
+    let Some(registry) = guard.as_mut() else {
+        return Vec::new();
+    };
     // An incomplete traversal cannot prove that omitted recorded watches are
     // live, so it does not get to consume the overflow repair request.
     let force = take_force_resubscribe(&state.watch_resubscribe, desired.completeness);
     let (added, removed) = registry.sync(&desired.dirs, desired.completeness, force);
     let total = registry.watched.len();
+    let failure = registry.failure.clone().or_else(|| {
+        (desired.completeness == TraversalCompleteness::Incomplete).then(|| {
+            "native coverage traversal was incomplete; some directories could not be inspected"
+                .into()
+        })
+    });
+    drop(guard);
+    if let Some(reason) = failure {
+        request_polling(state, reason);
+    }
+    if !native_watching(state) {
+        stop_native_watcher(state);
+        return Vec::new();
+    }
+    state.watcher_active.store(true, Ordering::SeqCst);
     if !added.is_empty() || removed > 0 {
         eprintln!(
             "[trace] watcher subscriptions: {total} directories \
@@ -3164,7 +3401,7 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
             start.elapsed().as_secs_f64() * 1000.0
         );
     }
-    (added, since)
+    added
 }
 
 /// The first ignore-rules file in `dirs` that the published matcher did not
@@ -3635,6 +3872,9 @@ fn sweep_removed_files(
 /// window is small but it is exactly the one a checkout or a build fills, and
 /// anything lost in it stays invisible until the hourly reconcile.
 fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
+    if !native_watching(state) {
+        return;
+    }
     // `is_dir` follows symlinks; the walker does not. Refuse a symlinked
     // directory here so we never subscribe to, or index, a tree the indexer
     // would not have walked into — and check every level, not just the last,
@@ -3669,8 +3909,8 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
         // exists to avoid — so only the enumeration below runs on those
         // platforms.
         if PER_DIRECTORY_WATCHES {
-            let mut registry = state.watch_registry.lock().unwrap();
-            let Some(registry) = registry.as_mut() else {
+            let mut guard = state.watch_registry.lock().unwrap();
+            let Some(registry) = guard.as_mut() else {
                 return;
             };
             // Additive, not a sync: this covers only the new subtree, and
@@ -3685,6 +3925,15 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
             // watched, but the kernel dropped its descriptor when the original
             // went away.
             registry.resubscribe_all(level.iter());
+            let failure = registry.failure.clone();
+            drop(guard);
+            if let Some(reason) = failure {
+                request_polling(state, reason);
+            }
+            if !native_watching(state) {
+                stop_native_watcher(state);
+                return;
+            }
         }
 
         // The registry lock is released before any `read_dir`, so a large
@@ -3773,6 +4022,11 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
 }
 
 fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
+    // Polling has one refresh authority. Rule churn or a failed native worker
+    // must not create a second, one-second retry loop after the handoff.
+    if state.refresh.polling.load(Ordering::SeqCst) {
+        return;
+    }
     if state
         .ignore_refresh_scheduled
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
@@ -3783,6 +4037,12 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
 
     thread::spawn(move || {
         loop {
+            if state.refresh.polling.load(Ordering::SeqCst) {
+                state
+                    .ignore_refresh_scheduled
+                    .store(false, Ordering::SeqCst);
+                break;
+            }
             if state.ignore_rules_dirty.swap(false, Ordering::SeqCst) {
                 // Wait out a build first. `background_index_build` publishes its
                 // matcher — and so reaches here — while it is still only
@@ -3798,6 +4058,12 @@ fn schedule_ignore_rules_refresh(state: Arc<ServerState>, root: PathBuf) {
                 // still walking the tree the refresh would walk.
                 while state.indexing.load(Ordering::SeqCst) {
                     thread::sleep(Duration::from_millis(200));
+                }
+                if state.refresh.polling.load(Ordering::SeqCst) {
+                    state
+                        .ignore_refresh_scheduled
+                        .store(false, Ordering::SeqCst);
+                    break;
                 }
                 // The stale refresh walks the tree anyway and republishes the
                 // matcher from that walk, so the reload costs one traversal
@@ -3907,6 +4173,9 @@ fn replay_deferred_events(state: &Arc<ServerState>, root: &Path) {
         Ok(mut guard) => guard.replace(std::collections::HashMap::new()),
         Err(_) => return,
     };
+    if state.refresh.polling.load(Ordering::SeqCst) {
+        return;
+    }
     let Some(paths) = deferred else {
         // Overflowed. A stale refresh rewalks the tree and diffs it against the
         // index, which covers every path the replay would have, and it is what
@@ -4011,6 +4280,9 @@ fn spawn_recovery_scan(
     dirs: Vec<PathBuf>,
     since: SystemTime,
 ) {
+    if !native_watching(state) {
+        return;
+    }
     let state = Arc::clone(state);
     let root = root.to_path_buf();
     let spawned = thread::Builder::new()
@@ -4018,6 +4290,9 @@ fn spawn_recovery_scan(
         .spawn(move || {
             while state.indexing.load(Ordering::SeqCst) {
                 thread::sleep(Duration::from_millis(200));
+            }
+            if !native_watching(&state) {
+                return;
             }
             // Before the gate, not under it: this takes `snapshot_gate` for
             // read itself, and std's `RwLock` may deadlock on a recursive read
@@ -4059,7 +4334,7 @@ fn spawn_recovery_scan(
 /// subdirectories would take exactly the per-directory watches that backend
 /// exists to avoid.
 fn recovery_scan_dirs(state: &ServerState, root: &Path, mut dirs: Vec<PathBuf>) -> Vec<PathBuf> {
-    if !PER_DIRECTORY_WATCHES || !state.watch_enabled {
+    if !PER_DIRECTORY_WATCHES || !native_watching(state) {
         return Vec::new();
     }
     if !dirs.iter().any(|d| d == root) {
@@ -4069,6 +4344,9 @@ fn recovery_scan_dirs(state: &ServerState, root: &Path, mut dirs: Vec<PathBuf>) 
 }
 
 fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
+    if state.refresh.polling.load(Ordering::SeqCst) {
+        return;
+    }
     let dominated_kinds = matches!(
         event.kind,
         EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
@@ -4993,6 +5271,9 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
         };
         let removed = extra.remove(rel_path);
         evidence.insert(rel_path.to_string(), current, content_id);
+        if force {
+            evidence.versions.insert(rel_path.to_string(), version);
+        }
         (removed, committed_overlay_id)
     };
     if removed_extra {
@@ -5045,38 +5326,85 @@ fn reconcile_due(since_last: Duration, quiet_for: Duration, busy: bool) -> bool 
 /// Periodically compare the whole tree against the index, so a change the
 /// watcher never heard about cannot stay wrong indefinitely.
 ///
-/// See [`RECONCILE_INTERVAL`] for why this is needed at all. It is deliberately
-/// unhurried: it defers to indexing, to flushing, and to a server that is
-/// being queried, and it does nothing at all on a tree that has not drifted —
-/// the walk finds no differences and returns without touching the index.
+/// Native safety checks retain their quiet-period policy. Polling ignores
+/// search traffic and uses its own completion-based interval; both defer to
+/// indexing/flushing and leave an unchanged index untouched.
 fn periodic_reconcile_loop(state: Arc<ServerState>, root: PathBuf, index_dir: PathBuf) {
-    let mut last = Instant::now();
     loop {
-        thread::sleep(RECONCILE_POLL);
+        scheduled_reconcile(&state, &root, &index_dir);
+        let status = state.refresh.status.lock().unwrap();
+        let busy = state.indexing.load(Ordering::SeqCst)
+            || state.flushing.load(Ordering::SeqCst)
+            || status.running;
+        let wait = if busy {
+            Duration::from_secs(1)
+        } else if status.catch_up {
+            Duration::ZERO
+        } else if state.refresh.polling.load(Ordering::SeqCst) {
+            state
+                .refresh
+                .poll_interval
+                .saturating_sub(status.finished.elapsed())
+        } else {
+            RECONCILE_POLL
+        };
+        // A completion-based cadence avoids overlapping work and catch-up
+        // storms when a scan/merge takes longer than its configured interval.
+        let _ = state
+            .refresh
+            .wake
+            .wait_timeout(status, wait.max(Duration::from_millis(10)))
+            .unwrap();
+    }
+}
 
-        let busy = state.indexing.load(Ordering::SeqCst) || state.flushing.load(Ordering::SeqCst);
-        if !reconcile_due(last.elapsed(), state.quiet_for(), busy) {
-            continue;
+fn scheduled_reconcile(state: &Arc<ServerState>, root: &Path, index_dir: &Path) -> Option<bool> {
+    if !state.watch_enabled {
+        return None;
+    }
+    if !native_watching(state) {
+        stop_native_watcher(state);
+    }
+    {
+        let mut status = state.refresh.status.lock().unwrap();
+        let busy = state.indexing.load(Ordering::SeqCst)
+            || state.flushing.load(Ordering::SeqCst)
+            || status.running;
+        let due = if state.refresh.polling.load(Ordering::SeqCst) {
+            !busy && (status.catch_up || status.finished.elapsed() >= state.refresh.poll_interval)
+        } else {
+            reconcile_due(status.finished.elapsed(), state.quiet_for(), busy)
+        };
+        if !due {
+            return None;
         }
+        status.catch_up = false;
+    }
+    Some(background_refresh_stale(state, root, index_dir, false))
+}
 
-        // Restart the interval before the walk rather than after it. On a large
-        // repository the reconcile itself takes a while, and timing from its
-        // completion would push each one further out than the last.
-        last = Instant::now();
-        eprintln!("[trace] periodic reconcile: looking for changes the watcher missed");
-        // Same comparison the startup check makes, and for the same reason: a
-        // lost event is a stamp that disagrees with the filesystem, a file with
-        // no stamp, or a stamp with no file, and all three fall out of that.
-        // Comparing index *membership* as well would additionally re-add any
-        // file whose stamp says indexed but which the reader does not hold —
-        // a publication bug rather than a lost event, and one that on an hourly
-        // timer would rebuild the whole index every hour if it ever misfired.
-        if !background_refresh_stale(&state, &root, &index_dir, false) {
-            // It declined — an unreadable directory, or a walk that raced a
-            // delete. The index is untouched and correct as far as it goes,
-            // and the next interval tries again.
-            eprintln!("[trace] periodic reconcile: declined, keeping the current index");
-        }
+fn record_reconcile(state: &ServerState, start: Instant, ok: bool) {
+    let mut status = state.refresh.status.lock().unwrap();
+    status.running = false;
+    status.finished = Instant::now();
+    status.duration_ms = Some(start.elapsed().as_millis().try_into().unwrap_or(u64::MAX));
+    if ok {
+        status.last_success = Some(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        );
+        status.error = None;
+    } else {
+        status.error = Some(
+            "reconciliation incomplete; see logs for filesystem or publication errors; will retry"
+                .into(),
+        );
+        eprintln!(
+            "[trace] reconciliation incomplete after {:.1}s; not marking the index fresh",
+            start.elapsed().as_secs_f64()
+        );
     }
 }
 
@@ -5447,6 +5775,27 @@ fn classify_file_changes(
     (changed, added, deleted)
 }
 
+fn classify_evidence_changes(
+    current_meta: &[tgrep_core::walker::FileMeta],
+    old: &tgrep_core::meta::FileEvidence,
+    indexed: &std::collections::HashSet<String>,
+    compare_index_membership: bool,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let (mut changed, added, deleted) =
+        classify_file_changes(current_meta, &old.stamps, indexed, compare_index_membership);
+    let already_changed: std::collections::HashSet<_> =
+        changed.iter().chain(&added).cloned().collect();
+    for file in current_meta {
+        if !already_changed.contains(&file.relative_path)
+            && (file.version.is_none()
+                || old.versions.get(&file.relative_path) != file.version.as_ref())
+        {
+            changed.push(file.relative_path.clone());
+        }
+    }
+    (changed, added, deleted)
+}
+
 struct StaleMergePolicy<'a> {
     preserved: &'a std::collections::HashSet<String>,
     operation: &'a str,
@@ -5612,9 +5961,15 @@ fn stream_merge_stale_changes(
             );
         }
         for path in &candidates {
-            published_evidence.content_ids.remove(path);
+            published_evidence.remove(path);
         }
         published_evidence.content_ids.extend(outcome.content_ids);
+        for (path, version) in outcome.versions {
+            published_evidence
+                .stamps
+                .insert(path.clone(), version.stamp().clone());
+            published_evidence.versions.insert(path, version);
+        }
 
         let delta = tgrep_core::reader::IndexReader::open(&delta_dir)?;
         if delta.num_files() != delta_count {
@@ -5788,6 +6143,17 @@ fn background_refresh_stale(
     compare_index_membership: bool,
 ) -> bool {
     let refresh = state.stale_refresh_lock.lock().unwrap();
+    let attempt = Instant::now();
+    {
+        let mut status = state.refresh.status.lock().unwrap();
+        status.running = true;
+        if state.refresh.polling.load(Ordering::SeqCst) {
+            status.catch_up = false;
+        }
+    }
+    if state.refresh.polling.load(Ordering::SeqCst) {
+        state.ignore_rules_dirty.store(false, Ordering::SeqCst);
+    }
     // Keep watcher/auto-save mutations out for the complete walk → matcher →
     // merge → recovery cycle. Search queries do not take this gate and remain
     // available. Held here rather than inside so the recovery scan below is
@@ -5831,14 +6197,49 @@ fn background_refresh_stale(
     // this pass used A throughout, while A→B schedules exactly one coalesced
     // refresh. Content-only staging cannot create an immediate refresh loop.
     let membership_changed = tracked_membership_changed(state);
+    let complete = ok
+        && state.unreadable.read().unwrap().is_empty()
+        && !state.filename_index_dirty.load(Ordering::SeqCst);
+    record_reconcile(state, attempt, complete);
     drop(gate);
     drop(refresh);
     schedule_tracked_membership_correction(state, root, membership_changed);
-    ok
+    if state.refresh.polling.load(Ordering::SeqCst) {
+        complete
+    } else {
+        ok
+    }
+}
+
+fn startup_refresh_stale(state: &Arc<ServerState>, root: &Path, index_dir: &Path) -> bool {
+    let mut retry_delay = Duration::from_secs(1);
+    loop {
+        let ok = background_refresh_stale(state, root, index_dir, false);
+        if ok || state.refresh.polling.load(Ordering::SeqCst) {
+            return ok;
+        }
+        eprintln!(
+            "[trace] stale check: retrying in {:.0}s",
+            retry_delay.as_secs_f64()
+        );
+        thread::sleep(retry_delay);
+        if state.refresh.polling.load(Ordering::SeqCst) {
+            return false;
+        }
+        retry_delay = (retry_delay * 2).min(Duration::from_secs(30));
+    }
 }
 
 fn catch_up_unwatched_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path) -> bool {
     let refresh = state.stale_refresh_lock.lock().unwrap();
+    let attempt = Instant::now();
+    {
+        let mut status = state.refresh.status.lock().unwrap();
+        status.running = true;
+        if state.refresh.polling.load(Ordering::SeqCst) {
+            status.catch_up = false;
+        }
+    }
     let gate = state.snapshot_gate.write().unwrap();
     let ignorecase = frozen_tracked_membership(state, root);
     let mut ignored_watches = Vec::new();
@@ -5852,10 +6253,18 @@ fn catch_up_unwatched_build(state: &Arc<ServerState>, root: &Path, index_dir: &P
         false,
     );
     let membership_changed = tracked_membership_changed(state);
+    let complete = caught_up
+        && state.unreadable.read().unwrap().is_empty()
+        && !state.filename_index_dirty.load(Ordering::SeqCst);
+    record_reconcile(state, attempt, complete);
     drop(gate);
     drop(refresh);
     schedule_tracked_membership_correction(state, root, membership_changed);
-    caught_up
+    if state.refresh.polling.load(Ordering::SeqCst) {
+        complete
+    } else {
+        caught_up
+    }
 }
 
 fn refresh_stale_locked(
@@ -5931,6 +6340,16 @@ fn refresh_stale_locked(
     }
     let current_meta = &walk.files;
     let listed_files = &walk.listed_files;
+    {
+        let mut unreadable = state.unreadable.write().unwrap();
+        if !unreadable.is_empty() {
+            let present: std::collections::HashSet<_> = current_meta
+                .iter()
+                .map(|file| file.relative_path.as_str())
+                .collect();
+            unreadable.retain(|path, _| present.contains(path.as_str()));
+        }
+    }
 
     // Load stored per-file stamps from last index write
     let mut old_evidence = match meta::read_file_evidence(index_dir) {
@@ -5949,9 +6368,16 @@ fn refresh_stale_locked(
     // on-disk stamps nor the filesystem, so it would never be classified as
     // deleted and would linger in the index. The in-memory stamps are the
     // fresher record of what the index actually holds, so they win.
-    for (path, stamp) in &state.file_evidence.read().unwrap().stamps {
+    let current_evidence = state.file_evidence.read().unwrap();
+    for (path, stamp) in &current_evidence.stamps {
         old_evidence.stamps.insert(path.clone(), stamp.clone());
+        if let Some(version) = current_evidence.versions.get(path) {
+            old_evidence.versions.insert(path.clone(), version.clone());
+        } else {
+            old_evidence.versions.remove(path);
+        }
     }
+    drop(current_evidence);
     let indexed_paths = {
         let index = state.index.read().unwrap();
         let mut paths = index.reader_paths();
@@ -5964,9 +6390,9 @@ fn refresh_stale_locked(
         return true;
     }
 
-    let (mut changed, mut added, deleted) = classify_file_changes(
+    let (mut changed, mut added, deleted) = classify_evidence_changes(
         current_meta,
-        &old_evidence.stamps,
+        &old_evidence,
         &indexed_paths,
         compare_index_membership,
     );
@@ -5976,8 +6402,12 @@ fn refresh_stale_locked(
     // makes every scheduled reconcile rebuild the index. `deleted` is exempt —
     // a file that is gone needs no read to evict.
     let skipped_unreadable = {
-        let memo = state.unreadable.read().unwrap();
-        drop_memoized_failures(&memo, current_meta, &mut changed, &mut added)
+        if state.refresh.polling.load(Ordering::SeqCst) {
+            std::collections::HashSet::new()
+        } else {
+            let memo = state.unreadable.read().unwrap();
+            drop_memoized_failures(&memo, current_meta, &mut changed, &mut added)
+        }
     };
     if !skipped_unreadable.is_empty() {
         eprintln!(
@@ -6016,6 +6446,14 @@ fn refresh_stale_locked(
 
     let new_stamps = stamps_for_indexed(current_meta, &skipped_unreadable);
     let mut new_evidence = tgrep_core::meta::FileEvidence::from_stamps(new_stamps);
+    // Unchanged paths keep their prior read-bound evidence, not metadata from
+    // this newer scan. Changed paths are replaced with the delta's read versions.
+    new_evidence.versions.extend(
+        old_evidence
+            .versions
+            .into_iter()
+            .filter(|(path, _)| new_evidence.stamps.contains_key(path)),
+    );
     {
         let current_evidence = state.file_evidence.read().unwrap();
         new_evidence.content_ids.extend(
@@ -6359,6 +6797,15 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             .map(|(path, id)| (path.clone(), *id))
             .collect()
     };
+    let mut versions: std::collections::HashMap<String, builder::FileVersion> = state
+        .file_evidence
+        .read()
+        .unwrap()
+        .versions
+        .iter()
+        .filter(|(path, _)| skip_paths.contains(path.as_str()))
+        .map(|(path, version)| (path.clone(), version.clone()))
+        .collect();
 
     // Nothing indexed yet: build straight to disk with bounded memory instead
     // of accumulating the whole repo in the live overlay. Resuming a partial
@@ -6481,7 +6928,35 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             batch
                 .par_iter()
                 .filter_map(|path| {
-                    let data = std::fs::read(path).ok()?;
+                    let read = (|| -> Result<_> {
+                        let mut file = open_within_root(root, path)?;
+                        let version = builder::file_version(&file.metadata()?);
+                        let data = match read_within_limit(
+                            &mut file,
+                            state.max_file_size,
+                            version.stamp().size.min(1 << 20) as usize,
+                        ) {
+                            CappedRead::Data(data) => data,
+                            CappedRead::TooLarge => {
+                                anyhow::bail!("file grew past the configured size limit")
+                            }
+                            CappedRead::Failed => anyhow::bail!("file read failed"),
+                        };
+                        if !file_still_has_bytes(root, path, &version, &data)? {
+                            anyhow::bail!("file changed during indexing");
+                        }
+                        Ok((data, version))
+                    })();
+                    let (data, version) = match read {
+                        Ok(read) => read,
+                        Err(error) => {
+                            eprintln!(
+                                "[trace] warning: could not index {}: {error}",
+                                path.display()
+                            );
+                            return None;
+                        }
+                    };
                     let data = tgrep_core::encoding::decode_for_index(&data);
                     if tgrep_core::trigram::is_binary(&data) {
                         return None;
@@ -6498,12 +6973,11 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
                         trigrams.extend(tgrep_core::trigram::extract(&lower));
                     }
                     let content_id = tgrep_core::meta::ContentId::from_indexed_bytes(&data);
-                    Some((rel_path, trigrams, content_id))
+                    Some((rel_path, trigrams, content_id, version))
                 })
-                .collect::<Vec<(String, Vec<u32>, tgrep_core::meta::ContentId)>>()
+                .collect::<Vec<_>>()
         };
-        let batch_results: Vec<(String, Vec<u32>, tgrep_core::meta::ContentId)> = match &index_pool
-        {
+        let batch_results = match &index_pool {
             Some(pool) => pool.install(extract),
             None => extract(),
         };
@@ -6511,8 +6985,9 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         // Sequential: insert into LiveIndex (brief write lock per batch)
         {
             let mut index = state.index.write().unwrap();
-            for (rel_path, trigrams, content_id) in batch_results {
+            for (rel_path, trigrams, content_id, version) in batch_results {
                 index.live.upsert_file_with_trigrams(&rel_path, trigrams);
+                versions.insert(rel_path.clone(), version);
                 content_ids.insert(rel_path, content_id);
             }
         }
@@ -6620,7 +7095,16 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         };
         stamps_for_index_members(walk_meta.files, &indexed)
     };
-    let evidence = complete_file_evidence(stamps, content_ids);
+    let mut evidence = complete_file_evidence(stamps, content_ids);
+    evidence.retain(|path, _| versions.contains_key(path));
+    for (path, version) in versions {
+        if evidence.stamps.contains_key(&path) {
+            evidence
+                .stamps
+                .insert(path.clone(), version.stamp().clone());
+            evidence.versions.insert(path, version);
+        }
+    }
 
     // The in-memory build is done — surface "complete" in status now even
     // though the final disk flush below can take minutes for very large
@@ -7771,10 +8255,111 @@ mod tests {
         assert_eq!(byte_limited.byte_len(), 0);
     }
 
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn subscription_snapshot_holds_registry_until_its_application() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let state = test_server_state(&root, &root.join(".tgrep"));
+        *state.watch_registry.lock().unwrap() = Some(WatchRegistry {
+            watcher: notify::recommended_watcher(|_: notify::Result<Event>| {}).unwrap(),
+            root: root.clone(),
+            watched: Default::default(),
+            budget: 8192,
+            failure: None,
+            fail_after: None,
+            polling: Arc::clone(&state.refresh.polling),
+        });
+        // Pause enumeration at its matcher read. The registry must remain
+        // locked so a newer subscription set cannot overtake this snapshot.
+        let matcher = state.gitignore.write().unwrap();
+        let worker_state = Arc::clone(&state);
+        let worker_root = root.clone();
+        let worker = thread::spawn(move || sync_watch_registrations(&worker_state, &worker_root));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut held = false;
+        while Instant::now() < deadline {
+            if matches!(
+                state.watch_registry.try_lock(),
+                Err(std::sync::TryLockError::WouldBlock)
+            ) {
+                held = true;
+                break;
+            }
+            thread::yield_now();
+        }
+        drop(matcher);
+        worker.join().unwrap();
+        stop_native_watcher(&state);
+        assert!(
+            held,
+            "subscription enumeration released its registry snapshot"
+        );
+    }
+
+    #[test]
+    fn failed_polling_startup_hands_retries_to_the_configured_cadence() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("missing");
+        let index_dir = tmp.path().join("index");
+        let mut state = test_server_state(&root, &index_dir);
+        Arc::get_mut(&mut state).unwrap().refresh =
+            RefreshControl::new(WatchMode::Poll, Duration::from_secs(120), 8192);
+        let worker_state = Arc::clone(&state);
+        let worker_root = root.clone();
+        let worker_index = index_dir.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let worker = thread::spawn(move || {
+            tx.send(startup_refresh_stale(
+                &worker_state,
+                &worker_root,
+                &worker_index,
+            ))
+            .unwrap();
+        });
+        assert!(
+            !rx.recv_timeout(Duration::from_secs(5))
+                .expect("startup kept its own polling retry loop")
+        );
+        worker.join().unwrap();
+        assert!(state.refresh.status.lock().unwrap().error.is_some());
+        assert_eq!(scheduled_reconcile(&state, &root, &index_dir), None);
+    }
+
+    #[test]
+    fn a_complete_poll_forgets_an_unindexed_read_failure_that_disappeared() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let index_dir = root.join(".tgrep");
+        let mut state = test_server_state(&root, &index_dir);
+        Arc::get_mut(&mut state).unwrap().refresh =
+            RefreshControl::new(WatchMode::Poll, Duration::from_secs(120), 8192);
+        let vanished = root.join("vanished.rs");
+        std::fs::write(&vanished, "vanishing_poll_marker").unwrap();
+        let removed = std::sync::atomic::AtomicBool::new(false);
+        *state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+            if matches!(phase, StaleRefreshPhase::AfterMatcherPublish)
+                && !removed.swap(true, Ordering::SeqCst)
+            {
+                std::fs::remove_file(&vanished).unwrap();
+            }
+        }));
+        assert_eq!(scheduled_reconcile(&state, &root, &index_dir), Some(false));
+        assert!(state.unreadable.read().unwrap().contains_key("vanished.rs"));
+        *state.stale_refresh_hook.lock().unwrap() = None;
+        state.refresh.status.lock().unwrap().finished =
+            Instant::now() - state.refresh.poll_interval;
+        assert_eq!(scheduled_reconcile(&state, &root, &index_dir), Some(true));
+        assert!(state.unreadable.read().unwrap().is_empty());
+        let status = state.refresh.status.lock().unwrap();
+        assert!(status.error.is_none());
+        assert!(status.last_success.is_some());
+    }
+
     /// A `ServerState` over an empty index, for exercising the stale path
     /// directly. Mirrors the defaults `run` uses with a watcher and ignore
     /// rules enabled, which is the configuration `gitignore_pending` gates.
-    fn test_server_state(root: &Path, index_dir: &Path) -> Arc<ServerState> {
+    pub(super) fn test_server_state(root: &Path, index_dir: &Path) -> Arc<ServerState> {
         create_empty_index(index_dir).expect("create empty index");
         let hybrid = HybridIndex::open(index_dir, root).expect("open empty index");
         Arc::new(ServerState {
@@ -7809,6 +8394,7 @@ mod tests {
             index_progress: std::sync::atomic::AtomicU64::new(0),
             index_total: std::sync::atomic::AtomicU64::new(0),
             watch_enabled: true,
+            refresh: RefreshControl::new(WatchMode::Auto, Duration::from_secs(120), 8192),
             watch_registry: Mutex::new(None),
             exclude_dirs: Vec::new(),
             no_ignore: false,
@@ -8314,6 +8900,10 @@ mod tests {
             watcher,
             root: tmp.path().to_path_buf(),
             watched: std::collections::HashSet::new(),
+            budget: 8192,
+            failure: None,
+            fail_after: None,
+            polling: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         let added = registry.add_all(&[a.clone(), b.clone()]);
@@ -8387,6 +8977,10 @@ mod tests {
             watcher,
             root: tmp.path().to_path_buf(),
             watched: std::collections::HashSet::new(),
+            budget: 8192,
+            failure: None,
+            fail_after: None,
+            polling: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         assert_eq!(registry.add_all(std::slice::from_ref(&a)).len(), 1);
 
@@ -8915,6 +9509,10 @@ mod tests {
                 watcher,
                 root: root.clone(),
                 watched: std::iter::once(root.clone()).collect(),
+                budget: 8192,
+                failure: None,
+                fail_after: None,
+                polling: Arc::clone(&state.refresh.polling),
             });
         }
 
@@ -9130,6 +9728,10 @@ mod tests {
                 watcher,
                 root: root.clone(),
                 watched: std::iter::once(root.clone()).collect(),
+                budget: 8192,
+                failure: None,
+                fail_after: None,
+                polling: Arc::clone(&state.refresh.polling),
             });
         }
 
@@ -10505,11 +11107,13 @@ mod tests {
                 relative_path: "kept.txt".to_string(),
                 mtime: 1,
                 size: 10,
+                version: None,
             },
             FileMeta {
                 relative_path: "newly-unignored.txt".to_string(),
                 mtime: 2,
                 size: 20,
+                version: None,
             },
         ];
         let stamps = HashMap::from([
@@ -10536,6 +11140,7 @@ mod tests {
             relative_path: "case.txt".to_string(),
             mtime: 1,
             size: 10,
+            version: None,
         }];
         let indexed = HashSet::from(["Case.txt".to_string(), "reader-only.txt".to_string()]);
 
@@ -10595,6 +11200,7 @@ mod tests {
                 relative_path: "locked.bin".to_string(),
                 mtime,
                 size,
+                version: None,
             }];
             let (mut changed, mut added, _) = classify_file_changes(
                 &current,
@@ -10635,11 +11241,13 @@ mod tests {
                 relative_path: "locked.bin".to_string(),
                 mtime: 100,
                 size: 5,
+                version: None,
             },
             FileMeta {
                 relative_path: "src/main.rs".to_string(),
                 mtime: 100,
                 size: 9,
+                version: None,
             },
         ];
         let memo = std::collections::HashMap::from([(
@@ -11901,6 +12509,10 @@ mod tests {
             watcher,
             root: root.clone(),
             watched: std::iter::once(root.clone()).collect(),
+            budget: 8192,
+            failure: None,
+            fail_after: None,
+            polling: Arc::clone(&state.refresh.polling),
         });
 
         let _gate = state.snapshot_gate.read().unwrap();
@@ -11929,11 +12541,13 @@ mod tests {
                 relative_path: "indexed.rs".to_string(),
                 mtime: 1,
                 size: 10,
+                version: None,
             },
             FileMeta {
                 relative_path: "arrived_between_the_walks.rs".to_string(),
                 mtime: 2,
                 size: 20,
+                version: None,
             },
         ];
         let indexed = std::iter::once("indexed.rs".to_string()).collect();
@@ -12101,6 +12715,10 @@ mod tests {
             watcher,
             root: root.clone(),
             watched: std::collections::HashSet::new(),
+            budget: 8192,
+            failure: None,
+            fail_after: None,
+            polling: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         let desired: std::collections::HashSet<PathBuf> = [
@@ -12139,6 +12757,10 @@ mod tests {
             watcher,
             root: root.clone(),
             watched: std::collections::HashSet::new(),
+            budget: 8192,
+            failure: None,
+            fail_after: None,
+            polling: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         assert_eq!(registry.add_all(std::slice::from_ref(&gone)).len(), 1);
 
@@ -12180,6 +12802,10 @@ mod tests {
             watcher,
             root: root.clone(),
             watched: std::iter::once(root.clone()).collect(),
+            budget: 8192,
+            failure: None,
+            fail_after: None,
+            polling: Arc::clone(&state.refresh.polling),
         });
 
         // Built somewhere else and moved in, so no event ever described its

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -5213,6 +5213,12 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
     let Some(per_tri) = per_tri else {
         eprintln!("[trace] reindex: modified {rel_path}");
         mark_filename_only(state, rel_path);
+        state.file_evidence.write().unwrap().insert_verified(
+            rel_path.to_string(),
+            current,
+            None,
+            Some(version),
+        );
         return;
     };
 
@@ -5584,7 +5590,7 @@ fn create_empty_index(index_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Stamps for the walked files that are actually in the index.
+/// Stamps for walked files that were indexed or verified as content-binary.
 ///
 /// The build stamps its work from a *second* traversal, taken after the content
 /// walk that fed the index, so a file created between the two appears here and
@@ -6937,22 +6943,24 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
                         }
                     };
                     let data = tgrep_core::encoding::decode_for_index(&data);
-                    if tgrep_core::trigram::is_binary(&data) {
-                        return None;
-                    }
                     let rel_path = path
                         .strip_prefix(root)
                         .unwrap_or(path)
                         .to_string_lossy()
                         .replace('\\', "/");
 
-                    let mut trigrams = tgrep_core::trigram::extract(&data);
-                    let lower = data.to_ascii_lowercase();
-                    if lower != *data {
-                        trigrams.extend(tgrep_core::trigram::extract(&lower));
-                    }
-                    let content_id = tgrep_core::meta::ContentId::from_indexed_bytes(&data);
-                    Some((rel_path, trigrams, content_id, version))
+                    let content = if tgrep_core::trigram::is_binary(&data) {
+                        None
+                    } else {
+                        let mut trigrams = tgrep_core::trigram::extract(&data);
+                        let lower = data.to_ascii_lowercase();
+                        if lower != *data {
+                            trigrams.extend(tgrep_core::trigram::extract(&lower));
+                        }
+                        let content_id = tgrep_core::meta::ContentId::from_indexed_bytes(&data);
+                        Some((trigrams, content_id))
+                    };
+                    Some((rel_path, content, version))
                 })
                 .collect::<Vec<_>>()
         };
@@ -6964,10 +6972,12 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         // Sequential: insert into LiveIndex (brief write lock per batch)
         {
             let mut index = state.index.write().unwrap();
-            for (rel_path, trigrams, content_id, version) in batch_results {
-                index.live.upsert_file_with_trigrams(&rel_path, trigrams);
+            for (rel_path, content, version) in batch_results {
                 versions.insert(rel_path.clone(), version);
-                content_ids.insert(rel_path, content_id);
+                if let Some((trigrams, content_id)) = content {
+                    index.live.upsert_file_with_trigrams(&rel_path, trigrams);
+                    content_ids.insert(rel_path, content_id);
+                }
             }
         }
 
@@ -7070,6 +7080,13 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
             let index = state.index.read().unwrap();
             let mut paths = index.reader_paths();
             paths.extend(index.live.overlay_paths());
+            // Verified binary classifications have evidence but no content postings.
+            paths.extend(
+                versions
+                    .keys()
+                    .filter(|path| !content_ids.contains_key(path.as_str()))
+                    .cloned(),
+            );
             paths
         };
         stamps_for_index_members(walk_meta.files, &indexed)

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -645,8 +645,7 @@ struct ServerState {
     /// save. Higher values reduce save frequency (and the pauses they cause)
     /// at the cost of more unsaved work if the process is killed.
     auto_save_mutations: u32,
-    /// Files a delta build could not read, and the metadata they had when it
-    /// tried.
+    /// Files a delta build could not read, and their preceding scan versions.
     ///
     /// A file that fails to read has its stamp withheld so the next reconcile
     /// retries it rather than recording it as indexed. That is right for a
@@ -655,12 +654,11 @@ struct ServerState {
     /// time, and with a reconcile on a timer it would rewrite the whole index
     /// once an hour forever to re-attempt a file that will fail again.
     ///
-    /// Remembering the metadata of the attempt separates the two. A file whose
-    /// mtime and size have not moved since it failed is not worth another
-    /// read; one that has changed gets a fresh look. The record lives in
-    /// memory, so restarting the server retries everything — which is the
-    /// escape hatch for a file made readable without being modified.
-    unreadable: RwLock<std::collections::HashMap<String, tgrep_core::meta::FileStamp>>,
+    /// Only a matching precise version suppresses another native read. Unknown
+    /// versions remain retryable; polling retries failures on every interval.
+    /// The record lives in memory, so a restart also retries files whose access
+    /// changed without changing their metadata.
+    unreadable: RwLock<std::collections::HashMap<String, Option<tgrep_core::meta::FileVersion>>>,
     /// Reference point for [`ServerState::quiet_for`], because an `Instant`
     /// cannot live in an atomic.
     started: Instant,
@@ -5425,6 +5423,7 @@ fn persist_pending_index_changes(state: &Arc<ServerState>) -> bool {
                 operation: "auto-save",
                 authoritative_membership: false,
                 authoritative_listed_files: None,
+                scanned_files: &[],
             },
         );
     }
@@ -5800,6 +5799,8 @@ struct StaleMergePolicy<'a> {
     operation: &'a str,
     authoritative_membership: bool,
     authoritative_listed_files: Option<&'a [String]>,
+    /// Pre-read scan metadata for failure memoization, never indexed evidence.
+    scanned_files: &'a [tgrep_core::walker::FileMeta],
 }
 
 /// Apply a stale diff without materializing the existing index in heap.
@@ -5829,6 +5830,7 @@ fn stream_merge_stale_changes(
         operation,
         authoritative_membership,
         authoritative_listed_files,
+        scanned_files,
     } = policy;
     let stamps = &evidence.stamps;
     let root = &state.root;
@@ -5921,14 +5923,13 @@ fn stream_merge_stale_changes(
         // would hide it from every later reconcile and make the miss permanent.
         // Dropping the stamp leaves it looking new, so the next pass retries it.
         //
-        // Record what the file looked like when it failed, so a permanent
-        // failure is retried when the file changes rather than on every pass.
-        // See `ServerState::unreadable`.
+        // Memoize the preceding scan version, not old indexed evidence or a
+        // later stat that could describe a file we never tried to read.
         let unreadable = {
             let mut memo = state.unreadable.write().unwrap();
             // Anything this delta was asked to build is settled: either it was
             // read, or it is in `outcome.unreadable` and re-recorded below.
-            for path in changed.iter().chain(added).chain(deleted) {
+            for path in &candidates {
                 memo.remove(path);
             }
             let mut unreadable = std::collections::HashSet::new();
@@ -5939,8 +5940,17 @@ fn stream_merge_stale_changes(
                     .to_string_lossy()
                     .replace('\\', "/");
                 unreadable.insert(rel.clone());
-                if let Some(stamp) = published_evidence.remove(&rel) {
-                    memo.insert(rel, stamp);
+                published_evidence.remove(&rel);
+                memo.insert(rel, None);
+            }
+            if !unreadable.is_empty() {
+                for file in scanned_files {
+                    if unreadable.contains(&file.relative_path) {
+                        memo.insert(
+                            file.relative_path.clone(),
+                            file.version.clone().filter(|version| version.is_trusted()),
+                        );
+                    }
                 }
             }
             unreadable
@@ -6079,7 +6089,7 @@ fn stream_merge_stale_changes(
 /// Returns the paths removed, which the caller must also keep out of the
 /// published stamps — see [`stamps_for_indexed`].
 fn drop_memoized_failures(
-    memo: &std::collections::HashMap<String, tgrep_core::meta::FileStamp>,
+    memo: &std::collections::HashMap<String, Option<tgrep_core::meta::FileVersion>>,
     current_meta: &[tgrep_core::walker::FileMeta],
     changed: &mut Vec<String>,
     added: &mut Vec<String>,
@@ -6092,8 +6102,12 @@ fn drop_memoized_failures(
     let still_failing: std::collections::HashSet<String> = current_meta
         .iter()
         .filter(|fm| {
-            memo.get(&fm.relative_path)
-                .is_some_and(|a| a.mtime == fm.mtime && a.size == fm.size)
+            fm.version
+                .as_ref()
+                .filter(|version| version.is_trusted())
+                .is_some_and(|version| {
+                    memo.get(&fm.relative_path).and_then(Option::as_ref) == Some(version)
+                })
         })
         .map(|fm| fm.relative_path.clone())
         .collect();
@@ -6509,6 +6523,7 @@ fn refresh_stale_locked(
             operation: "stale check",
             authoritative_membership: true,
             authoritative_listed_files: Some(listed_files),
+            scanned_files: current_meta,
         },
     ) {
         return false;
@@ -9276,6 +9291,7 @@ mod tests {
                     operation: "test stale check",
                     authoritative_membership: true,
                     authoritative_listed_files: Some(&listed_files),
+                    scanned_files: &[],
                 },
             ));
         }
@@ -9318,6 +9334,7 @@ mod tests {
                     operation: "test retry",
                     authoritative_membership: true,
                     authoritative_listed_files: None,
+                    scanned_files: &[],
                 },
             ));
         }
@@ -9400,6 +9417,7 @@ mod tests {
                     operation: "test evidence merge",
                     authoritative_membership: true,
                     authoritative_listed_files: None,
+                    scanned_files: &[],
                 },
             ));
         }
@@ -11223,6 +11241,16 @@ mod tests {
         assert!(!reconcile_due(RECONCILE_DEADLINE, long_quiet, true));
     }
 
+    fn file_meta_with_version(path: &Path, relative_path: &str) -> tgrep_core::walker::FileMeta {
+        let version = tgrep_core::meta::file_version(&std::fs::metadata(path).unwrap());
+        tgrep_core::walker::FileMeta {
+            relative_path: relative_path.to_string(),
+            mtime: version.stamp().mtime,
+            size: version.stamp().size,
+            version: Some(version),
+        }
+    }
+
     /// A file that cannot be read must not make every reconcile rebuild.
     ///
     /// Its stamp is deliberately withheld so it looks new and gets retried.
@@ -11231,24 +11259,18 @@ mod tests {
     /// hour, forever, to re-attempt a read that fails the same way each time.
     #[test]
     fn a_file_that_stays_unreadable_is_not_retried_until_it_changes() {
-        use tgrep_core::meta::FileStamp;
         use tgrep_core::walker::FileMeta;
 
-        let memo = std::collections::HashMap::from([(
-            "locked.bin".to_string(),
-            FileStamp {
-                mtime: 100,
-                size: 5,
-            },
-        )]);
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("locked.bin");
+        std::fs::write(&path, b"12345").unwrap();
+        let modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+        let initial = file_meta_with_version(&path, "locked.bin");
+        let memo =
+            std::collections::HashMap::from([("locked.bin".to_string(), initial.version.clone())]);
 
-        let retried = |mtime: u64, size: u64| {
-            let current = vec![FileMeta {
-                relative_path: "locked.bin".to_string(),
-                mtime,
-                size,
-                version: None,
-            }];
+        let retried = |file: FileMeta| {
+            let current = vec![file];
             let (mut changed, mut added, _) = classify_file_changes(
                 &current,
                 &std::collections::HashMap::new(),
@@ -11260,11 +11282,24 @@ mod tests {
         };
 
         // Unchanged since the failed read: leave it alone.
-        assert_eq!(retried(100, 5).0, 0);
+        assert_eq!(retried(initial).0, 0);
         // Touched: worth another look.
-        assert_eq!(retried(200, 5).0, 1);
+        File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(modified + Duration::from_secs(100)))
+            .unwrap();
+        assert_eq!(retried(file_meta_with_version(&path, "locked.bin")).0, 1);
         // Resized: likewise.
-        assert_eq!(retried(100, 6).0, 1);
+        std::fs::write(&path, b"123456").unwrap();
+        File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(modified))
+            .unwrap();
+        assert_eq!(retried(file_meta_with_version(&path, "locked.bin")).0, 1);
     }
 
     /// Skipping a file must not also mark it indexed.
@@ -11280,29 +11315,19 @@ mod tests {
     /// deleting the index.
     #[test]
     fn a_skipped_file_is_left_unstamped_so_the_next_pass_still_sees_it() {
-        use tgrep_core::meta::FileStamp;
-        use tgrep_core::walker::FileMeta;
-
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("locked.bin"), b"12345").unwrap();
+        std::fs::create_dir(root.join("src")).unwrap();
+        let source = root.join("src").join("main.rs");
+        std::fs::write(&source, b"fn main()").unwrap();
         let current = vec![
-            FileMeta {
-                relative_path: "locked.bin".to_string(),
-                mtime: 100,
-                size: 5,
-                version: None,
-            },
-            FileMeta {
-                relative_path: "src/main.rs".to_string(),
-                mtime: 100,
-                size: 9,
-                version: None,
-            },
+            file_meta_with_version(&root.join("locked.bin"), "locked.bin"),
+            file_meta_with_version(&source, "src/main.rs"),
         ];
         let memo = std::collections::HashMap::from([(
             "locked.bin".to_string(),
-            FileStamp {
-                mtime: 100,
-                size: 5,
-            },
+            current[0].version.clone(),
         )]);
 
         let (mut changed, mut added, _) = classify_file_changes(

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -28,6 +28,10 @@ use tgrep_core::query;
 #[path = "serve/poll_tests.rs"]
 mod poll_tests;
 
+#[cfg(test)]
+#[path = "serve/recovery_tests.rs"]
+mod recovery_tests;
+
 const CACHE_CAPACITY: usize = 50_000;
 /// Total decoded bytes the content cache may hold. The entry-count limit above
 /// says nothing about memory; without this a handful of large files can pin
@@ -3501,8 +3505,9 @@ fn changed_ignore_rules_in(
 /// dropping the ones that are gone, and subscribing to subdirectories that
 /// appeared while the subscriptions were being established.
 /// Used to close the gap between a walk and the subscriptions that follow it:
-/// [`reindex_file`] compares stamps first, so for a tree that did not change
-/// under us this costs one `metadata` call per file and indexes nothing.
+/// [`reindex_file`] compares verified file versions first, so a tree with
+/// unchanged, trusted evidence costs one `metadata` call per file and indexes
+/// nothing.
 ///
 /// `since` is when the walk behind `dirs` began — the start of the window this
 /// is closing. It is only consulted for ignore-rules files, where "did this
@@ -5009,8 +5014,9 @@ fn content_id_matches(
     decoded.is_some() && trusted == decoded
 }
 
-/// Read a file and merge it into the live index, unless its stamp says the
-/// content we already indexed is current.
+/// Read a file and merge it into the live index, unless its verified version
+/// says the content we already indexed is current. Concrete events force a
+/// read even when metadata matches; both paths validate bytes before publishing.
 ///
 /// The caller must hold `snapshot_gate`: the read, the commit, and the stamp
 /// update have to be atomic with respect to a flush or auto-save.
@@ -5042,16 +5048,12 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
             // because a build held the file open for a moment. The stale path
             // already treats unreadable files this way, keeping what it has and
             // retrying later, and the watcher should not disagree with it.
-            if force {
-                retry_failed_forced_reindex(state, rel_path, "the file could not be opened");
-            }
+            retry_failed_reindex(state, rel_path, "the file could not be opened");
             return;
         }
     };
     let Ok(meta) = file.metadata() else {
-        if force {
-            retry_failed_forced_reindex(state, rel_path, "the opened file could not be inspected");
-        }
+        retry_failed_reindex(state, rel_path, "the opened file could not be inspected");
         return;
     };
     let mut version = tgrep_core::builder::file_version(&meta);
@@ -5090,7 +5092,7 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
         return;
     }
 
-    if !force && state.file_evidence.read().unwrap().stamp(rel_path) == Some(&current) {
+    if !force && state.file_evidence.read().unwrap().version(rel_path) == Some(&version) {
         return;
     }
 
@@ -5099,11 +5101,10 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
     // on our file I/O and trigram parsing. Windows' SRWLock is
     // writer-preferring: a single waiting writer here would otherwise
     // stall every subsequent search request.
-    let data = if force {
-        // A concrete event is stronger evidence than the persisted stamp. The
-        // initial handle established eligibility, but its bytes need not be
-        // read: use one fresh, containment-safe handle as the indexing snapshot
-        // and retry only if full-resolution metadata changes during that read.
+    let data = {
+        // The initial handle established eligibility. Use a fresh, containment-safe
+        // snapshot for concrete events and recovery reads with changed or missing
+        // version evidence, retrying if full-resolution metadata changes mid-read.
         drop(file);
         let mut stable = None;
         for _ in 0..2 {
@@ -5114,7 +5115,7 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
                     return;
                 }
                 Err(_) => {
-                    retry_failed_forced_reindex(
+                    retry_failed_reindex(
                         state,
                         rel_path,
                         "the verification handle could not be opened",
@@ -5123,7 +5124,7 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
                 }
             };
             let Ok(meta) = verify.metadata() else {
-                retry_failed_forced_reindex(
+                retry_failed_reindex(
                     state,
                     rel_path,
                     "the verification handle could not be inspected",
@@ -5152,7 +5153,13 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
                     return;
                 }
                 CappedRead::Failed => {
-                    retry_failed_forced_reindex(state, rel_path, "the verification read failed");
+                    if !force {
+                        let already_indexed = state.index.read().unwrap().has_active_path(rel_path);
+                        if !already_indexed {
+                            mark_filename_only(state, rel_path);
+                        }
+                    }
+                    retry_failed_reindex(state, rel_path, "the verification read failed");
                     return;
                 }
             };
@@ -5166,34 +5173,12 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
             }
         }
         let Some(verified) = stable else {
-            retry_failed_forced_reindex(state, rel_path, "the file kept changing while read");
+            retry_failed_reindex(state, rel_path, "the file kept changing while read");
             return;
         };
         #[cfg(test)]
         run_stale_refresh_hook(state, StaleRefreshPhase::AfterConcreteRead);
         verified
-    } else {
-        // From the approved handle, not the path: re-opening here is what would
-        // let a symlink take the place of the file we just approved.
-        let mut file = file;
-        match read_within_limit(
-            &mut file,
-            state.max_file_size,
-            current.size.min(1 << 20) as usize,
-        ) {
-            CappedRead::Data(data) => data,
-            CappedRead::TooLarge => {
-                drop_indexed_file(state, rel_path, "grew past the size limit while being read");
-                return;
-            }
-            CappedRead::Failed => {
-                let already_indexed = state.index.read().unwrap().has_active_path(rel_path);
-                if !already_indexed {
-                    mark_filename_only(state, rel_path);
-                }
-                return;
-            }
-        }
     };
     let text = tgrep_core::encoding::decode_for_index(&data);
     let is_binary = tgrep_core::trigram::is_binary(&text);
@@ -5205,25 +5190,23 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
     };
     #[cfg(test)]
     run_stale_refresh_hook(state, StaleRefreshPhase::BeforeConcreteCommit);
-    if force {
-        match file_still_has_bytes(&state.root, path, &version, &data) {
-            Ok(true) => {}
-            Ok(false) => {
-                if current_path_is_ineligible(state, path) {
-                    drop_indexed_file(state, rel_path, "no longer eligible");
-                } else {
-                    retry_failed_forced_reindex(state, rel_path, "the file changed before commit");
-                }
-                return;
-            }
-            Err(error) if proves_ineligible(&error) => {
+    match file_still_has_bytes(&state.root, path, &version, &data) {
+        Ok(true) => {}
+        Ok(false) => {
+            if current_path_is_ineligible(state, path) {
                 drop_indexed_file(state, rel_path, "no longer eligible");
-                return;
+            } else {
+                retry_failed_reindex(state, rel_path, "the file changed before commit");
             }
-            Err(_) => {
-                retry_failed_forced_reindex(state, rel_path, "the file changed before commit");
-                return;
-            }
+            return;
+        }
+        Err(error) if proves_ineligible(&error) => {
+            drop_indexed_file(state, rel_path, "no longer eligible");
+            return;
+        }
+        Err(_) => {
+            retry_failed_reindex(state, rel_path, "the file changed before commit");
+            return;
         }
     }
 
@@ -5253,8 +5236,7 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
         // between the two verification reads.
         invalidate_cached_paths_locked(state, std::iter::once(rel_path));
         let mut evidence = state.file_evidence.write().unwrap();
-        let duplicate_reader = force
-            && !index.live.has_path(rel_path)
+        let duplicate_reader = !index.live.has_path(rel_path)
             && !index.live.is_deleted(rel_path)
             && index.reader_has_path(rel_path)
             && content_id_matches(evidence.content_id(rel_path), content_id);
@@ -5270,10 +5252,7 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
             )
         };
         let removed = extra.remove(rel_path);
-        evidence.insert(rel_path.to_string(), current, content_id);
-        if force {
-            evidence.versions.insert(rel_path.to_string(), version);
-        }
+        evidence.insert_verified(rel_path.to_string(), current, content_id, Some(version));
         (removed, committed_overlay_id)
     };
     if removed_extra {
@@ -5289,10 +5268,10 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
     }
 }
 
-fn retry_failed_forced_reindex(state: &Arc<ServerState>, rel_path: &str, reason: &str) {
+fn retry_failed_reindex(state: &Arc<ServerState>, rel_path: &str, reason: &str) {
     // In-memory stamps override the persisted map during stale comparison.
     // A sentinel therefore records "this path must be read" without rewriting
-    // filestamps.json for a transient event failure.
+    // filestamps.json for a transient event or recovery-read failure.
     state.file_evidence.write().unwrap().insert(
         rel_path.to_string(),
         tgrep_core::meta::FileStamp {
@@ -10250,7 +10229,7 @@ mod tests {
     }
 
     #[test]
-    fn concrete_event_reindexes_equal_length_rewrite_with_matching_stamp() {
+    fn concrete_event_reindexes_equal_length_rewrite_with_matching_version() {
         let tmp = TempDir::new().unwrap();
         let root = std::fs::canonicalize(tmp.path()).unwrap();
         let path = root.join("same.rs");
@@ -10270,17 +10249,17 @@ mod tests {
             )
         };
         std::fs::write(&path, "fn new_marker() {}\n").unwrap();
-        let current = tgrep_core::meta::collect_filestamps(&root, &["same.rs".to_string()])
-            .remove("same.rs")
-            .unwrap();
-        state
-            .file_evidence
-            .write()
-            .unwrap()
-            .insert("same.rs".to_string(), current, None);
+        let version = builder::file_version(&std::fs::metadata(&path).unwrap());
+        let current = version.stamp().clone();
+        state.file_evidence.write().unwrap().insert_verified(
+            "same.rs".to_string(),
+            current,
+            None,
+            Some(version),
+        );
 
-        // Mutation control: the speculative path still trusts the persisted
-        // stamp and therefore leaves the old posting set in place.
+        // Deliberately pair current metadata with stale postings: a concrete
+        // event must force a read even when the trusted version matches.
         {
             let _gate = state.snapshot_gate.read().unwrap();
             reindex_file(&state, &path, "same.rs", false);
@@ -10288,7 +10267,7 @@ mod tests {
         let stale = handle_search(None, &serde_json::json!({"pattern": "new_marker"}), &state);
         assert!(
             !stale.contains("\"content\":\"fn new_marker"),
-            "the control must demonstrate that stamp-only filtering misses the rewrite"
+            "the control must demonstrate that metadata-only filtering misses the rewrite"
         );
 
         handle_fs_event(
@@ -10305,7 +10284,7 @@ mod tests {
         let repaired = handle_search(None, &serde_json::json!({"pattern": "new_marker"}), &state);
         assert!(
             repaired.contains("\"content\":\"fn new_marker"),
-            "a concrete event must bypass the coarse matching stamp: {repaired}"
+            "a concrete event must bypass the matching version: {repaired}"
         );
         let index = state.index.read().unwrap();
         assert_ne!(index.live.file_id_for_path("same.rs"), Some(old_id));

--- a/tgrep-cli/src/serve/poll_tests.rs
+++ b/tgrep-cli/src/serve/poll_tests.rs
@@ -1,0 +1,1050 @@
+use super::tests::test_server_state;
+use super::*;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::{Weak, mpsc};
+use tempfile::TempDir;
+
+struct Fixture {
+    state: Arc<ServerState>,
+    root: PathBuf,
+    _temp: TempDir,
+}
+
+impl Fixture {
+    fn new(mode: WatchMode, budget: usize) -> Self {
+        Self::with_interval(mode, budget, Duration::from_secs(120))
+    }
+
+    fn with_interval(mode: WatchMode, budget: usize, interval: Duration) -> Self {
+        let temp = TempDir::new().unwrap();
+        let root = std::fs::canonicalize(temp.path()).unwrap();
+        let mut state = test_server_state(&root, &root.join(".tgrep"));
+        let unique = Arc::get_mut(&mut state).unwrap();
+        unique.refresh = RefreshControl::new(mode, interval, budget);
+        unique.no_require_git = true;
+        Self {
+            state,
+            root,
+            _temp: temp,
+        }
+    }
+
+    fn write(&self, relative: &str, bytes: impl AsRef<[u8]>) -> PathBuf {
+        let path = self.root.join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    fn due(&self) {
+        let mut status = self.state.refresh.status.lock().unwrap();
+        status.finished = Instant::now()
+            .checked_sub(self.state.refresh.poll_interval)
+            .unwrap();
+    }
+
+    fn tick(&self) -> Option<bool> {
+        scheduled_reconcile(&self.state, &self.root, &self.state.index_dir)
+    }
+
+    fn poll(&self) {
+        self.due();
+        assert_eq!(self.tick(), Some(true));
+        self.assert_polling();
+    }
+
+    fn assert_polling(&self) {
+        assert!(self.state.watch_enabled);
+        assert!(self.state.refresh.polling.load(Ordering::SeqCst));
+        assert!(!native_watching(&self.state));
+        assert!(!self.state.watcher_active.load(Ordering::SeqCst));
+        assert!(self.state.watch_registry.lock().unwrap().is_none());
+    }
+
+    fn assert_files(&self, expected: &[&str]) {
+        let response = process_request(r#"{"jsonrpc":"2.0","method":"files","id":1}"#, &self.state);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let actual: BTreeSet<_> = value["result"]["files"]
+            .as_array()
+            .unwrap_or_else(|| panic!("files RPC failed: {response}"))
+            .iter()
+            .map(|path| path.as_str().unwrap())
+            .collect();
+        assert_eq!(actual, expected.iter().copied().collect());
+    }
+
+    fn assert_hit(&self, pattern: &str, expected_path: &str) {
+        let response = handle_search(None, &serde_json::json!({"pattern": pattern}), &self.state);
+        let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+        let matches = value["result"]["matches"]
+            .as_array()
+            .unwrap_or_else(|| panic!("search RPC failed: {response}"));
+        assert!(
+            matches.iter().any(|hit| {
+                hit["file"] == expected_path
+                    && hit["content"]
+                        .as_str()
+                        .is_some_and(|text| text.contains(pattern))
+            }),
+            "missing {pattern} in {expected_path}: {response}"
+        );
+    }
+
+    fn desired(&self) -> WatchableDirs {
+        let matcher = self.state.gitignore.read().unwrap();
+        watchable_dirs(
+            &self.root,
+            &self.root,
+            &self.state.exclude_dirs,
+            matcher.as_ref(),
+        )
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        // Also break notify's callback -> state -> registry cycle on a panic.
+        self.state.refresh.polling.store(true, Ordering::SeqCst);
+        stop_native_watcher(&self.state);
+    }
+}
+
+fn disk_snapshot(index_dir: &Path) -> BTreeMap<String, (Vec<u8>, SystemTime)> {
+    std::fs::read_dir(index_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap())
+        .filter(|entry| entry.file_type().unwrap().is_file())
+        .map(|entry| {
+            (
+                entry.file_name().into_string().unwrap(),
+                (
+                    std::fs::read(entry.path()).unwrap(),
+                    entry.metadata().unwrap().modified().unwrap(),
+                ),
+            )
+        })
+        .collect()
+}
+
+struct WatcherDropProbe {
+    state: Weak<ServerState>,
+    dropped: mpsc::Sender<bool>,
+}
+
+impl Drop for WatcherDropProbe {
+    fn drop(&mut self) {
+        let outside_registry_lock = self
+            .state
+            .upgrade()
+            .is_some_and(|state| state.watch_registry.try_lock().is_ok());
+        let _ = self.dropped.send(outside_registry_lock);
+    }
+}
+
+fn install_registry(fixture: &Fixture, fail_after: Option<usize>) -> mpsc::Receiver<bool> {
+    let (dropped, receive_drop) = mpsc::channel();
+    let probe = WatcherDropProbe {
+        state: Arc::downgrade(&fixture.state),
+        dropped,
+    };
+    let mut watcher = notify::recommended_watcher(move |_event: notify::Result<Event>| {
+        let _keep_probe_alive = &probe;
+    })
+    .unwrap();
+    watcher
+        .watch(&fixture.root, RecursiveMode::NonRecursive)
+        .unwrap();
+    *fixture.state.watch_registry.lock().unwrap() = Some(WatchRegistry {
+        watcher,
+        root: fixture.root.clone(),
+        watched: HashSet::from([fixture.root.clone()]),
+        budget: fixture.state.refresh.watch_budget,
+        failure: None,
+        fail_after,
+        polling: Arc::clone(&fixture.state.refresh.polling),
+    });
+    fixture.state.watcher_active.store(true, Ordering::SeqCst);
+    receive_drop
+}
+
+fn assert_retired(fixture: &Fixture, dropped: mpsc::Receiver<bool>, reason: &str) {
+    fixture.assert_polling();
+    assert!(
+        dropped.recv_timeout(Duration::from_secs(5)).unwrap(),
+        "notify and its callback must be destroyed outside watch_registry's mutex"
+    );
+    let status = fixture.state.refresh.status.lock().unwrap();
+    assert!(
+        status.catch_up,
+        "fallback must request an immediate catch-up"
+    );
+    assert!(
+        status.fallback_reason.as_deref().unwrap().contains(reason),
+        "unexpected fallback: {:?}",
+        status.fallback_reason
+    );
+}
+
+#[test]
+fn a_small_eligible_tree_stays_native_and_ignored_trees_cost_no_budget() {
+    let fixture = Fixture::new(WatchMode::Auto, 2);
+    fixture.write("src/visible.rs", "fn visible_marker() {}\n");
+    fixture.write("ignored/deep/hidden.rs", "fn ignored_marker() {}\n");
+    fixture.write(".gitignore", "ignored/\n");
+    assert!(background_refresh_stale(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        false,
+    ));
+    let desired = fixture.desired();
+    assert_eq!(desired.completeness, TraversalCompleteness::Complete);
+    assert_eq!(
+        desired.dirs,
+        HashSet::from([fixture.root.clone(), fixture.root.join("src")])
+    );
+
+    let dropped = install_registry(&fixture, None);
+    let added = apply_watch_registrations(&fixture.state, &desired, Instant::now());
+    assert_eq!(added, vec![fixture.root.join("src")]);
+    assert!(native_watching(&fixture.state));
+    assert!(fixture.state.watcher_active.load(Ordering::SeqCst));
+    assert_eq!(
+        fixture
+            .state
+            .watch_registry
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .watched,
+        desired.dirs
+    );
+    assert!(matches!(dropped.try_recv(), Err(mpsc::TryRecvError::Empty)));
+    fixture.assert_files(&["src/visible.rs"]);
+    fixture.assert_hit("visible_marker", "src/visible.rs");
+}
+
+#[test]
+fn budget_preflight_releases_the_entire_registry_and_never_restarts_it() {
+    let fixture = Fixture::new(WatchMode::Auto, 2);
+    fixture.write("src/old.rs", "fn available_marker() {}\n");
+    assert!(background_refresh_stale(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        false,
+    ));
+    let dropped = install_registry(&fixture, None);
+    assert_eq!(
+        apply_watch_registrations(&fixture.state, &fixture.desired(), Instant::now()).len(),
+        1
+    );
+    fixture.write("added/new.rs", "fn catchup_marker() {}\n");
+    fixture
+        .state
+        .watch_registry
+        .lock()
+        .unwrap()
+        .as_mut()
+        .unwrap()
+        .fail_after = Some(0);
+    assert!(
+        apply_watch_registrations(&fixture.state, &fixture.desired(), Instant::now()).is_empty()
+    );
+    assert_retired(&fixture, dropped, "budget");
+    fixture.assert_hit("available_marker", "src/old.rs");
+    assert_eq!(
+        fixture.tick(),
+        Some(true),
+        "fallback catch-up must not wait 120 seconds"
+    );
+    fixture.assert_hit("catchup_marker", "added/new.rs");
+
+    for _ in 0..2 {
+        assert!(
+            apply_watch_registrations(&fixture.state, &fixture.desired(), Instant::now())
+                .is_empty()
+        );
+        assert!(!start_file_watcher(
+            Arc::clone(&fixture.state),
+            &fixture.root,
+            4
+        ));
+        assert!(
+            sync_watch_registrations(&fixture.state, &fixture.root)
+                .0
+                .is_empty()
+        );
+        fixture.assert_polling();
+    }
+}
+
+#[test]
+fn capacity_failure_before_or_after_one_registration_releases_all_watches() {
+    for fail_after in [0, 1] {
+        let fixture = Fixture::new(WatchMode::Auto, 4);
+        fixture.write("first/a.rs", "fn first_marker() {}\n");
+        fixture.write("second/b.rs", "fn second_marker() {}\n");
+        let dropped = install_registry(&fixture, Some(fail_after));
+        assert!(
+            apply_watch_registrations(&fixture.state, &fixture.desired(), Instant::now())
+                .is_empty()
+        );
+        assert_retired(&fixture, dropped, "capacity");
+        assert_eq!(fixture.tick(), Some(true));
+        fixture.assert_files(&["first/a.rs", "second/b.rs"]);
+        fixture.assert_hit("second_marker", "second/b.rs");
+        assert!(!start_file_watcher(
+            Arc::clone(&fixture.state),
+            &fixture.root,
+            4
+        ));
+        assert!(
+            apply_watch_registrations(&fixture.state, &fixture.desired(), Instant::now())
+                .is_empty()
+        );
+        fixture.assert_polling();
+    }
+}
+
+#[test]
+fn registration_failure_is_sticky_even_if_the_injection_is_removed() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    for dir in ["first", "second", "third"] {
+        std::fs::create_dir(fixture.root.join(dir)).unwrap();
+    }
+    let _dropped = install_registry(&fixture, Some(1));
+    let mut guard = fixture.state.watch_registry.lock().unwrap();
+    let registry = guard.as_mut().unwrap();
+    let first = fixture.root.join("first");
+    let second = fixture.root.join("second");
+    let third = fixture.root.join("third");
+    assert_eq!(registry.add_all([&first, &second]), vec![first.clone()]);
+    assert!(registry.failure.is_some());
+    assert_eq!(
+        registry.watched,
+        HashSet::from([fixture.root.clone(), first])
+    );
+    let before = registry.watched.clone();
+    registry.fail_after = None;
+    assert!(registry.add_all([&third]).is_empty());
+    assert!(registry.resubscribe_all([&second]).is_empty());
+    assert_eq!(registry.watched, before);
+}
+
+#[test]
+fn a_callback_handoff_after_the_registration_entry_check_prevents_subscriptions() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    let first = fixture.root.join("first");
+    let second = fixture.root.join("second");
+    std::fs::create_dir(&first).unwrap();
+    std::fs::create_dir(&second).unwrap();
+    let dropped = install_registry(&fixture, Some(1));
+    let mut guard = fixture.state.watch_registry.lock().unwrap();
+    let registry = guard.as_mut().unwrap();
+    assert!(Arc::ptr_eq(
+        &registry.polling,
+        &fixture.state.refresh.polling
+    ));
+    // Collection runs after subscribe's entry check but before its per-directory
+    // loop, placing the callback handoff in that window without OS-event timing.
+    let desired = [&first, &second].into_iter().inspect(|_| {
+        request_polling(&fixture.state, "injected callback capacity failure".into());
+    });
+    assert!(registry.add_all(desired).is_empty());
+    assert_eq!(
+        registry.fail_after,
+        Some(1),
+        "no native watch call should be attempted"
+    );
+    assert_eq!(registry.watched, HashSet::from([fixture.root.clone()]));
+    assert!(registry.failure.is_none());
+    drop(guard);
+    assert!(
+        apply_watch_registrations(&fixture.state, &fixture.desired(), Instant::now()).is_empty()
+    );
+    assert_retired(&fixture, dropped, "callback");
+}
+
+#[test]
+fn watcher_creation_capacity_failure_requests_polling_without_a_registry() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    fixture.write("source.rs", "fn creation_fallback_marker() {}\n");
+    let attempted = AtomicBool::new(false);
+    assert!(!start_file_watcher_using(
+        Arc::clone(&fixture.state),
+        &fixture.root,
+        4,
+        |_callback| {
+            attempted.store(true, Ordering::SeqCst);
+            Err(notify::Error::new(notify::ErrorKind::MaxFilesWatch))
+        },
+    ));
+    assert!(attempted.load(Ordering::SeqCst));
+    fixture.assert_polling();
+    assert!(fixture.state.refresh.status.lock().unwrap().catch_up);
+    assert_eq!(fixture.tick(), Some(true));
+    fixture.assert_hit("creation_fallback_marker", "source.rs");
+}
+
+#[test]
+fn root_subscription_failure_drops_the_created_watcher_and_requests_catch_up() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    fixture.write("source.rs", "fn root_fallback_marker() {}\n");
+    let (dropped, receive_drop) = mpsc::channel();
+    let probe = WatcherDropProbe {
+        state: Arc::downgrade(&fixture.state),
+        dropped,
+    };
+    assert!(!start_file_watcher_using(
+        Arc::clone(&fixture.state),
+        &fixture.root.join("missing-root"),
+        4,
+        |mut callback| {
+            notify::recommended_watcher(move |event| {
+                let _keep_probe_alive = &probe;
+                callback(event);
+            })
+        },
+    ));
+    assert_retired(&fixture, receive_drop, "coverage");
+    assert_eq!(fixture.tick(), Some(true));
+    fixture.assert_hit("root_fallback_marker", "source.rs");
+}
+
+#[test]
+fn incomplete_registration_coverage_releases_watches_instead_of_claiming_native() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    fixture.write("src/source.rs", "fn incomplete_coverage_marker() {}\n");
+    let dropped = install_registry(&fixture, None);
+    let mut desired = fixture.desired();
+    desired.completeness = TraversalCompleteness::Incomplete;
+    assert!(apply_watch_registrations(&fixture.state, &desired, Instant::now()).is_empty());
+    assert_retired(&fixture, dropped, "incomplete");
+    assert_eq!(fixture.tick(), Some(true));
+    fixture.assert_hit("incomplete_coverage_marker", "src/source.rs");
+}
+
+#[test]
+fn queue_overflow_repairs_content_but_does_not_abandon_native_watching() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    fixture.write("source.rs", "fn before_overflow_marker() {}\n");
+    assert!(background_refresh_stale(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        false,
+    ));
+    let _dropped = install_registry(&fixture, None);
+    fixture.write("source.rs", "fn after_overflow_repaired_marker() {}\n");
+    let overflowed = AtomicBool::new(true);
+    fixture
+        .state
+        .watch_resubscribe
+        .store(true, Ordering::SeqCst);
+    recover_watcher_overflow(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        &overflowed,
+        1,
+    );
+    assert!(!overflowed.load(Ordering::SeqCst));
+    assert!(native_watching(&fixture.state));
+    assert!(fixture.state.watch_registry.lock().unwrap().is_some());
+    assert!(
+        fixture
+            .state
+            .refresh
+            .status
+            .lock()
+            .unwrap()
+            .fallback_reason
+            .is_none()
+    );
+    fixture.assert_hit("after_overflow_repaired_marker", "source.rs");
+}
+
+#[test]
+fn explicit_poll_never_creates_a_watcher_or_starts_native_recovery() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    fixture.write("src/source.rs", "fn polled_marker() {}\n");
+    let attempted = AtomicBool::new(false);
+    assert!(!start_file_watcher_using(
+        Arc::clone(&fixture.state),
+        &fixture.root,
+        4,
+        |_callback| {
+            attempted.store(true, Ordering::SeqCst);
+            Err(notify::Error::new(notify::ErrorKind::MaxFilesWatch))
+        },
+    ));
+    assert!(!attempted.load(Ordering::SeqCst));
+    assert!(!start_file_watcher(
+        Arc::clone(&fixture.state),
+        &fixture.root,
+        4
+    ));
+    assert_eq!(
+        fixture.tick(),
+        Some(true),
+        "explicit poll starts with catch-up due"
+    );
+    fixture.assert_polling();
+    fixture.assert_hit("polled_marker", "src/source.rs");
+
+    let before = disk_snapshot(&fixture.state.index_dir);
+    let evidence = fixture.state.file_evidence.read().unwrap().clone();
+    let generation = fixture.state.cache_generation.load(Ordering::SeqCst);
+    fixture.write("arrived/new.rs", "fn next_poll_marker() {}\n");
+    watch_new_subtree(&fixture.state, &fixture.root, &fixture.root.join("arrived"));
+    spawn_recovery_scan(
+        &fixture.state,
+        &fixture.root,
+        vec![fixture.root.join("arrived")],
+        SystemTime::UNIX_EPOCH,
+    );
+    let overflowed = AtomicBool::new(true);
+    recover_watcher_overflow(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        &overflowed,
+        1,
+    );
+    fixture
+        .state
+        .ignore_rules_dirty
+        .store(true, Ordering::SeqCst);
+    schedule_ignore_rules_refresh(Arc::clone(&fixture.state), fixture.root.clone());
+    assert!(
+        !fixture
+            .state
+            .ignore_refresh_scheduled
+            .load(Ordering::SeqCst)
+    );
+    assert!(
+        sync_watch_registrations(&fixture.state, &fixture.root)
+            .0
+            .is_empty()
+    );
+    assert!(
+        apply_watch_registrations(&fixture.state, &fixture.desired(), Instant::now()).is_empty()
+    );
+    assert_eq!(fixture.tick(), None);
+    assert_eq!(*fixture.state.file_evidence.read().unwrap(), evidence);
+    assert_eq!(
+        fixture.state.cache_generation.load(Ordering::SeqCst),
+        generation
+    );
+    assert_eq!(disk_snapshot(&fixture.state.index_dir), before);
+    fixture.assert_polling();
+    fixture.poll();
+    fixture.assert_hit("next_poll_marker", "arrived/new.rs");
+}
+
+#[test]
+fn scheduled_polling_reconciles_add_modify_delete_rename_and_ignore_changes() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    fixture.write("source.rs", "fn initial_marker() {}\n");
+    let deleted = fixture.write("delete.rs", "fn removed_marker() {}\n");
+    let renamed = fixture.write("rename.rs", "fn renamed_marker() {}\n");
+    fixture.write("ignored/hidden.rs", "fn initially_hidden_marker() {}\n");
+    fixture.write(".gitignore", "ignored/\n");
+    fixture.poll();
+    fixture.assert_files(&["delete.rs", "rename.rs", "source.rs"]);
+    fixture.assert_hit("initial_marker", "source.rs");
+
+    fixture.write("source.rs", "fn modified_polling_marker() {}\n");
+    fixture.write("added.rs", "fn added_marker() {}\n");
+    fixture.write("asset.bin", [0, 1, 2, 3]);
+    std::fs::remove_file(deleted).unwrap();
+    std::fs::rename(renamed, fixture.root.join("renamed.rs")).unwrap();
+    fixture.poll();
+    fixture.assert_files(&["added.rs", "asset.bin", "renamed.rs", "source.rs"]);
+    fixture.assert_hit("modified_polling_marker", "source.rs");
+    fixture.assert_hit("renamed_marker", "renamed.rs");
+    assert!(
+        !fixture
+            .state
+            .index
+            .read()
+            .unwrap()
+            .reader_has_path("delete.rs")
+    );
+    assert!(
+        !fixture
+            .state
+            .index
+            .read()
+            .unwrap()
+            .reader_has_path("rename.rs")
+    );
+    assert!(
+        !fixture
+            .state
+            .file_evidence
+            .read()
+            .unwrap()
+            .stamps
+            .contains_key("delete.rs")
+    );
+
+    fixture.write(".gitignore", "source.rs\nasset.bin\n");
+    fixture.poll();
+    fixture.assert_files(&["added.rs", "ignored/hidden.rs", "renamed.rs"]);
+    fixture.assert_hit("initially_hidden_marker", "ignored/hidden.rs");
+    assert!(
+        !fixture
+            .state
+            .index
+            .read()
+            .unwrap()
+            .reader_has_path("source.rs")
+    );
+    std::fs::remove_file(fixture.root.join(".gitignore")).unwrap();
+    fixture.poll();
+    fixture.assert_files(&[
+        "added.rs",
+        "asset.bin",
+        "ignored/hidden.rs",
+        "renamed.rs",
+        "source.rs",
+    ]);
+    fixture.assert_hit("modified_polling_marker", "source.rs");
+}
+
+#[test]
+fn unchanged_scheduled_polls_preserve_evidence_index_bytes_mtimes_and_cache() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    fixture.write("source.rs", "fn unchanged_marker() {}\n");
+    fixture.write("asset.bin", [0, 1, 2]);
+    fixture.poll();
+    fixture.assert_hit("unchanged_marker", "source.rs");
+    let before = disk_snapshot(&fixture.state.index_dir);
+    assert!(before.contains_key("filestamps.json"));
+    assert!(before.contains_key("index.bin"));
+    let evidence = fixture.state.file_evidence.read().unwrap().clone();
+    assert_eq!(
+        evidence,
+        tgrep_core::meta::read_file_evidence(&fixture.state.index_dir).unwrap()
+    );
+    let reader = fixture.state.index.read().unwrap().reader_arc();
+    let generation = fixture.state.cache_generation.load(Ordering::SeqCst);
+    for _ in 0..3 {
+        fixture.poll();
+        assert_eq!(disk_snapshot(&fixture.state.index_dir), before);
+        assert_eq!(*fixture.state.file_evidence.read().unwrap(), evidence);
+        assert!(Arc::ptr_eq(
+            &reader,
+            &fixture.state.index.read().unwrap().reader_arc()
+        ));
+        assert_eq!(
+            fixture.state.cache_generation.load(Ordering::SeqCst),
+            generation
+        );
+        assert!(
+            !fixture
+                .state
+                .index
+                .read()
+                .unwrap()
+                .live
+                .has_pending_changes()
+        );
+        assert_eq!(fixture.tick(), None);
+    }
+}
+
+#[test]
+fn indexing_and_flushing_preserve_catch_up_until_the_first_idle_tick() {
+    for indexing in [true, false] {
+        let fixture = Fixture::new(WatchMode::Poll, 4);
+        fixture.write("source.rs", "fn deferred_marker() {}\n");
+        let busy = if indexing {
+            &fixture.state.indexing
+        } else {
+            &fixture.state.flushing
+        };
+        busy.store(true, Ordering::SeqCst);
+        for _ in 0..2 {
+            assert_eq!(fixture.tick(), None);
+            let status = fixture.state.refresh.status.lock().unwrap();
+            assert!(status.catch_up);
+            assert!(!status.running);
+            assert!(status.last_success.is_none());
+        }
+        busy.store(false, Ordering::SeqCst);
+        assert_eq!(fixture.tick(), Some(true));
+        fixture.assert_hit("deferred_marker", "source.rs");
+        assert!(!fixture.state.refresh.status.lock().unwrap().catch_up);
+    }
+}
+
+#[test]
+fn a_fallback_requested_during_a_scan_retains_exactly_one_immediate_catch_up() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    fixture.write("source.rs", "fn original_marker() {}\n");
+    let hook_state = Arc::downgrade(&fixture.state);
+    let late = fixture.root.join("late.rs");
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::AfterMatcherPublish) {
+            let state = hook_state.upgrade().unwrap();
+            assert!(state.refresh.status.lock().unwrap().running);
+            std::fs::write(&late, "fn catch_up_after_walk_marker() {}\n").unwrap();
+            request_polling(
+                &state,
+                "capacity failure during native reconciliation".into(),
+            );
+        }
+    }));
+    assert!(background_refresh_stale(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        false,
+    ));
+    *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+    fixture.assert_polling();
+    assert!(fixture.state.refresh.status.lock().unwrap().catch_up);
+    fixture.assert_files(&["source.rs"]);
+    assert_eq!(
+        fixture.tick(),
+        Some(true),
+        "catch-up must survive scan completion"
+    );
+    fixture.assert_hit("catch_up_after_walk_marker", "late.rs");
+    assert!(!fixture.state.refresh.status.lock().unwrap().catch_up);
+    assert_eq!(
+        fixture.tick(),
+        None,
+        "one handoff must cause only one catch-up"
+    );
+}
+
+#[test]
+fn sustained_searches_do_not_defer_due_polls() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    fixture.write("source.rs", "fn searchable_marker() {}\n");
+    fixture.poll();
+    for iteration in 0..3 {
+        fixture.assert_hit("searchable_marker", "source.rs");
+        fixture.state.note_search();
+        assert!(fixture.state.quiet_for() < RECONCILE_QUIET_PERIOD);
+        let name = format!("new{iteration}.rs");
+        fixture.write(&name, format!("fn arrival_{iteration}_marker() {{}}\n"));
+        fixture.poll();
+        fixture.assert_hit(&format!("arrival_{iteration}_marker"), &name);
+    }
+}
+
+#[test]
+fn a_running_production_refresh_rejects_a_second_tick_and_keeps_search_available() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    fixture.write("source.rs", "fn searchable_marker() {}\n");
+    fixture.poll();
+    let walks = Arc::new(AtomicUsize::new(0));
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel();
+    let resume_rx = Mutex::new(resume_rx);
+    let hook_walks = Arc::clone(&walks);
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::BeforeWalk)
+            && hook_walks.fetch_add(1, Ordering::SeqCst) == 0
+        {
+            entered_tx.send(()).unwrap();
+            resume_rx
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(10))
+                .unwrap();
+        }
+    }));
+    fixture.due();
+    let first_state = Arc::clone(&fixture.state);
+    let first = thread::spawn(move || {
+        scheduled_reconcile(&first_state, &first_state.root, &first_state.index_dir)
+    });
+    entered_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    assert!(fixture.state.refresh.status.lock().unwrap().running);
+    fixture.assert_hit("searchable_marker", "source.rs");
+    let (second_tx, second_rx) = mpsc::channel();
+    let second_state = Arc::clone(&fixture.state);
+    let second = thread::spawn(move || {
+        second_tx
+            .send(scheduled_reconcile(
+                &second_state,
+                &second_state.root,
+                &second_state.index_dir,
+            ))
+            .unwrap();
+    });
+    let second_result = second_rx.recv_timeout(Duration::from_secs(2));
+    resume_tx.send(()).unwrap();
+    let first_result = first.join().unwrap();
+    second.join().unwrap();
+    *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+    assert_eq!(
+        second_result.unwrap(),
+        None,
+        "a second tick must not queue another walk"
+    );
+    assert_eq!(first_result, Some(true));
+    assert_eq!(walks.load(Ordering::SeqCst), 1);
+    assert!(!fixture.state.refresh.status.lock().unwrap().running);
+}
+
+#[test]
+fn a_scan_longer_than_the_interval_schedules_from_completion_not_start() {
+    let interval = Duration::from_secs(1);
+    let fixture = Fixture::with_interval(WatchMode::Poll, 4, interval);
+    fixture.write("source.rs", "fn slow_scan_marker() {}\n");
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::BeforeWalk) {
+            thread::sleep(interval + Duration::from_millis(20));
+        }
+    }));
+    assert_eq!(fixture.tick(), Some(true));
+    *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+    let status = fixture.state.refresh.status.lock().unwrap();
+    assert!(status.duration_ms.unwrap() >= interval.as_millis() as u64);
+    assert!(status.last_success.is_some());
+    assert!(!status.catch_up);
+    assert!(!status.running);
+    assert!(status.error.is_none());
+    drop(status);
+    assert_eq!(
+        fixture.tick(),
+        None,
+        "a long scan must not trigger a catch-up storm"
+    );
+    fixture.poll();
+}
+
+#[test]
+fn a_failed_poll_preserves_last_success_and_retries_an_unchanged_failed_stamp() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    let path = fixture.write("source.rs", "fn original_marker() {}\n");
+    fixture.poll();
+    let last_success = fixture.state.refresh.status.lock().unwrap().last_success;
+    fixture.write("source.rs", "fn recovered_after_failure_marker() {}\n");
+    let modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+    let failed_stamp = tgrep_core::meta::file_stamp(&std::fs::metadata(&path).unwrap());
+    let hook_path = path.clone();
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::AfterMatcherPublish) {
+            std::fs::remove_file(&hook_path).unwrap();
+        }
+    }));
+    fixture.due();
+    assert_eq!(fixture.tick(), Some(false));
+    *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+    assert!(
+        fixture
+            .state
+            .index
+            .read()
+            .unwrap()
+            .reader_has_path("source.rs")
+    );
+    assert_eq!(
+        fixture.state.unreadable.read().unwrap().get("source.rs"),
+        Some(&failed_stamp)
+    );
+    let status = fixture.state.refresh.status.lock().unwrap();
+    assert_eq!(status.last_success, last_success);
+    assert!(status.error.is_some());
+    assert!(status.duration_ms.is_some());
+    assert!(!status.running);
+    drop(status);
+    assert_eq!(
+        fixture.tick(),
+        None,
+        "failures also obey the completion-based retry interval"
+    );
+
+    fixture.write("source.rs", "fn recovered_after_failure_marker() {}\n");
+    set_modified(&path, modified);
+    assert_eq!(
+        tgrep_core::meta::file_stamp(&std::fs::metadata(&path).unwrap()),
+        failed_stamp
+    );
+    fixture.poll();
+    assert!(fixture.state.unreadable.read().unwrap().is_empty());
+    assert!(fixture.state.refresh.status.lock().unwrap().error.is_none());
+    fixture.assert_hit("recovered_after_failure_marker", "source.rs");
+}
+
+#[test]
+fn a_change_after_the_metadata_walk_is_reconciled_on_the_next_poll() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    let path = fixture.write("source.rs", "fn scanned_marker() {}\n");
+    fixture.poll();
+    let prior_evidence = fixture.state.file_evidence.read().unwrap().clone();
+    let hook_root = fixture.root.clone();
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::AfterMatcherPublish) {
+            std::fs::write(&path, "fn changed_after_walk_marker() {}\n").unwrap();
+            std::fs::write(hook_root.join("late.rs"), "fn late_arrival_marker() {}\n").unwrap();
+        }
+    }));
+    fixture.poll();
+    *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+    assert_eq!(*fixture.state.file_evidence.read().unwrap(), prior_evidence);
+    fixture.poll();
+    fixture.assert_hit("changed_after_walk_marker", "source.rs");
+    fixture.assert_hit("late_arrival_marker", "late.rs");
+    fixture.assert_files(&["late.rs", "source.rs"]);
+}
+
+#[test]
+fn poll_build_paths_repair_post_extraction_changes_without_native_watches() {
+    enum Build {
+        Bootstrap,
+        Reload,
+        Resume,
+    }
+    for build in [Build::Bootstrap, Build::Reload, Build::Resume] {
+        let fixture = Fixture::new(WatchMode::Poll, 4);
+        if !matches!(build, Build::Bootstrap) {
+            fixture.write("seeded.rs", "fn seeded_marker() {}\n");
+            fixture.poll();
+        }
+        let path = fixture.write("source.rs", "fn before_build_marker() {}\n");
+        let writes = Arc::new(AtomicUsize::new(0));
+        let hook_writes = Arc::clone(&writes);
+        *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+            if matches!(phase, StaleRefreshPhase::AfterBuildBeforeStampPublish)
+                && hook_writes.fetch_add(1, Ordering::SeqCst) == 0
+            {
+                std::fs::write(&path, "fn after_build_final_marker() {}\n").unwrap();
+            }
+        }));
+        match build {
+            Build::Bootstrap => {
+                fixture.state.indexing.store(true, Ordering::SeqCst);
+                assert!(bootstrap_index_build(
+                    &fixture.state,
+                    &fixture.root,
+                    &fixture.state.index_dir
+                ));
+            }
+            Build::Reload => {
+                let response = handle_reload(None, &fixture.state);
+                let value: serde_json::Value = serde_json::from_str(&response).unwrap();
+                assert_eq!(value["result"]["status"], "reloaded", "{response}");
+            }
+            Build::Resume => {
+                fixture.state.indexing.store(true, Ordering::SeqCst);
+                background_index_build(&fixture.state, &fixture.root, &fixture.state.index_dir);
+            }
+        }
+        *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+        assert!(writes.load(Ordering::SeqCst) >= 1);
+        fixture.assert_polling();
+        assert!(!fixture.state.indexing.load(Ordering::SeqCst));
+        assert!(!fixture.state.gitignore_pending.load(Ordering::SeqCst));
+        fixture.poll();
+        fixture.assert_hit("after_build_final_marker", "source.rs");
+    }
+}
+
+fn set_modified(path: &Path, modified: SystemTime) {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(modified))
+        .unwrap();
+}
+
+#[test]
+fn legacy_evidence_without_metadata_versions_fails_open_and_converges() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    let path = fixture.write("source.rs", "fn old_legacy_marker() {}\n");
+    fixture.poll();
+    let modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+    let legacy = tgrep_core::meta::FileEvidence::from_stamps(
+        fixture.state.file_evidence.read().unwrap().stamps.clone(),
+    );
+    tgrep_core::meta::write_file_evidence(&legacy, &fixture.state.index_dir).unwrap();
+    *fixture.state.file_evidence.write().unwrap() = legacy.clone();
+    fixture.write("source.rs", "fn new_legacy_marker() {}\n");
+    set_modified(&path, modified);
+    assert_eq!(
+        tgrep_core::meta::file_stamp(&std::fs::metadata(&path).unwrap()),
+        legacy.stamps["source.rs"]
+    );
+    fixture.poll();
+    fixture.assert_hit("new_legacy_marker", "source.rs");
+    let repaired = disk_snapshot(&fixture.state.index_dir);
+    fixture.poll();
+    assert_eq!(disk_snapshot(&fixture.state.index_dir), repaired);
+}
+
+#[cfg(unix)]
+#[test]
+fn equal_size_writes_with_restored_mtime_and_same_second_changes_are_polled() {
+    for preserve_mtime in [true, false] {
+        let fixture = Fixture::new(WatchMode::Poll, 4);
+        let path = fixture.write("source.rs", "fn old_precise_marker() {}\n");
+        let second = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let original_time = second + Duration::from_millis(100);
+        set_modified(&path, original_time);
+        fixture.poll();
+        fixture.assert_hit("old_precise_marker", "source.rs");
+        let old = fixture.state.file_evidence.read().unwrap().stamps["source.rs"].clone();
+        fixture.write("source.rs", "fn new_precise_marker() {}\n");
+        let new_time = if preserve_mtime {
+            original_time
+        } else {
+            second + Duration::from_millis(900)
+        };
+        set_modified(&path, new_time);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            new_time
+        );
+        assert_eq!(
+            tgrep_core::meta::file_stamp(&std::fs::metadata(&path).unwrap()),
+            old
+        );
+        fixture.poll();
+        fixture.assert_hit("new_precise_marker", "source.rs");
+        let settled = disk_snapshot(&fixture.state.index_dir);
+        fixture.poll();
+        assert_eq!(disk_snapshot(&fixture.state.index_dir), settled);
+    }
+}
+
+#[test]
+#[ignore = "bounded local polling measurement; run with --ignored --nocapture"]
+fn measure_polling_1000_files_and_20_file_change_batch() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    for file in 0..1000 {
+        fixture.write(
+            &format!("file{file:04}.rs"),
+            format!("fn fixture_{file:04}_marker() {{}}\n"),
+        );
+    }
+    fixture.poll();
+    let before = disk_snapshot(&fixture.state.index_dir);
+    let no_change_start = Instant::now();
+    fixture.poll();
+    let no_change = no_change_start.elapsed();
+    assert_eq!(disk_snapshot(&fixture.state.index_dir), before);
+    for file in 0..20 {
+        fixture.write(
+            &format!("file{file:04}.rs"),
+            format!("fn changed_{file:04}_batch_marker() {{}}\n"),
+        );
+    }
+    let changed_start = Instant::now();
+    fixture.poll();
+    let changed = changed_start.elapsed();
+    fixture.assert_hit("changed_0019_batch_marker", "file0019.rs");
+    assert_eq!(fixture.state.index.read().unwrap().num_files(), 1000);
+    eprintln!("polling fixture: 1000 files; no-change {no_change:?}; 20-file batch {changed:?}");
+}

--- a/tgrep-cli/src/serve/poll_tests.rs
+++ b/tgrep-cli/src/serve/poll_tests.rs
@@ -127,6 +127,272 @@ fn disk_snapshot(index_dir: &Path) -> BTreeMap<String, (Vec<u8>, SystemTime)> {
         .collect()
 }
 
+fn assert_binary_evidence(fixture: &Fixture, relative: &str) {
+    let version = builder::file_version(&std::fs::metadata(fixture.root.join(relative)).unwrap());
+    let evidence = fixture.state.file_evidence.read().unwrap();
+    assert_eq!(evidence.version(relative), Some(&version), "{relative}");
+    assert_eq!(evidence.content_id(relative), None, "{relative}");
+    drop(evidence);
+    assert!(
+        !fixture
+            .state
+            .index
+            .read()
+            .unwrap()
+            .has_active_path(relative),
+        "binary classification must not add content postings for {relative}"
+    );
+    assert!(
+        fixture
+            .state
+            .filename_extra_paths
+            .read()
+            .unwrap()
+            .contains(relative)
+    );
+}
+
+#[test]
+fn verified_binary_reindex_preserves_evidence_without_rewriting_the_index() {
+    for force in [false, true] {
+        let fixture = Fixture::new(WatchMode::Poll, 4);
+        fixture.write("seeded.rs", "fn seeded_marker() {}\n");
+        fixture.poll();
+        let binary = fixture.write("binary.rs", b"binary_marker\n\0");
+        {
+            let _gate = fixture.state.snapshot_gate.read().unwrap();
+            reindex_file(&fixture.state, &binary, "binary.rs", force);
+        }
+        assert_binary_evidence(&fixture, "binary.rs");
+        assert!(
+            !fixture
+                .state
+                .index
+                .read()
+                .unwrap()
+                .live
+                .has_pending_changes()
+        );
+        assert!(persist_pending_index_changes(&fixture.state));
+
+        let reads = Arc::new(AtomicUsize::new(0));
+        let hook_reads = Arc::clone(&reads);
+        *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+            if matches!(phase, StaleRefreshPhase::AfterConcreteRead) {
+                hook_reads.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+        let before = disk_snapshot(&fixture.state.index_dir);
+        let evidence = fixture.state.file_evidence.read().unwrap().clone();
+        for _ in 0..2 {
+            {
+                let _gate = fixture.state.snapshot_gate.read().unwrap();
+                reindex_file(&fixture.state, &binary, "binary.rs", false);
+            }
+            fixture.poll();
+        }
+        assert_eq!(reads.load(Ordering::SeqCst), 0);
+        assert_eq!(disk_snapshot(&fixture.state.index_dir), before);
+        assert_eq!(*fixture.state.file_evidence.read().unwrap(), evidence);
+        fixture.assert_files(&["binary.rs", "seeded.rs"]);
+    }
+}
+
+#[test]
+fn verified_binary_reindex_preserves_text_binary_text_transitions() {
+    for force in [false, true] {
+        let fixture = Fixture::new(WatchMode::Poll, 4);
+        let path = fixture.write("source.rs", "fn original_text_marker() {}\n");
+        fixture.poll();
+        fixture.assert_hit("original_text_marker", "source.rs");
+        fixture.write("source.rs", b"binary_content\n\0");
+        {
+            let _gate = fixture.state.snapshot_gate.read().unwrap();
+            reindex_file(&fixture.state, &path, "source.rs", force);
+        }
+        assert_binary_evidence(&fixture, "source.rs");
+        assert!(
+            fixture
+                .state
+                .cache
+                .read()
+                .unwrap()
+                .peek("source.rs")
+                .is_none()
+        );
+        assert!(persist_pending_index_changes(&fixture.state));
+        let persisted = tgrep_core::meta::read_file_evidence(&fixture.state.index_dir).unwrap();
+        assert_eq!(
+            persisted,
+            *fixture.state.file_evidence.read().unwrap(),
+            "the content eviction must publish the verified binary classification"
+        );
+        let before = disk_snapshot(&fixture.state.index_dir);
+        fixture.poll();
+        assert_eq!(disk_snapshot(&fixture.state.index_dir), before);
+
+        fixture.write("source.rs", "fn restored_text_marker() {}\n");
+        {
+            let _gate = fixture.state.snapshot_gate.read().unwrap();
+            reindex_file(&fixture.state, &path, "source.rs", force);
+        }
+        fixture.assert_hit("restored_text_marker", "source.rs");
+        assert!(
+            !fixture
+                .state
+                .filename_extra_paths
+                .read()
+                .unwrap()
+                .contains("source.rs")
+        );
+        assert!(
+            fixture
+                .state
+                .file_evidence
+                .read()
+                .unwrap()
+                .content_id("source.rs")
+                .is_some()
+        );
+        fixture.assert_files(&["source.rs"]);
+    }
+}
+
+#[test]
+fn verified_binary_reindex_rejects_raced_classification() {
+    for force in [false, true] {
+        let fixture = Fixture::new(WatchMode::Poll, 4);
+        let path = fixture.write("source.rs", "fn original_text_marker() {}\n");
+        fixture.poll();
+        fixture.write("source.rs", b"binary_content\n\0");
+        let hook_path = path.clone();
+        *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+            if matches!(phase, StaleRefreshPhase::BeforeConcreteCommit) {
+                std::fs::write(&hook_path, "fn latest_text_marker() {}\n").unwrap();
+            }
+        }));
+        {
+            let _gate = fixture.state.snapshot_gate.read().unwrap();
+            reindex_file(&fixture.state, &path, "source.rs", force);
+        }
+        assert!(
+            fixture
+                .state
+                .file_evidence
+                .read()
+                .unwrap()
+                .version("source.rs")
+                .is_none()
+        );
+        assert!(
+            fixture
+                .state
+                .index
+                .read()
+                .unwrap()
+                .has_active_path("source.rs")
+        );
+        assert!(
+            !fixture
+                .state
+                .filename_extra_paths
+                .read()
+                .unwrap()
+                .contains("source.rs")
+        );
+        *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+        fixture.poll();
+        fixture.assert_hit("latest_text_marker", "source.rs");
+    }
+}
+
+#[test]
+fn resumed_build_preserves_binary_evidence_across_batches_and_flushes() {
+    for force_flush in [false, true] {
+        let mut fixture = Fixture::new(WatchMode::Poll, 4);
+        if force_flush {
+            Arc::get_mut(&mut fixture.state).unwrap().memory_cap_bytes = 0;
+        }
+        fixture.write("seeded.rs", "fn seeded_marker() {}\n");
+        fixture.write("existing.rs", b"existing_binary\n\0");
+        fixture.poll();
+        let mut binaries = vec!["existing.rs".to_string()];
+        for number in 0..501 {
+            let name = format!("binary-{number:03}.rs");
+            fixture.write(&name, b"batch_binary\n\0");
+            binaries.push(name);
+        }
+        fixture.write("text.rs", "fn new_text_marker() {}\n");
+        fixture.state.indexing.store(true, Ordering::SeqCst);
+        background_index_build(&fixture.state, &fixture.root, &fixture.state.index_dir);
+        assert!(!fixture.state.indexing.load(Ordering::SeqCst));
+        assert!(!fixture.state.flushing.load(Ordering::SeqCst));
+        assert_eq!(fixture.state.index.read().unwrap().num_files(), 2);
+        fixture.assert_hit("new_text_marker", "text.rs");
+        for name in &binaries {
+            assert_binary_evidence(&fixture, name);
+        }
+        let persisted = tgrep_core::meta::read_file_evidence(&fixture.state.index_dir).unwrap();
+        assert_eq!(persisted, *fixture.state.file_evidence.read().unwrap());
+        assert_eq!(persisted.versions.len(), binaries.len() + 2);
+        let before = disk_snapshot(&fixture.state.index_dir);
+        fixture.poll();
+        fixture.poll();
+        assert_eq!(disk_snapshot(&fixture.state.index_dir), before);
+        let mut expected: Vec<_> = binaries.iter().map(String::as_str).collect();
+        expected.extend(["seeded.rs", "text.rs"]);
+        fixture.assert_files(&expected);
+    }
+}
+
+#[test]
+fn resumed_build_binary_evidence_describes_the_read_not_the_final_walk() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    fixture.write("seeded.rs", "fn seeded_marker() {}\n");
+    fixture.poll();
+    let path = fixture.write("raced.rs", b"original_binary\n\0");
+    let version = builder::file_version(&std::fs::metadata(&path).unwrap());
+    let hook_root = fixture.root.clone();
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::AfterBuildBeforeStampPublish) {
+            std::fs::write(&path, "fn after_classification_marker() {}\n").unwrap();
+            std::fs::write(hook_root.join("late.rs"), "fn late_arrival_marker() {}\n").unwrap();
+        }
+    }));
+    fixture.state.indexing.store(true, Ordering::SeqCst);
+    background_index_build(&fixture.state, &fixture.root, &fixture.state.index_dir);
+    *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+    assert_eq!(
+        fixture
+            .state
+            .file_evidence
+            .read()
+            .unwrap()
+            .version("raced.rs"),
+        Some(&version)
+    );
+    assert!(
+        fixture
+            .state
+            .file_evidence
+            .read()
+            .unwrap()
+            .stamp("late.rs")
+            .is_none()
+    );
+    assert!(
+        !fixture
+            .state
+            .index
+            .read()
+            .unwrap()
+            .has_active_path("raced.rs")
+    );
+    fixture.poll();
+    fixture.assert_hit("after_classification_marker", "raced.rs");
+    fixture.assert_hit("late_arrival_marker", "late.rs");
+}
+
 struct WatcherDropProbe {
     state: Weak<ServerState>,
     dropped: mpsc::Sender<bool>,

--- a/tgrep-cli/src/serve/poll_tests.rs
+++ b/tgrep-cli/src/serve/poll_tests.rs
@@ -54,6 +54,12 @@ impl Fixture {
         self.assert_polling();
     }
 
+    fn native_reconcile(&self) {
+        assert!(native_watching(&self.state));
+        self.state.refresh.status.lock().unwrap().finished = Instant::now() - RECONCILE_DEADLINE;
+        assert_eq!(self.tick(), Some(true));
+    }
+
     fn assert_polling(&self) {
         assert!(self.state.watch_enabled);
         assert!(self.state.refresh.polling.load(Ordering::SeqCst));
@@ -1371,7 +1377,8 @@ fn a_failed_poll_preserves_last_success_and_retries_an_unchanged_failed_stamp() 
     let last_success = fixture.state.refresh.status.lock().unwrap().last_success;
     fixture.write("source.rs", "fn recovered_after_failure_marker() {}\n");
     let modified = std::fs::metadata(&path).unwrap().modified().unwrap();
-    let failed_stamp = tgrep_core::meta::file_stamp(&std::fs::metadata(&path).unwrap());
+    let failed_version = builder::file_version(&std::fs::metadata(&path).unwrap());
+    let failed_stamp = failed_version.stamp().clone();
     let hook_path = path.clone();
     *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
         if matches!(phase, StaleRefreshPhase::AfterMatcherPublish) {
@@ -1391,7 +1398,7 @@ fn a_failed_poll_preserves_last_success_and_retries_an_unchanged_failed_stamp() 
     );
     assert_eq!(
         fixture.state.unreadable.read().unwrap().get("source.rs"),
-        Some(&failed_stamp)
+        Some(&Some(failed_version))
     );
     let status = fixture.state.refresh.status.lock().unwrap();
     assert_eq!(status.last_success, last_success);
@@ -1415,6 +1422,154 @@ fn a_failed_poll_preserves_last_success_and_retries_an_unchanged_failed_stamp() 
     assert!(fixture.state.unreadable.read().unwrap().is_empty());
     assert!(fixture.state.refresh.status.lock().unwrap().error.is_none());
     fixture.assert_hit("recovered_after_failure_marker", "source.rs");
+}
+
+fn assert_native_retry_after_failed_read(restore_mtime: bool) {
+    for previously_indexed in [true, false] {
+        let fixture = Fixture::new(WatchMode::Auto, 4);
+        let modified = SystemTime::UNIX_EPOCH
+            + Duration::from_secs(1_700_000_000)
+            + Duration::from_millis(100);
+        if previously_indexed {
+            let path = fixture.write("source.rs", "fn old_memo_marker() {}\n");
+            set_modified(&path, modified - Duration::from_millis(100));
+            fixture.native_reconcile();
+            fixture.assert_hit("old_memo_marker", "source.rs");
+        }
+        let path = fixture.write("source.rs", "fn bad_memo_marker() {}\n");
+        set_modified(&path, modified);
+        let failed_version = builder::file_version(&std::fs::metadata(&path).unwrap());
+        let hook_path = path.clone();
+        *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+            if matches!(phase, StaleRefreshPhase::AfterMatcherPublish) {
+                std::fs::remove_file(&hook_path).unwrap();
+            }
+        }));
+        fixture.native_reconcile();
+        *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+        assert_eq!(
+            fixture.state.unreadable.read().unwrap().get("source.rs"),
+            Some(&Some(failed_version.clone())),
+            "failure evidence must come from the scan, not the old indexed read or a later stat"
+        );
+        assert!(fixture.state.refresh.status.lock().unwrap().error.is_some());
+        assert_eq!(
+            fixture
+                .state
+                .index
+                .read()
+                .unwrap()
+                .reader_has_path("source.rs"),
+            previously_indexed
+        );
+
+        fixture.write("source.rs", "fn new_memo_marker() {}\n");
+        set_modified(
+            &path,
+            if restore_mtime {
+                modified
+            } else {
+                modified + Duration::from_millis(100)
+            },
+        );
+        #[cfg(windows)]
+        if restore_mtime {
+            use std::os::windows::fs::FileTimesExt;
+            // NTFS can reuse a deleted name's creation time. Give the replacement
+            // distinct creation evidence while retaining the failed file's mtime.
+            File::options()
+                .write(true)
+                .open(&path)
+                .unwrap()
+                .set_times(std::fs::FileTimes::new().set_created(modified))
+                .unwrap();
+        }
+        let recovered_version = builder::file_version(&std::fs::metadata(&path).unwrap());
+        assert_eq!(failed_version.stamp(), recovered_version.stamp());
+        assert_ne!(failed_version, recovered_version);
+        fixture.native_reconcile();
+        fixture.assert_hit("new_memo_marker", "source.rs");
+        assert!(fixture.state.unreadable.read().unwrap().is_empty());
+        assert!(fixture.state.refresh.status.lock().unwrap().error.is_none());
+        assert_eq!(
+            fixture
+                .state
+                .file_evidence
+                .read()
+                .unwrap()
+                .version("source.rs"),
+            Some(&recovered_version)
+        );
+        let disk = disk_snapshot(&fixture.state.index_dir);
+        fixture.native_reconcile();
+        assert_eq!(disk_snapshot(&fixture.state.index_dir), disk);
+    }
+}
+
+#[test]
+fn native_reconciliation_retries_failed_files_after_same_second_writes() {
+    assert_native_retry_after_failed_read(false);
+}
+
+#[test]
+fn native_reconciliation_retries_failed_replacements_with_restored_mtime() {
+    assert_native_retry_after_failed_read(true);
+}
+
+#[test]
+fn memoized_read_failures_with_missing_versions_remain_retryable() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    let path = fixture.write("source.rs", "fn unknown_version_marker() {}\n");
+    let version = builder::file_version(&std::fs::metadata(&path).unwrap());
+    for (memo_known, scan_known) in [(true, false), (false, true), (false, false)] {
+        let memo = std::collections::HashMap::from([(
+            "source.rs".to_string(),
+            memo_known.then_some(version.clone()),
+        )]);
+        let current = [tgrep_core::walker::FileMeta {
+            relative_path: "source.rs".into(),
+            mtime: version.stamp().mtime,
+            size: version.stamp().size,
+            version: scan_known.then_some(version.clone()),
+        }];
+        for was_indexed in [true, false] {
+            let mut changed = Vec::new();
+            let mut added = Vec::new();
+            if was_indexed {
+                changed.push("source.rs".to_string());
+            } else {
+                added.push("source.rs".to_string());
+            }
+            assert!(drop_memoized_failures(&memo, &current, &mut changed, &mut added).is_empty());
+            assert_eq!(changed.len() + added.len(), 1);
+        }
+    }
+}
+
+#[test]
+fn auto_save_clears_a_recovered_unreadable_memo_entry() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    let path = fixture.write("source.rs", "fn before_auto_save_marker() {}\n");
+    {
+        let _gate = fixture.state.snapshot_gate.read().unwrap();
+        reindex_file(&fixture.state, &path, "source.rs", true);
+    }
+    std::fs::remove_file(&path).unwrap();
+    assert!(persist_pending_index_changes(&fixture.state));
+    assert_eq!(
+        fixture.state.unreadable.read().unwrap().get("source.rs"),
+        Some(&None),
+        "an auto-save has no preceding scan and must leave the failure retryable"
+    );
+
+    fixture.write("source.rs", "fn repaired_auto_save_marker() {}\n");
+    {
+        let _gate = fixture.state.snapshot_gate.read().unwrap();
+        reindex_file(&fixture.state, &path, "source.rs", true);
+    }
+    assert!(persist_pending_index_changes(&fixture.state));
+    assert!(fixture.state.unreadable.read().unwrap().is_empty());
+    fixture.assert_hit("repaired_auto_save_marker", "source.rs");
 }
 
 #[test]

--- a/tgrep-cli/src/serve/poll_tests.rs
+++ b/tgrep-cli/src/serve/poll_tests.rs
@@ -949,6 +949,280 @@ fn indexing_and_flushing_preserve_catch_up_until_the_first_idle_tick() {
     }
 }
 
+fn pause_first_refresh_before_lock(
+    state: &Arc<ServerState>,
+) -> (mpsc::Receiver<()>, mpsc::Sender<()>, Arc<AtomicUsize>) {
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel();
+    let resume_rx = Mutex::new(resume_rx);
+    let first = AtomicBool::new(true);
+    let walks = Arc::new(AtomicUsize::new(0));
+    let hook_walks = Arc::clone(&walks);
+    *state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| match phase {
+        StaleRefreshPhase::BeforeRefreshLock if first.swap(false, Ordering::SeqCst) => {
+            entered_tx.send(()).unwrap();
+            resume_rx
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(10))
+                .unwrap();
+        }
+        StaleRefreshPhase::BeforeWalk => {
+            hook_walks.fetch_add(1, Ordering::SeqCst);
+        }
+        _ => {}
+    }));
+    (entered_rx, resume_tx, walks)
+}
+
+fn assert_initial_poll_handoff(startup_waits: bool) {
+    for mode in [WatchMode::Poll, WatchMode::Auto] {
+        let fixture = Fixture::new(mode, 4);
+        fixture.write("source.rs", "fn startup_handoff_marker() {}\n");
+        if mode == WatchMode::Auto {
+            request_polling(&fixture.state, "startup watch capacity failure".into());
+        }
+        let (entered, resume, walks) = pause_first_refresh_before_lock(&fixture.state);
+        let waiting_state = Arc::clone(&fixture.state);
+        let waiting = thread::spawn(move || {
+            if startup_waits {
+                Some(startup_refresh_stale(
+                    &waiting_state,
+                    &waiting_state.root,
+                    &waiting_state.index_dir,
+                ))
+            } else {
+                scheduled_reconcile(
+                    &waiting_state,
+                    &waiting_state.root,
+                    &waiting_state.index_dir,
+                )
+            }
+        });
+        entered.recv_timeout(Duration::from_secs(5)).unwrap();
+        let first_result = if startup_waits {
+            fixture.tick()
+        } else {
+            Some(startup_refresh_stale(
+                &fixture.state,
+                &fixture.root,
+                &fixture.state.index_dir,
+            ))
+        };
+        let finished = fixture.state.refresh.status.lock().unwrap().finished;
+        let disk = disk_snapshot(&fixture.state.index_dir);
+        resume.send(()).unwrap();
+        let waiting_result = waiting.join().unwrap();
+        *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+
+        assert_eq!(first_result, Some(true));
+        assert_eq!(
+            walks.load(Ordering::SeqCst),
+            1,
+            "the initial poll must be shared by startup and the scheduler"
+        );
+        assert_eq!(
+            waiting_result,
+            if startup_waits { Some(true) } else { None }
+        );
+        let status = fixture.state.refresh.status.lock().unwrap();
+        assert_eq!(status.finished, finished, "skipping must not reset cadence");
+        assert!(!status.running);
+        assert!(!status.catch_up);
+        assert!(status.error.is_none());
+        drop(status);
+        assert_eq!(disk_snapshot(&fixture.state.index_dir), disk);
+        fixture.assert_hit("startup_handoff_marker", "source.rs");
+        assert_eq!(fixture.tick(), None);
+    }
+}
+
+#[test]
+fn polling_startup_skips_a_completed_scheduled_reconciliation() {
+    assert_initial_poll_handoff(true);
+}
+
+#[test]
+fn scheduled_poll_skips_a_completed_startup_reconciliation() {
+    assert_initial_poll_handoff(false);
+}
+
+#[test]
+fn scheduled_poll_rechecks_busy_state_before_claiming_catch_up() {
+    for indexing in [true, false] {
+        let fixture = Fixture::new(WatchMode::Poll, 4);
+        fixture.write("source.rs", "fn busy_handoff_marker() {}\n");
+        let (entered, resume, walks) = pause_first_refresh_before_lock(&fixture.state);
+        let waiting_state = Arc::clone(&fixture.state);
+        let waiting = thread::spawn(move || {
+            scheduled_reconcile(
+                &waiting_state,
+                &waiting_state.root,
+                &waiting_state.index_dir,
+            )
+        });
+        entered.recv_timeout(Duration::from_secs(5)).unwrap();
+        let busy = if indexing {
+            &fixture.state.indexing
+        } else {
+            &fixture.state.flushing
+        };
+        busy.store(true, Ordering::SeqCst);
+        resume.send(()).unwrap();
+        let result = waiting.join().unwrap();
+        *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+        busy.store(false, Ordering::SeqCst);
+
+        assert_eq!(result, None);
+        assert_eq!(walks.load(Ordering::SeqCst), 0);
+        assert!(fixture.state.refresh.status.lock().unwrap().catch_up);
+        assert_eq!(fixture.tick(), Some(true));
+        fixture.assert_hit("busy_handoff_marker", "source.rs");
+    }
+}
+
+#[test]
+fn polling_startup_preserves_a_previous_failed_attempt_and_its_retry_cadence() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path().join("missing");
+    let index_dir = temp.path().join("index");
+    let mut state = test_server_state(&root, &index_dir);
+    Arc::get_mut(&mut state).unwrap().refresh =
+        RefreshControl::new(WatchMode::Poll, Duration::from_secs(120), 4);
+    let walks = Arc::new(AtomicUsize::new(0));
+    let hook_walks = Arc::clone(&walks);
+    *state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::BeforeWalk) {
+            hook_walks.fetch_add(1, Ordering::SeqCst);
+        }
+    }));
+    assert_eq!(scheduled_reconcile(&state, &root, &index_dir), Some(false));
+    let finished = state.refresh.status.lock().unwrap().finished;
+    assert!(!startup_refresh_stale(&state, &root, &index_dir));
+    assert_eq!(walks.load(Ordering::SeqCst), 1);
+    let status = state.refresh.status.lock().unwrap();
+    assert_eq!(status.finished, finished);
+    assert!(status.last_success.is_none());
+    assert!(status.error.is_some());
+    drop(status);
+    assert_eq!(scheduled_reconcile(&state, &root, &index_dir), None);
+}
+
+#[test]
+fn polling_startup_does_not_claim_deferred_work_as_successful() {
+    for indexing in [true, false] {
+        for previously_reconciled in [true, false] {
+            let fixture = Fixture::new(WatchMode::Poll, 4);
+            if previously_reconciled {
+                fixture.poll();
+                fixture.due();
+            }
+            fixture.write("source.rs", "fn deferred_startup_marker() {}\n");
+            let busy = if indexing {
+                &fixture.state.indexing
+            } else {
+                &fixture.state.flushing
+            };
+            busy.store(true, Ordering::SeqCst);
+            let result =
+                startup_refresh_stale(&fixture.state, &fixture.root, &fixture.state.index_dir);
+            busy.store(false, Ordering::SeqCst);
+            assert!(!result);
+            assert_eq!(fixture.tick(), Some(true));
+            fixture.assert_hit("deferred_startup_marker", "source.rs");
+        }
+    }
+}
+
+#[test]
+fn native_and_unwatched_startup_refreshes_do_not_depend_on_the_poll_schedule() {
+    for (mode, watch_enabled) in [
+        (WatchMode::Auto, true),
+        (WatchMode::Auto, false),
+        (WatchMode::Poll, false),
+    ] {
+        let mut fixture = Fixture::new(mode, 4);
+        Arc::get_mut(&mut fixture.state).unwrap().watch_enabled = watch_enabled;
+        assert!(background_refresh_stale(
+            &fixture.state,
+            &fixture.root,
+            &fixture.state.index_dir,
+            false,
+        ));
+        fixture.write("source.rs", "fn mandatory_startup_marker() {}\n");
+        assert!(startup_refresh_stale(
+            &fixture.state,
+            &fixture.root,
+            &fixture.state.index_dir,
+        ));
+        fixture.assert_hit("mandatory_startup_marker", "source.rs");
+    }
+}
+
+#[test]
+fn polling_startup_runs_again_when_the_completion_interval_has_elapsed() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    fixture.poll();
+    fixture.write("source.rs", "fn overdue_startup_marker() {}\n");
+    fixture.due();
+    assert!(startup_refresh_stale(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+    ));
+    fixture.assert_hit("overdue_startup_marker", "source.rs");
+    assert_eq!(fixture.tick(), None);
+}
+
+#[test]
+fn polling_startup_retains_catch_up_requested_during_a_previous_scan() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    fixture.write("source.rs", "fn initial_native_marker() {}\n");
+    let hook_state = Arc::downgrade(&fixture.state);
+    let late = fixture.root.join("late.rs");
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::AfterMatcherPublish) {
+            let state = hook_state.upgrade().unwrap();
+            std::fs::write(&late, "fn startup_catch_up_marker() {}\n").unwrap();
+            request_polling(&state, "capacity failure during a startup scan".into());
+        }
+    }));
+    assert!(background_refresh_stale(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        false,
+    ));
+    *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+    assert!(fixture.state.refresh.status.lock().unwrap().catch_up);
+    fixture.assert_files(&["source.rs"]);
+    assert!(startup_refresh_stale(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+    ));
+    fixture.assert_hit("startup_catch_up_marker", "late.rs");
+    assert!(!fixture.state.refresh.status.lock().unwrap().catch_up);
+    assert_eq!(fixture.tick(), None);
+}
+
+#[test]
+fn explicit_refreshes_do_not_depend_on_the_poll_schedule() {
+    let fixture = Fixture::new(WatchMode::Poll, 4);
+    fixture.poll();
+    for compare_index_membership in [false, true] {
+        let path = format!("forced_{compare_index_membership}.rs");
+        fixture.write(&path, "fn explicit_refresh_marker() {}\n");
+        assert!(background_refresh_stale(
+            &fixture.state,
+            &fixture.root,
+            &fixture.state.index_dir,
+            compare_index_membership,
+        ));
+        fixture.assert_hit("explicit_refresh_marker", &path);
+    }
+}
+
 #[test]
 fn a_fallback_requested_during_a_scan_retains_exactly_one_immediate_catch_up() {
     let fixture = Fixture::new(WatchMode::Auto, 4);

--- a/tgrep-cli/src/serve/recovery_tests.rs
+++ b/tgrep-cli/src/serve/recovery_tests.rs
@@ -1,0 +1,226 @@
+use super::*;
+use std::sync::atomic::AtomicUsize;
+use tempfile::TempDir;
+
+const OLD: &[u8] = b"fn old_recovery_marker() {}\n";
+const NEW: &[u8] = b"fn new_recovery_marker() {}\n";
+const LATEST: &[u8] = b"fn end_recovery_marker() {}\n";
+const REL_PATH: &str = "source.rs";
+
+struct Fixture {
+    _dir: TempDir,
+    root: PathBuf,
+    path: PathBuf,
+    state: Arc<ServerState>,
+    modified: SystemTime,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = TempDir::new().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        let index_dir = root.join(".tgrep");
+        let fixture = Self {
+            path: root.join(REL_PATH),
+            state: tests::test_server_state(&root, &index_dir),
+            _dir: dir,
+            root,
+            modified: SystemTime::UNIX_EPOCH
+                + Duration::from_secs(1_700_000_000)
+                + Duration::from_millis(100),
+        };
+        fixture.write(OLD, fixture.modified);
+        let outcome = builder::build_index_for_files(
+            &fixture.root,
+            &index_dir,
+            std::slice::from_ref(&fixture.path),
+            1024,
+        )
+        .unwrap();
+        let version = outcome.versions[REL_PATH].clone();
+        let mut evidence = tgrep_core::meta::FileEvidence::default();
+        evidence.insert_verified(
+            REL_PATH.into(),
+            version.stamp().clone(),
+            Some(outcome.content_ids[REL_PATH]),
+            Some(version),
+        );
+        tgrep_core::meta::write_file_evidence(&evidence, &index_dir).unwrap();
+        *fixture.state.index.write().unwrap() =
+            HybridIndex::open(&index_dir, &fixture.root).unwrap();
+        *fixture.state.file_evidence.write().unwrap() = evidence;
+        fixture
+            .state
+            .gitignore_pending
+            .store(false, Ordering::SeqCst);
+        fixture.assert_matches("old_recovery_marker", 1);
+        fixture
+    }
+
+    fn write(&self, bytes: &[u8], modified: SystemTime) {
+        std::fs::write(&self.path, bytes).unwrap();
+        File::options()
+            .write(true)
+            .open(&self.path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(modified))
+            .unwrap();
+    }
+
+    fn recover(&self) {
+        let _gate = self.state.snapshot_gate.read().unwrap();
+        reindex_files_in(
+            &self.state,
+            &self.root,
+            std::slice::from_ref(&self.root),
+            SystemTime::now(),
+        );
+    }
+
+    fn assert_matches(&self, pattern: &str, expected: u64) {
+        let response = handle_search(None, &serde_json::json!({"pattern": pattern}), &self.state);
+        let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(response["result"]["num_matches"], expected, "{response}");
+    }
+
+    fn assert_repaired(&self) {
+        self.recover();
+        self.assert_matches("new_recovery_marker", 1);
+        self.assert_matches("old_recovery_marker", 0);
+        let version = builder::file_version(&std::fs::metadata(&self.path).unwrap());
+        assert_eq!(
+            self.state.file_evidence.read().unwrap().version(REL_PATH),
+            Some(&version),
+            "recovery must retain the version validated around its indexing read"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn subscription_recovery_detects_equal_size_writes_with_restored_mtime() {
+    let fixture = Fixture::new();
+    let before = fixture.state.file_evidence.read().unwrap().clone();
+    fixture.write(NEW, fixture.modified);
+    let version = builder::file_version(&std::fs::metadata(&fixture.path).unwrap());
+    assert_eq!(before.stamp(REL_PATH), Some(version.stamp()));
+    assert_ne!(before.version(REL_PATH), Some(&version));
+    fixture.assert_repaired();
+}
+
+#[test]
+fn subscription_recovery_detects_equal_size_same_second_writes() {
+    let fixture = Fixture::new();
+    let before = fixture.state.file_evidence.read().unwrap().clone();
+    fixture.write(NEW, fixture.modified + Duration::from_millis(100));
+    let version = builder::file_version(&std::fs::metadata(&fixture.path).unwrap());
+    assert_eq!(before.stamp(REL_PATH), Some(version.stamp()));
+    assert_ne!(before.version(REL_PATH), Some(&version));
+    fixture.assert_repaired();
+}
+
+#[test]
+fn subscription_recovery_verifies_legacy_evidence_once_without_overlay_churn() {
+    let fixture = Fixture::new();
+    fixture
+        .state
+        .file_evidence
+        .write()
+        .unwrap()
+        .versions
+        .remove(REL_PATH);
+    let reads = Arc::new(AtomicUsize::new(0));
+    let hook_reads = Arc::clone(&reads);
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::AfterConcreteRead) {
+            hook_reads.fetch_add(1, Ordering::SeqCst);
+        }
+    }));
+
+    fixture.recover();
+    assert_eq!(reads.load(Ordering::SeqCst), 1);
+    assert!(
+        fixture
+            .state
+            .file_evidence
+            .read()
+            .unwrap()
+            .version(REL_PATH)
+            .is_some()
+    );
+    fixture.recover();
+    assert_eq!(reads.load(Ordering::SeqCst), 1);
+    let index = fixture.state.index.read().unwrap();
+    assert!(!index.live.has_path(REL_PATH));
+    assert_eq!(index.live.dirty_count(), 0);
+}
+
+#[test]
+fn subscription_recovery_keeps_unchanged_versions_on_the_metadata_fast_path() {
+    let fixture = Fixture::new();
+    let before = fixture.state.file_evidence.read().unwrap().clone();
+    let generation = fixture.state.cache_generation.load(Ordering::SeqCst);
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(|phase| {
+        if matches!(phase, StaleRefreshPhase::AfterConcreteRead) {
+            panic!("unchanged recovery must not re-read and verify file contents");
+        }
+    }));
+    fixture.recover();
+    assert_eq!(*fixture.state.file_evidence.read().unwrap(), before);
+    assert_eq!(
+        fixture.state.cache_generation.load(Ordering::SeqCst),
+        generation
+    );
+    assert_eq!(fixture.state.index.read().unwrap().live.dirty_count(), 0);
+}
+
+#[test]
+fn subscription_recovery_rejects_changes_after_read_or_before_commit() {
+    for change_after_read in [true, false] {
+        let fixture = Fixture::new();
+        let modified = fixture.modified + Duration::from_secs(2);
+        fixture.write(NEW, modified);
+        // Coalesce the retry instead of starting a refresh that races these assertions.
+        fixture
+            .state
+            .ignore_refresh_scheduled
+            .store(true, Ordering::SeqCst);
+        let path = fixture.path.clone();
+        *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+            if (change_after_read && matches!(phase, StaleRefreshPhase::AfterConcreteRead))
+                || (!change_after_read && matches!(phase, StaleRefreshPhase::BeforeConcreteCommit))
+            {
+                std::fs::write(&path, LATEST).unwrap();
+                File::options()
+                    .write(true)
+                    .open(&path)
+                    .unwrap()
+                    .set_times(std::fs::FileTimes::new().set_modified(modified))
+                    .unwrap();
+            }
+        }));
+
+        fixture.recover();
+        assert_eq!(
+            fixture.state.index.read().unwrap().live.dirty_count(),
+            0,
+            "recovery must not publish bytes invalidated during verification"
+        );
+        assert!(fixture.state.ignore_rules_dirty.load(Ordering::SeqCst));
+        let evidence = fixture.state.file_evidence.read().unwrap();
+        assert_eq!(
+            evidence.stamp(REL_PATH),
+            Some(&tgrep_core::meta::FileStamp {
+                mtime: u64::MAX,
+                size: u64::MAX,
+            })
+        );
+        assert!(evidence.version(REL_PATH).is_none());
+        drop(evidence);
+
+        *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+        fixture.recover();
+        fixture.assert_matches("end_recovery_marker", 1);
+        fixture.assert_matches("new_recovery_marker", 0);
+    }
+}

--- a/tgrep-cli/src/status.rs
+++ b/tgrep-cli/src/status.rs
@@ -36,6 +36,7 @@ pub fn run(root: &Path, index_path: Option<&Path>) -> Result<()> {
                 "inactive"
             }
         );
+        write_refresh_status(&mut std::io::stdout().lock(), &status)?;
         if status.indexing {
             println!(
                 "  Indexing:   {}/{} files",
@@ -73,12 +74,90 @@ struct StatusResult {
     cache_size: u64,
     cache_capacity: u64,
     watcher_active: bool,
+    watch_mode_requested: Option<String>,
+    watch_mode_active: Option<String>,
+    watch_fallback_reason: Option<String>,
+    watch_budget: Option<usize>,
+    poll_interval_secs: Option<u64>,
+    last_reconcile_at: Option<u64>,
+    last_reconcile_duration_ms: Option<u64>,
+    last_reconcile_error: Option<String>,
+    #[serde(default)]
+    reconcile_running: bool,
+    reconcile_pending: Option<bool>,
+    reconcile_overdue: Option<bool>,
     #[serde(default)]
     indexing: bool,
     #[serde(default)]
     index_progress: u64,
     #[serde(default)]
     index_total: u64,
+}
+
+fn write_refresh_status(writer: &mut impl Write, status: &StatusResult) -> std::io::Result<()> {
+    if let Some(mode) = &status.watch_mode_active {
+        write!(writer, "  Watch mode: {mode}")?;
+        if let Some(requested) = &status.watch_mode_requested {
+            write!(writer, " (requested: {requested})")?;
+        }
+        writeln!(writer)?;
+    } else if let Some(requested) = &status.watch_mode_requested {
+        writeln!(writer, "  Requested:  {requested}")?;
+    }
+    if let Some(reason) = &status.watch_fallback_reason {
+        writeln!(writer, "  Fallback:   {reason}")?;
+    }
+    if let Some(budget) = status.watch_budget {
+        writeln!(writer, "  Watch budget: {budget}")?;
+    }
+    if let Some(interval) = status.poll_interval_secs {
+        writeln!(writer, "  Poll interval: {interval}s (after completion)")?;
+    }
+    if status.watch_mode_active.is_some()
+        || status.watch_mode_requested.is_some()
+        || status.reconcile_running
+    {
+        writeln!(
+            writer,
+            "  Reconcile:  {}",
+            if status.reconcile_running {
+                "running"
+            } else {
+                "idle"
+            }
+        )?;
+        if status.last_reconcile_at.is_none() {
+            writeln!(writer, "  Last successful reconcile: never")?;
+        }
+    }
+    if let Some(timestamp) = status.last_reconcile_at {
+        writeln!(
+            writer,
+            "  Last successful reconcile: {}",
+            format_timestamp(timestamp)
+        )?;
+    }
+    if let Some(pending) = status.reconcile_pending {
+        writeln!(
+            writer,
+            "  Reconcile pending: {}",
+            if pending { "yes" } else { "no" }
+        )?;
+    }
+    if let Some(overdue) = status.reconcile_overdue {
+        writeln!(
+            writer,
+            "  Reconcile overdue: {}",
+            if overdue { "yes" } else { "no" }
+        )?;
+    }
+    if let Some(duration) = status.last_reconcile_duration_ms {
+        writeln!(writer, "  Last reconcile duration: {duration}ms")?;
+    }
+    if let Some(error) = &status.last_reconcile_error {
+        writeln!(writer, "  Last reconcile error: {error}")?;
+    }
+    Ok(())
 }
 
 fn query_server_status(info: &ServerInfo) -> Result<StatusResult> {
@@ -118,5 +197,128 @@ fn format_timestamp(ts: u64) -> String {
         format!("{}h ago", age / 3600)
     } else {
         format!("{}d ago", age / 86400)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn legacy_status() -> serde_json::Value {
+        serde_json::json!({
+            "num_files": 152,
+            "num_trigrams": 12265,
+            "cache_size": 2,
+            "cache_capacity": 50000,
+            "watcher_active": true
+        })
+    }
+
+    fn render(status: &StatusResult) -> String {
+        let mut output = Vec::new();
+        write_refresh_status(&mut output, status).unwrap();
+        String::from_utf8(output).unwrap()
+    }
+
+    #[test]
+    fn refresh_legacy_status_remains_compatible() {
+        let status: StatusResult = serde_json::from_value(legacy_status()).unwrap();
+        assert!(status.watcher_active);
+        assert!(!status.indexing);
+        assert!(!status.reconcile_running);
+        assert!(status.watch_mode_requested.is_none());
+        assert!(status.watch_mode_active.is_none());
+        assert!(status.watch_budget.is_none());
+        assert!(status.poll_interval_secs.is_none());
+        assert!(status.reconcile_pending.is_none());
+        assert!(status.reconcile_overdue.is_none());
+        assert_eq!(render(&status), "");
+    }
+
+    #[test]
+    fn refresh_status_renders_fallback_timing_and_failure() {
+        let mut json = legacy_status();
+        json.as_object_mut().unwrap().extend(
+            serde_json::json!({
+                "watcher_active": false,
+                "watch_mode_requested": "auto",
+                "watch_mode_active": "poll",
+                "watch_fallback_reason": "watch_budget_exceeded",
+                "watch_budget": 8192,
+                "poll_interval_secs": 120,
+                "last_reconcile_at": 1,
+                "last_reconcile_duration_ms": 42,
+                "last_reconcile_error": "reconcile failed",
+                "reconcile_running": true,
+                "reconcile_pending": true,
+                "reconcile_overdue": true,
+                "future_status_field": "ignored"
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+        );
+        let status: StatusResult = serde_json::from_value(json).unwrap();
+        assert!(!status.watcher_active);
+        let output = render(&status);
+        for expected in [
+            "Watch mode: poll (requested: auto)",
+            "Fallback:   watch_budget_exceeded",
+            "Watch budget: 8192",
+            "Poll interval: 120s (after completion)",
+            "Reconcile:  running",
+            "Reconcile pending: yes",
+            "Reconcile overdue: yes",
+            "Last reconcile duration: 42ms",
+            "Last reconcile error: reconcile failed",
+        ] {
+            assert!(
+                output.contains(expected),
+                "missing {expected:?} in {output}"
+            );
+        }
+        assert!(output.contains(&format!(
+            "Last successful reconcile: {}",
+            format_timestamp(1)
+        )));
+    }
+
+    #[test]
+    fn refresh_status_accepts_null_optional_fields_and_each_mode() {
+        for (requested, active) in [
+            ("auto", "native"),
+            ("auto", "starting"),
+            ("poll", "poll"),
+            ("disabled", "disabled"),
+        ] {
+            let mut json = legacy_status();
+            json.as_object_mut().unwrap().extend(
+                serde_json::json!({
+                    "watch_mode_requested": requested,
+                    "watch_mode_active": active,
+                    "watch_fallback_reason": null,
+                    "watch_budget": null,
+                    "poll_interval_secs": null,
+                    "last_reconcile_at": null,
+                    "last_reconcile_duration_ms": null,
+                    "last_reconcile_error": null,
+                    "reconcile_running": false,
+                    "reconcile_pending": false,
+                    "reconcile_overdue": false
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            );
+            let status: StatusResult = serde_json::from_value(json).unwrap();
+            let output = render(&status);
+            assert!(output.contains(&format!("Watch mode: {active} (requested: {requested})")));
+            assert!(output.contains("Reconcile:  idle"));
+            assert!(output.contains("Reconcile pending: no"));
+            assert!(output.contains("Reconcile overdue: no"));
+            assert!(output.contains("Last successful reconcile: never"));
+            assert!(!output.contains("Fallback:"));
+            assert!(!output.contains("Last reconcile error:"));
+        }
     }
 }

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -146,6 +146,118 @@ fn wait_for_server(index_dir: &Path) -> (u32, u16) {
     }
 }
 
+fn server_status(port: u16) -> serde_json::Value {
+    let response = send_request(port, r#"{"jsonrpc":"2.0","method":"status","id":1}"#).unwrap();
+    serde_json::from_str::<serde_json::Value>(&response).unwrap()["result"].clone()
+}
+
+fn assert_polling_server_refreshes(mode_args: &[&str]) {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let index_dir = root.join(".tgrep");
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("excluded")).unwrap();
+    fs::write(root.join(".ignore"), "excluded/\n").unwrap();
+    fs::write(root.join("src").join("old.txt"), "poll_original_marker\n").unwrap();
+    fs::write(
+        root.join("excluded").join("hidden.txt"),
+        "poll_unignored_marker\n",
+    )
+    .unwrap();
+    let child = Command::new(tgrep_bin())
+        .arg("serve")
+        .args(mode_args)
+        .args(["--poll-interval", "1", "--index-path"])
+        .arg(&index_dir)
+        .arg(root)
+        .stdout(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+    let _server = ServerGuard { child };
+    let (_pid, port) = wait_for_server(&index_dir);
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let status = server_status(port);
+        if status["indexing"] == false && status["last_reconcile_at"].is_u64() {
+            assert_eq!(status["watch_mode_active"], "poll");
+            assert_eq!(status["watcher_active"], false);
+            assert!(status["last_reconcile_error"].is_null());
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "poll bootstrap stalled: {status}"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+    #[cfg(target_os = "linux")]
+    assert_eq!(inotify_watch_count(_pid), 0);
+    assert_eq!(search_matches(port, "poll_original_marker"), 1);
+    assert_eq!(search_matches(port, "poll_unignored_marker"), 0);
+
+    fs::write(root.join("src").join("old.txt"), "poll_modified_marker\n").unwrap();
+    fs::create_dir_all(root.join("new").join("nested")).unwrap();
+    fs::write(
+        root.join("new").join("nested").join("added.txt"),
+        "poll_added_marker\n",
+    )
+    .unwrap();
+    // Repeated searches intentionally deny the native safety loop's quiet
+    // period. They must not defer the polling cadence.
+    assert!(wait_for_match(
+        port,
+        "poll_modified_marker",
+        Duration::from_secs(15)
+    ));
+    assert!(wait_for_match(
+        port,
+        "poll_added_marker",
+        Duration::from_secs(15)
+    ));
+    fs::write(root.join(".ignore"), "").unwrap();
+    assert!(wait_for_match(
+        port,
+        "poll_unignored_marker",
+        Duration::from_secs(15)
+    ));
+
+    fs::rename(root.join("src").join("old.txt"), root.join("renamed.txt")).unwrap();
+    fs::remove_file(root.join("new").join("nested").join("added.txt")).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let evidence = tgrep_core::meta::read_file_evidence(&index_dir).unwrap();
+        if evidence.stamps.contains_key("renamed.txt")
+            && !evidence.stamps.contains_key("src/old.txt")
+            && !evidence.stamps.contains_key("new/nested/added.txt")
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "poll did not reconcile rename/deletion"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(search_matches(port, "poll_modified_marker"), 1);
+    assert_eq!(search_matches(port, "poll_added_marker"), 0);
+    let status = server_status(port);
+    assert_eq!(status["watch_mode_active"], "poll");
+    assert!(status["last_reconcile_error"].is_null());
+    #[cfg(target_os = "linux")]
+    assert_eq!(inotify_watch_count(_pid), 0);
+}
+
+#[test]
+fn explicit_polling_bootstraps_and_refreshes_without_native_watches() {
+    assert_polling_server_refreshes(&["--watch-mode", "poll"]);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn tiny_native_budget_falls_back_and_finishes_bootstrap() {
+    assert_polling_server_refreshes(&["--watch-budget", "1"]);
+}
+
 /// Total inotify watch descriptors held by `pid`.
 ///
 /// Each inotify file descriptor's `fdinfo` lists one `inotify wd:` line per

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use crate::external::{self, ExternalSorter, TrigramPosting};
 use crate::meta::{self, IndexMeta};
+pub use crate::meta::{FileVersion, file_version};
 use crate::ondisk::{
     self, LOOKUP_WRITE_CHUNK_ENTRIES, LookupEntry, POSTING_WRITE_CHUNK_ENTRIES, PostingEntry,
     flush_lookup_entries, write_lookup_entry, write_posting_entries,
@@ -154,6 +155,9 @@ impl PostingSink {
 pub struct BuildOutcome {
     /// Number of files written to the index.
     pub num_files: usize,
+    /// Versions validated around the reads that produced indexed text or
+    /// binary classifications. Missing entries must be treated as unverified.
+    pub versions: HashMap<String, FileVersion>,
     /// Absolute `.gitignore` paths seen during the walk, when
     /// [`BuildOptions::collect_gitignore_files`] was set; empty otherwise.
     ///
@@ -404,48 +408,81 @@ impl Drop for OwnedReadPermit {
     }
 }
 
-type ExtractedFile = (String, trigram::TrigramMaskMap, meta::ContentId);
-
-/// Full-resolution identity used to validate that bytes came from one file
-/// version without changing the persisted [`meta::FileStamp`] format.
-#[doc(hidden)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FileVersion {
-    stamp: meta::FileStamp,
-    modified: Option<std::time::SystemTime>,
-    created: Option<std::time::SystemTime>,
-    #[cfg(unix)]
-    device: u64,
-    #[cfg(unix)]
-    inode: u64,
-    #[cfg(unix)]
-    change_seconds: i64,
-    #[cfg(unix)]
-    change_nanos: i64,
+struct ExtractedFile {
+    path: String,
+    trigrams: Option<trigram::TrigramMaskMap>,
+    content_id: Option<meta::ContentId>,
+    version: Option<FileVersion>,
 }
 
-impl FileVersion {
-    pub fn stamp(&self) -> &meta::FileStamp {
-        &self.stamp
+struct IndexRead {
+    bytes: FileBytes,
+    file: std::fs::File,
+    version: Option<FileVersion>,
+}
+
+impl IndexRead {
+    fn open(
+        path: &Path,
+        read: impl FnOnce(&mut std::fs::File) -> std::io::Result<FileBytes>,
+    ) -> std::io::Result<Self> {
+        let mut file = std::fs::File::open(path)?;
+        let version = file.metadata().ok().map(|metadata| file_version(&metadata));
+        let bytes = read(&mut file)?;
+        Ok(Self {
+            bytes,
+            file,
+            version,
+        })
+    }
+
+    /// Call after decoding, classification, and extraction: mapped bytes can
+    /// change even after the initial read/map has completed.
+    fn verified_version(&self) -> Option<FileVersion> {
+        let version = self
+            .version
+            .as_ref()
+            .filter(|version| version.is_trusted())?;
+        (self.bytes.len() as u64 == version.stamp().size
+            && self
+                .file
+                .metadata()
+                .is_ok_and(|metadata| file_version(&metadata) == *version))
+        .then(|| version.clone())
     }
 }
 
-#[doc(hidden)]
-pub fn file_version(metadata: &std::fs::Metadata) -> FileVersion {
-    #[cfg(unix)]
-    use std::os::unix::fs::MetadataExt;
-    FileVersion {
-        stamp: meta::file_stamp(metadata),
-        modified: metadata.modified().ok(),
-        created: metadata.created().ok(),
-        #[cfg(unix)]
-        device: metadata.dev(),
-        #[cfg(unix)]
-        inode: metadata.ino(),
-        #[cfg(unix)]
-        change_seconds: metadata.ctime(),
-        #[cfg(unix)]
-        change_nanos: metadata.ctime_nsec(),
+impl std::ops::Deref for IndexRead {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+fn extract_indexed_file(path: String, data: &IndexRead) -> ExtractedFile {
+    let text = crate::encoding::decode_for_index(data);
+    let (trigrams, content_id) = if trigram::is_binary(&text) {
+        (None, None)
+    } else {
+        (
+            Some(trigram::extract_merged_masks(&text)),
+            Some(meta::ContentId::from_indexed_bytes(&text)),
+        )
+    };
+    let version = data.verified_version();
+    // Unlike owned bytes, a raced map may have changed between extracting
+    // postings and hashing. Its identity cannot safely deduplicate a retry.
+    let content_id = if version.is_none() && matches!(data.bytes, FileBytes::Mapped(_)) {
+        None
+    } else {
+        content_id
+    };
+    ExtractedFile {
+        path,
+        trigrams,
+        content_id,
+        version,
     }
 }
 
@@ -471,7 +508,7 @@ fn read_for_index(
     size: u64,
     owned_budget: &std::sync::Arc<OwnedReadBudget>,
     configured_limit: Option<u64>,
-) -> std::io::Result<FileBytes> {
+) -> std::io::Result<IndexRead> {
     let owned_limit = configured_limit.unwrap_or(u64::MAX);
     if size > owned_limit {
         return Err(std::io::Error::new(
@@ -485,54 +522,59 @@ fn read_for_index(
         // truncation would be undefined behaviour; that is inherent to mapping
         // a file being indexed, and is the same exposure the search path
         // accepts.
-        let mapped =
-            std::fs::File::open(path).and_then(|file| unsafe { memmap2::Mmap::map(&file) });
-        if let Ok(map) = mapped
-            && map.len() as u64 <= owned_limit
+        let mapped = IndexRead::open(path, |file| {
+            unsafe { memmap2::Mmap::map(&*file) }.map(FileBytes::Mapped)
+        });
+        if let Ok(data) = mapped
+            && data.len() as u64 <= owned_limit
         {
-            return Ok(FileBytes::Mapped(map));
+            return Ok(data);
         }
         // The file grew between the walk's stat and the map. Do not let a
         // successful mmap bypass a caller-supplied max-file-size limit.
     }
     let permit = owned_budget.acquire(size);
-    match read_owned_for_index(path, size, owned_limit) {
-        Ok(bytes) => Ok(FileBytes::Read {
+    match IndexRead::open(path, |file| {
+        read_owned_for_index(file, size, owned_limit).map(|bytes| FileBytes::Read {
             bytes,
             _permit: permit,
-        }),
+        })
+    }) {
+        Ok(data) => Ok(data),
         Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
             // The file grew after it was stat'd. Release the smaller claim
             // before waiting for the retry allowance so concurrent growers
             // cannot deadlock while each holds part of the batch budget.
-            drop(permit);
             match configured_limit {
                 Some(limit) => {
                     let permit = owned_budget.acquire(limit);
-                    read_owned_for_index(path, limit, limit)
-                        .map(|bytes| FileBytes::Read {
+                    IndexRead::open(path, |file| {
+                        read_owned_for_index(file, limit, limit).map(|bytes| FileBytes::Read {
                             bytes,
                             _permit: permit,
                         })
-                        .map_err(|retry| {
-                            if retry.kind() == std::io::ErrorKind::WouldBlock {
-                                std::io::Error::new(
-                                    std::io::ErrorKind::InvalidData,
-                                    format!("file exceeds the configured {} byte limit", limit),
-                                )
-                            } else {
-                                retry
-                            }
-                        })
+                    })
+                    .map_err(|retry| {
+                        if retry.kind() == std::io::ErrorKind::WouldBlock {
+                            std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                format!("file exceeds the configured {} byte limit", limit),
+                            )
+                        } else {
+                            retry
+                        }
+                    })
                 }
                 None => {
                     // No caller limit means no implicit fallback limit either.
                     // Claiming more than the budget takes it exclusively, so
                     // this unbounded read cannot overlap another owned buffer.
                     let permit = owned_budget.acquire(u64::MAX);
-                    read_owned_unbounded(path, size).map(|bytes| FileBytes::Read {
-                        bytes,
-                        _permit: permit,
+                    IndexRead::open(path, |file| {
+                        read_owned_unbounded(file, size).map(|bytes| FileBytes::Read {
+                            bytes,
+                            _permit: permit,
+                        })
                     })
                 }
             }
@@ -541,7 +583,11 @@ fn read_for_index(
     }
 }
 
-fn read_owned_for_index(path: &Path, size: u64, owned_limit: u64) -> std::io::Result<Vec<u8>> {
+fn read_owned_for_index(
+    file: &mut std::fs::File,
+    size: u64,
+    owned_limit: u64,
+) -> std::io::Result<Vec<u8>> {
     use std::io::Read;
 
     if size > owned_limit {
@@ -550,9 +596,8 @@ fn read_owned_for_index(path: &Path, size: u64, owned_limit: u64) -> std::io::Re
             format!("file exceeds the configured {} byte limit", owned_limit),
         ));
     }
-    let mut file = std::fs::File::open(path)?;
     let mut bytes = Vec::with_capacity(usize::try_from(size).unwrap_or(0));
-    std::io::Read::by_ref(&mut file)
+    std::io::Read::by_ref(file)
         .take(size)
         .read_to_end(&mut bytes)?;
     let mut extra = [0u8; 1];
@@ -565,10 +610,9 @@ fn read_owned_for_index(path: &Path, size: u64, owned_limit: u64) -> std::io::Re
     Ok(bytes)
 }
 
-fn read_owned_unbounded(path: &Path, expected_size: u64) -> std::io::Result<Vec<u8>> {
+fn read_owned_unbounded(file: &mut std::fs::File, expected_size: u64) -> std::io::Result<Vec<u8>> {
     use std::io::Read;
 
-    let mut file = std::fs::File::open(path)?;
     let initial_capacity = expected_size.min(MAX_OWNED_FILE_BYTES);
     let mut bytes = Vec::with_capacity(usize::try_from(initial_capacity).unwrap_or(0));
     file.read_to_end(&mut bytes)?;
@@ -652,6 +696,7 @@ pub fn build_index_with_options_and_ignorecase(
     // resident at once, since the whole batch is read concurrently.
     let mut file_id_map: Vec<(u32, String)> = Vec::with_capacity(walk.files.len());
     let mut content_ids = HashMap::with_capacity(walk.files.len());
+    let mut versions = HashMap::with_capacity(walk.files.len());
     let mut sink = match opts.strategy {
         IndexStrategy::InMemory => PostingSink::InMemory(Vec::new()),
         IndexStrategy::External => {
@@ -682,25 +727,28 @@ pub fn build_index_with_options_and_ignorecase(
                         return None;
                     }
                 };
-                let text = crate::encoding::decode_for_index(&data);
-                if trigram::is_binary(&text) {
-                    binary_skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    return None;
-                }
                 let rel = path
                     .strip_prefix(&root)
                     .unwrap_or(path)
                     .to_string_lossy()
                     .replace('\\', "/");
-                let per_tri = trigram::extract_merged_masks(&text);
-                let content_id = meta::ContentId::from_indexed_bytes(&text);
-                Some((rel, per_tri, content_id))
+                Some(extract_indexed_file(rel, &data))
             })
             .collect();
 
-        for (path, per_tri, content_id) in batch_data {
+        for extracted in batch_data {
+            let path = extracted.path;
+            if let Some(version) = extracted.version {
+                versions.insert(path.clone(), version);
+            }
+            let Some(per_tri) = extracted.trigrams else {
+                binary_skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                continue;
+            };
             let file_id = file_id_map.len() as u32;
-            content_ids.insert(path.clone(), content_id);
+            if let Some(content_id) = extracted.content_id {
+                content_ids.insert(path.clone(), content_id);
+            }
             file_id_map.push((file_id, path));
             sink.push_file(file_id, per_tri)?;
         }
@@ -737,9 +785,8 @@ pub fn build_index_with_options_and_ignorecase(
         }
     }
 
-    // Write per-file stamps for walked files, including those later rejected
-    // as binary-by-content. A file that raced past max-file-size is different:
-    // withholding its stamp leaves it eligible for a later retry.
+    // Publish only read-bound stamps, including verified binary classifications.
+    // A later stat must never make an unreadable or raced read look current.
     let raced_too_large = raced_too_large.into_inner().unwrap();
     if !raced_too_large.is_empty() {
         eprintln!(
@@ -747,11 +794,11 @@ pub fn build_index_with_options_and_ignorecase(
             raced_too_large.len()
         );
     }
-    let all_walked = walked_paths_for_stamps(&root, &walk.files, &raced_too_large);
-    let stamps = meta::collect_filestamps(&root, &all_walked);
-    let mut evidence = meta::FileEvidence::from_stamps(stamps);
-    content_ids.retain(|path, _| evidence.stamps.contains_key(path));
-    evidence.content_ids = content_ids;
+    let evidence = evidence_for_indexed_reads(
+        walked_paths_for_stamps(&root, &walk.files, &raced_too_large),
+        versions,
+        content_ids,
+    );
 
     let indexed_paths: HashSet<&str> = file_id_map.iter().map(|(_, path)| path.as_str()).collect();
     let mut extra_paths: Vec<String> = walk
@@ -770,9 +817,25 @@ pub fn build_index_with_options_and_ignorecase(
     eprintln!("Index built successfully at {}", index_dir.display());
     Ok(BuildOutcome {
         num_files: file_id_map.len(),
+        versions: evidence.versions,
         gitignore_files,
         ignore_files,
     })
+}
+
+fn evidence_for_indexed_reads(
+    paths: Vec<String>,
+    mut versions: HashMap<String, FileVersion>,
+    mut content_ids: HashMap<String, meta::ContentId>,
+) -> meta::FileEvidence {
+    let mut evidence = meta::FileEvidence::default();
+    for path in paths {
+        if let Some(version) = versions.remove(&path) {
+            let content_id = content_ids.remove(&path);
+            evidence.insert_verified(path, version.stamp().clone(), content_id, Some(version));
+        }
+    }
+    evidence
 }
 
 /// Outcome of [`build_index_for_files`].
@@ -780,7 +843,8 @@ pub fn build_index_with_options_and_ignorecase(
 pub struct FileDeltaOutcome {
     /// Number of text files written into the delta index.
     pub indexed: usize,
-    /// Paths that could not be read, and are therefore absent from the delta.
+    /// Paths that could not be read at a verified version, and are therefore
+    /// absent from the delta.
     ///
     /// The caller must drop these from the filestamp set it publishes. A stamp
     /// asserts "this file is indexed at this version"; publishing one for a
@@ -795,6 +859,9 @@ pub struct FileDeltaOutcome {
     pub unreadable: Vec<std::path::PathBuf>,
     /// Identities of the decoded bytes that produced successful text entries.
     pub content_ids: HashMap<String, meta::ContentId>,
+    /// Read-bound versions, including successful binary classifications.
+    /// A missing version must not be replaced with a later filesystem stat.
+    pub versions: HashMap<String, FileVersion>,
 }
 
 /// Build an external-sort index for an exact list of absolute file paths.
@@ -825,6 +892,7 @@ pub fn build_index_for_files(
     let mut sorter = ExternalSorter::new(index_dir, buffer_bytes);
     let mut unreadable: Vec<std::path::PathBuf> = Vec::new();
     let mut content_ids = HashMap::with_capacity(files.len());
+    let mut versions = HashMap::with_capacity(files.len());
 
     for range in batch_ranges(&charges, INDEX_BUILD_BATCH_BYTES) {
         let batch = &files[range.clone()];
@@ -833,44 +901,53 @@ pub fn build_index_for_files(
         let batch_data: Vec<std::result::Result<ExtractedFile, std::path::PathBuf>> = batch
             .par_iter()
             .zip(batch_sizes.par_iter())
-            .filter_map(|(path, &size)| {
+            .map(|(path, &size)| {
                 let data = match read_for_index(path, size, &owned_budget, None) {
                     Ok(data) => data,
                     Err(error) => {
                         eprintln!("tgrep: skipping {}: {error}", path.display());
-                        return Some(Err(path.clone()));
+                        return Err(path.clone());
                     }
                 };
-                let text = crate::encoding::decode_for_index(&data);
-                if trigram::is_binary(&text) {
-                    return None;
-                }
                 let rel = path
                     .strip_prefix(&root)
                     .or_else(|_| path.strip_prefix(input_root))
                     .unwrap_or(path)
                     .to_string_lossy()
                     .replace('\\', "/");
-                Some(Ok((
-                    rel,
-                    trigram::extract_merged_masks(&text),
-                    meta::ContentId::from_indexed_bytes(&text),
-                )))
+                let extracted = extract_indexed_file(rel, &data);
+                if extracted.version.is_none() {
+                    eprintln!(
+                        "tgrep: skipping {}: file changed during extraction or precise metadata is unavailable",
+                        path.display()
+                    );
+                    return Err(path.clone());
+                }
+                Ok(extracted)
             })
             .collect();
 
         for entry in batch_data {
-            let (path, per_tri, content_id) = match entry {
+            let extracted = match entry {
                 Ok(extracted) => extracted,
                 Err(skipped) => {
                     unreadable.push(skipped);
                     continue;
                 }
             };
+            let path = extracted.path;
+            if let Some(version) = extracted.version {
+                versions.insert(path.clone(), version);
+            }
+            let Some(per_tri) = extracted.trigrams else {
+                continue;
+            };
             let file_id = u32::try_from(file_id_map.len()).map_err(|_| {
                 Error::IndexCorrupted("file count exceeds the u32 file-id limit".into())
             })?;
-            content_ids.insert(path.clone(), content_id);
+            if let Some(content_id) = extracted.content_id {
+                content_ids.insert(path.clone(), content_id);
+            }
             file_id_map.push((file_id, path));
             sorter.push_file(file_id, per_tri)?;
         }
@@ -889,6 +966,7 @@ pub fn build_index_for_files(
         indexed: file_id_map.len(),
         unreadable,
         content_ids,
+        versions,
     })
 }
 
@@ -1535,6 +1613,27 @@ mod tests {
     }
 
     #[test]
+    fn publication_never_stamps_a_missing_read_version_from_current_metadata() {
+        let repo = tempfile::tempdir().unwrap();
+        let path = repo.path().join("source.rs");
+        std::fs::write(&path, b"old text").unwrap();
+        let version = file_version(&std::fs::metadata(&path).unwrap());
+        std::fs::write(&path, b"newer longer text").unwrap();
+        let evidence = evidence_for_indexed_reads(
+            vec!["source.rs".into(), "unverified.rs".into()],
+            HashMap::from([("source.rs".into(), version.clone())]),
+            HashMap::new(),
+        );
+        assert_eq!(evidence.stamp("source.rs"), Some(version.stamp()));
+        assert_ne!(
+            evidence.stamp("source.rs"),
+            Some(&meta::file_stamp(&std::fs::metadata(path).unwrap()))
+        );
+        assert!(evidence.stamp("unverified.rs").is_none());
+        assert!(evidence.version("unverified.rs").is_none());
+    }
+
+    #[test]
     fn full_builder_records_exact_decoded_identity_for_text_only() {
         let repo = tempfile::tempdir().unwrap();
         let text_path = repo.path().join("text.rs");
@@ -1545,7 +1644,7 @@ mod tests {
 
         for strategy in [IndexStrategy::InMemory, IndexStrategy::External] {
             let index = tempfile::tempdir().unwrap();
-            build_index_with_options(
+            let outcome = build_index_with_options(
                 repo.path(),
                 Some(index.path()),
                 &BuildOptions {
@@ -1562,6 +1661,13 @@ mod tests {
                 Some(meta::ContentId::from_indexed_bytes(&decoded))
             );
             assert_eq!(evidence.content_id("binary.rs"), None);
+            assert_eq!(outcome.versions, evidence.versions);
+            for (path, full_path) in [("text.rs", &text_path), ("binary.rs", &binary_path)] {
+                assert_eq!(
+                    evidence.version(path),
+                    Some(&file_version(&std::fs::metadata(full_path).unwrap()))
+                );
+            }
         }
     }
 
@@ -1677,8 +1783,12 @@ mod tests {
             .set_len(MAX_OWNED_FILE_BYTES + 1)
             .unwrap();
 
-        let error = read_owned_for_index(&path, MAX_OWNED_FILE_BYTES + 1, MAX_OWNED_FILE_BYTES)
-            .unwrap_err();
+        let error = read_owned_for_index(
+            &mut std::fs::File::open(&path).unwrap(),
+            MAX_OWNED_FILE_BYTES + 1,
+            MAX_OWNED_FILE_BYTES,
+        )
+        .unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
     }
 
@@ -1705,7 +1815,8 @@ mod tests {
         let path = tmp.path().join("growing.txt");
         std::fs::write(&path, b"four").unwrap();
 
-        let error = read_owned_for_index(&path, 2, 2).unwrap_err();
+        let error =
+            read_owned_for_index(&mut std::fs::File::open(&path).unwrap(), 2, 2).unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
     }
 
@@ -1718,6 +1829,10 @@ mod tests {
 
         let bytes = read_for_index(&path, 2, &budget, None).unwrap();
         assert_eq!(&*bytes, b"four");
+        assert_eq!(
+            bytes.verified_version(),
+            Some(file_version(&std::fs::metadata(&path).unwrap()))
+        );
     }
 
     #[test]
@@ -1766,29 +1881,115 @@ mod tests {
     }
 
     #[test]
-    fn file_version_distinguishes_subsecond_modified_times() {
-        let stamp = meta::FileStamp { mtime: 1, size: 10 };
-        let base = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1);
-        let first = FileVersion {
-            stamp: stamp.clone(),
-            modified: Some(base + std::time::Duration::from_nanos(100)),
-            created: Some(base),
-            #[cfg(unix)]
-            device: 1,
-            #[cfg(unix)]
-            inode: 2,
-            #[cfg(unix)]
-            change_seconds: 1,
-            #[cfg(unix)]
-            change_nanos: 0,
-        };
-        let second = FileVersion {
-            modified: Some(base + std::time::Duration::from_nanos(200)),
-            ..first.clone()
-        };
+    fn indexed_read_race_withholds_version_without_changing_decoded_identity() {
+        let repo = tempfile::tempdir().unwrap();
+        let path = repo.path().join("race.rs");
+        let original = b"old decoded text\xff";
+        std::fs::write(&path, original).unwrap();
+        let file = std::fs::File::options().write(true).open(&path).unwrap();
+        let old_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        file.set_modified(old_time).unwrap();
+        drop(file);
+        let budget = OwnedReadBudget::new(INDEX_BUILD_BATCH_BYTES);
+        let data = read_for_index(&path, original.len() as u64, &budget, None).unwrap();
 
-        assert_ne!(first, second);
-        assert_eq!(first.stamp, second.stamp);
+        std::fs::write(&path, b"new decoded text\xff").unwrap();
+        let extracted = extract_indexed_file("race.rs".into(), &data);
+        assert_eq!(
+            extracted.content_id,
+            Some(meta::ContentId::from_indexed_bytes(
+                &crate::encoding::decode_for_index(original)
+            ))
+        );
+        assert!(extracted.version.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn indexed_read_mtime_restore_race_withholds_version() {
+        let repo = tempfile::tempdir().unwrap();
+        let path = repo.path().join("restored.rs");
+        std::fs::write(&path, b"old text").unwrap();
+        let before = std::fs::metadata(&path).unwrap();
+        let budget = OwnedReadBudget::new(INDEX_BUILD_BATCH_BYTES);
+        let data = read_for_index(&path, 8, &budget, None).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&path, b"new text").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(before.modified().unwrap())
+            .unwrap();
+
+        assert_eq!(
+            meta::file_stamp(&before),
+            meta::file_stamp(&std::fs::metadata(&path).unwrap())
+        );
+        let extracted = extract_indexed_file("restored.rs".into(), &data);
+        assert_eq!(
+            extracted.content_id,
+            Some(meta::ContentId::from_indexed_bytes(b"old text"))
+        );
+        assert!(extracted.version.is_none());
+    }
+
+    #[test]
+    fn indexed_version_is_not_replaced_by_metadata_after_extraction() {
+        let repo = tempfile::tempdir().unwrap();
+        let path = repo.path().join("race.rs");
+        std::fs::write(&path, b"old text").unwrap();
+        let budget = OwnedReadBudget::new(INDEX_BUILD_BATCH_BYTES);
+        let data = read_for_index(&path, 8, &budget, None).unwrap();
+        let extracted = extract_indexed_file("race.rs".into(), &data);
+        let indexed_version = extracted.version.unwrap();
+        drop(data);
+
+        std::fs::write(&path, b"changed text").unwrap();
+        let current = file_version(&std::fs::metadata(&path).unwrap());
+        assert_ne!(indexed_version, current);
+        assert_eq!(indexed_version.stamp().size, 8);
+    }
+
+    #[test]
+    fn mapped_indexed_read_verifies_version_after_extraction() {
+        let repo = tempfile::tempdir().unwrap();
+        let path = repo.path().join("mapped.rs");
+        std::fs::write(&path, vec![b'a'; MMAP_MIN_BYTES as usize]).unwrap();
+        let budget = OwnedReadBudget::new(INDEX_BUILD_BATCH_BYTES);
+        let data = read_for_index(&path, MMAP_MIN_BYTES, &budget, None).unwrap();
+        assert!(matches!(data.bytes, FileBytes::Mapped(_)));
+        assert!(
+            extract_indexed_file("mapped.rs".into(), &data)
+                .version
+                .is_some()
+        );
+
+        let mut writer = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        writer.write_all(b"b").unwrap();
+        writer
+            .set_modified(std::time::UNIX_EPOCH + std::time::Duration::from_secs(1))
+            .unwrap();
+        drop(writer);
+        let raced = extract_indexed_file("mapped.rs".into(), &data);
+        assert!(raced.version.is_none());
+        assert!(raced.content_id.is_none());
+    }
+
+    #[test]
+    fn indexed_read_without_pre_read_metadata_cannot_gain_trust_after_read() {
+        let repo = tempfile::tempdir().unwrap();
+        let path = repo.path().join("unverified.rs");
+        std::fs::write(&path, b"text").unwrap();
+        let budget = OwnedReadBudget::new(INDEX_BUILD_BATCH_BYTES);
+        let mut data = read_for_index(&path, 4, &budget, None).unwrap();
+        data.version = None;
+        assert!(
+            extract_indexed_file("unverified.rs".into(), &data)
+                .version
+                .is_none()
+        );
     }
 
     fn write_test_git_index(root: &Path, tracked: &[&str]) {
@@ -2362,6 +2563,13 @@ mod tests {
             outcome.content_ids.get("present.txt"),
             Some(&meta::ContentId::from_indexed_bytes(b"needle one\n"))
         );
+        assert_eq!(outcome.versions.len(), 1);
+        assert_eq!(
+            outcome.versions.get("present.txt"),
+            Some(&file_version(
+                &std::fs::metadata(repo.path().join("present.txt")).unwrap()
+            ))
+        );
 
         // The delta is usable, not a half-written casualty of the failure.
         let reader = IndexReader::open(delta.path()).unwrap();
@@ -2390,6 +2598,13 @@ mod tests {
         assert_eq!(outcome.indexed, 0);
         assert!(outcome.unreadable.is_empty());
         assert!(outcome.content_ids.is_empty());
+        assert_eq!(outcome.versions.len(), 1);
+        assert_eq!(
+            outcome.versions.get("blob.bin"),
+            Some(&file_version(
+                &std::fs::metadata(repo.path().join("blob.bin")).unwrap()
+            ))
+        );
     }
 
     #[test]

--- a/tgrep-core/src/meta.rs
+++ b/tgrep-core/src/meta.rs
@@ -70,6 +70,190 @@ pub struct FileStamp {
     pub size: u64,
 }
 
+/// Full-resolution metadata identifying the file version used by an indexed
+/// read. A scan may compare this evidence, but must not create read evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileVersion {
+    stamp: FileStamp,
+    modified: Option<SystemTime>,
+    created: Option<SystemTime>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    change_seconds: i64,
+    #[cfg(unix)]
+    change_nanos: i64,
+}
+
+impl FileVersion {
+    pub fn stamp(&self) -> &FileStamp {
+        &self.stamp
+    }
+
+    /// Whether this platform supplied enough metadata for precise comparisons.
+    pub fn is_trusted(&self) -> bool {
+        if self.modified.is_none() {
+            return false;
+        }
+        #[cfg(unix)]
+        {
+            (0..1_000_000_000).contains(&self.change_nanos)
+        }
+        #[cfg(windows)]
+        {
+            self.created.is_some()
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            false
+        }
+    }
+
+    fn persisted(&self) -> Option<PersistedVersion> {
+        if !self.is_trusted() {
+            return None;
+        }
+        Some(PersistedVersion {
+            schema: 1,
+            platform: std::env::consts::OS.to_string(),
+            size: self.stamp.size,
+            modified: VersionTime::from(self.modified?),
+            created: self.created.map(VersionTime::from),
+            #[cfg(unix)]
+            unix: Some(UnixVersion {
+                device: self.device,
+                inode: self.inode,
+                change_seconds: self.change_seconds,
+                change_nanos: self.change_nanos,
+            }),
+            #[cfg(not(unix))]
+            unix: None,
+        })
+    }
+}
+
+/// Derive precise metadata from an existing stat, without another filesystem
+/// query. Trust as indexed evidence only after validating the associated read.
+pub fn file_version(metadata: &std::fs::Metadata) -> FileVersion {
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
+    FileVersion {
+        stamp: file_stamp(metadata),
+        modified: metadata.modified().ok(),
+        created: metadata.created().ok(),
+        #[cfg(unix)]
+        device: metadata.dev(),
+        #[cfg(unix)]
+        inode: metadata.ino(),
+        #[cfg(unix)]
+        change_seconds: metadata.ctime(),
+        #[cfg(unix)]
+        change_nanos: metadata.ctime_nsec(),
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VersionTime {
+    before_epoch: bool,
+    seconds: u64,
+    nanos: u32,
+}
+
+impl From<SystemTime> for VersionTime {
+    fn from(time: SystemTime) -> Self {
+        let (before_epoch, duration) = match time.duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(duration) => (false, duration),
+            Err(error) => (true, error.duration()),
+        };
+        Self {
+            before_epoch,
+            seconds: duration.as_secs(),
+            nanos: duration.subsec_nanos(),
+        }
+    }
+}
+
+impl VersionTime {
+    fn decode(self) -> Option<SystemTime> {
+        if self.nanos >= 1_000_000_000 {
+            return None;
+        }
+        let duration = std::time::Duration::new(self.seconds, self.nanos);
+        if self.before_epoch {
+            SystemTime::UNIX_EPOCH.checked_sub(duration)
+        } else {
+            SystemTime::UNIX_EPOCH.checked_add(duration)
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UnixVersion {
+    device: u64,
+    inode: u64,
+    change_seconds: i64,
+    change_nanos: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedVersion {
+    schema: u32,
+    platform: String,
+    size: u64,
+    modified: VersionTime,
+    // An explicit null represents unavailable birth time; omission is not
+    // complete evidence for this schema.
+    #[serde(deserialize_with = "Deserialize::deserialize")]
+    created: Option<VersionTime>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unix: Option<UnixVersion>,
+}
+
+impl PersistedVersion {
+    fn decode(self, stamp: FileStamp) -> Option<FileVersion> {
+        if self.schema != 1 || self.platform != std::env::consts::OS || self.size != stamp.size {
+            return None;
+        }
+        let modified = self.modified.decode()?;
+        if modified
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_secs())
+            != stamp.mtime
+        {
+            return None;
+        }
+        let created = match self.created {
+            Some(time) => Some(time.decode()?),
+            None => None,
+        };
+        #[cfg(unix)]
+        let unix = self.unix?;
+        #[cfg(not(unix))]
+        if self.unix.is_some() {
+            return None;
+        }
+        let version = FileVersion {
+            stamp,
+            modified: Some(modified),
+            created,
+            #[cfg(unix)]
+            device: unix.device,
+            #[cfg(unix)]
+            inode: unix.inode,
+            #[cfg(unix)]
+            change_seconds: unix.change_seconds,
+            #[cfg(unix)]
+            change_nanos: unix.change_nanos,
+        };
+        version.is_trusted().then_some(version)
+    }
+}
+
 /// Identity of the decoded bytes used to build one path's postings.
 ///
 /// The domain prefix must change if decoding, binary classification, or posting
@@ -122,11 +306,13 @@ fn hex_digit(digit: u8) -> Option<u8> {
     }
 }
 
-/// Per-path metadata and optional trusted identity from one index generation.
+/// Per-path metadata and optional trusted content/version evidence from one
+/// index generation.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FileEvidence {
     pub stamps: HashMap<String, FileStamp>,
     pub content_ids: HashMap<String, ContentId>,
+    pub versions: HashMap<String, FileVersion>,
 }
 
 impl FileEvidence {
@@ -134,6 +320,7 @@ impl FileEvidence {
         Self {
             stamps,
             content_ids: HashMap::new(),
+            versions: HashMap::new(),
         }
     }
 
@@ -145,7 +332,33 @@ impl FileEvidence {
         self.content_ids.get(path).copied()
     }
 
+    pub fn version(&self, path: &str) -> Option<&FileVersion> {
+        self.versions
+            .get(path)
+            .filter(|version| version.is_trusted() && self.stamp(path) == Some(version.stamp()))
+    }
+
     pub fn insert(&mut self, path: String, stamp: FileStamp, content_id: Option<ContentId>) {
+        self.insert_verified(path, stamp, content_id, None);
+    }
+
+    /// Insert a version validated around the read that produced this path's
+    /// postings (or binary classification), not metadata collected afterwards.
+    /// Omitted or incompatible evidence clears the previous version.
+    pub fn insert_verified(
+        &mut self,
+        path: String,
+        stamp: FileStamp,
+        content_id: Option<ContentId>,
+        version: Option<FileVersion>,
+    ) {
+        if let Some(version) =
+            version.filter(|version| version.is_trusted() && version.stamp() == &stamp)
+        {
+            self.versions.insert(path.clone(), version);
+        } else {
+            self.versions.remove(&path);
+        }
         if let Some(content_id) = content_id {
             self.content_ids.insert(path.clone(), content_id);
         } else {
@@ -155,6 +368,7 @@ impl FileEvidence {
     }
 
     pub fn remove(&mut self, path: &str) -> Option<FileStamp> {
+        self.versions.remove(path);
         self.content_ids.remove(path);
         self.stamps.remove(path)
     }
@@ -162,12 +376,15 @@ impl FileEvidence {
     pub fn clear(&mut self) {
         self.stamps.clear();
         self.content_ids.clear();
+        self.versions.clear();
     }
 
     pub fn retain(&mut self, mut keep: impl FnMut(&str, &FileStamp) -> bool) {
         self.stamps.retain(|path, stamp| keep(path, stamp));
         self.content_ids
             .retain(|path, _| self.stamps.contains_key(path));
+        self.versions
+            .retain(|path, version| self.stamps.get(path) == Some(version.stamp()));
     }
 }
 
@@ -211,6 +428,8 @@ struct EvidenceEntry {
     size: u64,
     #[serde(default)]
     c: Option<serde_json::Value>,
+    #[serde(default)]
+    v: Option<serde_json::Value>,
 }
 
 #[derive(Serialize)]
@@ -219,10 +438,12 @@ struct EvidenceEntryRef<'a> {
     size: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     c: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    v: Option<PersistedVersion>,
 }
 
-/// Write stamps and optional content identities in the compatible filestamp
-/// JSON shape. Older readers ignore the compact `c` field.
+/// Write stamps and optional content/version evidence in the compatible
+/// filestamp JSON shape. Older readers ignore the compact `c` and `v` fields.
 pub fn write_file_evidence(evidence: &FileEvidence, index_dir: &Path) -> Result<()> {
     let path = index_dir.join(FILESTAMPS_FILENAME);
     let encoded_ids: HashMap<&str, String> = evidence
@@ -241,6 +462,7 @@ pub fn write_file_evidence(evidence: &FileEvidence, index_dir: &Path) -> Result<
                     mtime: stamp.mtime,
                     size: stamp.size,
                     c: encoded_ids.get(path.as_str()).map(String::as_str),
+                    v: evidence.version(path).and_then(FileVersion::persisted),
                 },
             )
         })
@@ -249,8 +471,8 @@ pub fn write_file_evidence(evidence: &FileEvidence, index_dir: &Path) -> Result<
     Ok(())
 }
 
-/// Read stamps and any valid per-path identities. A malformed identity discards
-/// only that identity; the path's metadata remains available for stale checks.
+/// Read stamps and valid per-path evidence. Malformed, unsupported, or
+/// platform-incompatible evidence is discarded, preserving the legacy stamp.
 pub fn read_file_evidence(index_dir: &Path) -> Result<FileEvidence> {
     let path = index_dir.join(FILESTAMPS_FILENAME);
     if !path.exists() {
@@ -265,14 +487,15 @@ pub fn read_file_evidence(index_dir: &Path) -> Result<FileEvidence> {
             .as_ref()
             .and_then(serde_json::Value::as_str)
             .and_then(ContentId::from_hex);
-        evidence.insert(
-            path,
-            FileStamp {
-                mtime: entry.mtime,
-                size: entry.size,
-            },
-            content_id,
-        );
+        let stamp = FileStamp {
+            mtime: entry.mtime,
+            size: entry.size,
+        };
+        let version = entry
+            .v
+            .and_then(|value| serde_json::from_value::<PersistedVersion>(value).ok())
+            .and_then(|version| version.decode(stamp.clone()));
+        evidence.insert_verified(path, stamp, content_id, version);
     }
     Ok(evidence)
 }
@@ -319,6 +542,7 @@ mod tests {
             Some(&FileStamp { mtime: 1, size: 2 })
         );
         assert_eq!(legacy.content_id("legacy.rs"), None);
+        assert!(legacy.versions.is_empty());
 
         let id = ContentId::from_indexed_bytes(b"decoded text");
         let mut evidence = FileEvidence::default();
@@ -358,5 +582,208 @@ mod tests {
             evidence.stamp("wrong-type.rs"),
             Some(&FileStamp { mtime: 5, size: 6 })
         );
+    }
+
+    fn test_version() -> FileVersion {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("indexed.rs");
+        std::fs::write(&path, b"indexed text").unwrap();
+        file_version(&std::fs::metadata(path).unwrap())
+    }
+
+    #[test]
+    fn file_version_distinguishes_subsecond_modified_times() {
+        let mut first = test_version();
+        let base = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1);
+        first.stamp.mtime = 1;
+        first.modified = Some(base + std::time::Duration::from_nanos(100));
+        let second = FileVersion {
+            modified: Some(base + std::time::Duration::from_nanos(200)),
+            ..first.clone()
+        };
+
+        assert_ne!(first, second);
+        assert_eq!(first.stamp, second.stamp);
+    }
+
+    #[test]
+    fn precise_versions_roundtrip_without_changing_legacy_stamps() {
+        let dir = tempfile::tempdir().unwrap();
+        let version = test_version();
+        let mut evidence = FileEvidence::default();
+        evidence.insert_verified(
+            "indexed.rs".into(),
+            version.stamp().clone(),
+            Some(ContentId::from_indexed_bytes(b"indexed text")),
+            Some(version),
+        );
+        write_file_evidence(&evidence, dir.path()).unwrap();
+        assert_eq!(read_file_evidence(dir.path()).unwrap(), evidence);
+        assert_eq!(read_filestamps(dir.path()).unwrap(), evidence.stamps);
+
+        write_filestamps(&evidence.stamps, dir.path()).unwrap();
+        let legacy = read_file_evidence(dir.path()).unwrap();
+        assert_eq!(legacy.stamps, evidence.stamps);
+        assert!(legacy.versions.is_empty());
+    }
+
+    #[test]
+    fn malformed_or_incompatible_versions_fail_open_per_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let version = test_version();
+        let id = ContentId::from_indexed_bytes(b"indexed text");
+        let valid = serde_json::to_value(version.persisted().unwrap()).unwrap();
+        let mut bad_platform = valid.clone();
+        bad_platform["platform"] = "unsupported-platform".into();
+        let mut future_schema = valid.clone();
+        future_schema["schema"] = 2.into();
+        let mut bad_nanos = valid.clone();
+        bad_nanos["modified"]["nanos"] = 1_000_000_000u64.into();
+        let mut overflow_time = valid.clone();
+        overflow_time["modified"]["seconds"] = u64::MAX.into();
+        let mut missing_modified = valid.clone();
+        missing_modified.as_object_mut().unwrap().remove("modified");
+        let mut missing_created = valid.clone();
+        missing_created.as_object_mut().unwrap().remove("created");
+        let mut bad_created = valid.clone();
+        bad_created["created"] = serde_json::json!({
+            "before_epoch": false, "seconds": 0, "nanos": 1_000_000_000
+        });
+        let mut mismatched_stamp = valid.clone();
+        mismatched_stamp["modified"]["seconds"] = (version.stamp().mtime + 1).into();
+        let mut mismatched_size = valid.clone();
+        mismatched_size["size"] = (version.stamp().size + 1).into();
+        let mut bad_unix = valid.clone();
+        #[cfg(unix)]
+        {
+            bad_unix["unix"] = serde_json::Value::Null;
+        }
+        #[cfg(not(unix))]
+        {
+            bad_unix["unix"] = serde_json::json!({
+                "device": 1, "inode": 2, "change_seconds": 3, "change_nanos": 4
+            });
+        }
+        let invalid = [
+            serde_json::Value::Null,
+            serde_json::json!("not a version"),
+            serde_json::json!({}),
+            bad_platform,
+            future_schema,
+            bad_nanos,
+            overflow_time,
+            missing_modified,
+            missing_created,
+            bad_created,
+            mismatched_stamp,
+            mismatched_size,
+            bad_unix,
+        ];
+        let mut entries = serde_json::Map::new();
+        for (i, value) in invalid.into_iter().enumerate() {
+            entries.insert(
+                format!("{i}.rs"),
+                serde_json::json!({
+                    "mtime": version.stamp().mtime,
+                    "size": version.stamp().size,
+                    "c": id.to_hex(),
+                    "v": value,
+                }),
+            );
+        }
+        entries.insert(
+            "valid.rs".into(),
+            serde_json::json!({
+                "mtime": version.stamp().mtime,
+                "size": version.stamp().size,
+                "c": id.to_hex(),
+                "v": valid,
+            }),
+        );
+        std::fs::write(
+            dir.path().join(FILESTAMPS_FILENAME),
+            serde_json::to_vec(&entries).unwrap(),
+        )
+        .unwrap();
+        let evidence = read_file_evidence(dir.path()).unwrap();
+        assert_eq!(evidence.stamps.len(), entries.len());
+        assert_eq!(evidence.content_ids.len(), entries.len());
+        assert_eq!(evidence.versions.len(), 1);
+        assert_eq!(evidence.version("valid.rs"), Some(&version));
+    }
+
+    #[test]
+    fn legacy_insert_and_evidence_lifecycle_clear_versions() {
+        let version = test_version();
+        let mut evidence = FileEvidence::default();
+        for path in ["legacy.rs", "remove.rs", "retain.rs", "clear.rs"] {
+            evidence.insert_verified(
+                path.into(),
+                version.stamp().clone(),
+                None,
+                Some(version.clone()),
+            );
+        }
+        evidence.insert("legacy.rs".into(), version.stamp().clone(), None);
+        assert!(evidence.version("legacy.rs").is_none());
+        assert!(!evidence.versions.contains_key("legacy.rs"));
+        evidence.remove("remove.rs");
+        assert!(!evidence.versions.contains_key("remove.rs"));
+        evidence.retain(|path, _| path != "retain.rs");
+        assert!(!evidence.versions.contains_key("retain.rs"));
+        assert_eq!(evidence.versions.len(), 1);
+        evidence.clear();
+        assert!(evidence.versions.is_empty());
+    }
+
+    #[test]
+    fn untrusted_or_mismatched_versions_are_not_persisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let version = test_version();
+        let mut untrusted = version.clone();
+        untrusted.modified = None;
+        let mut evidence = FileEvidence::default();
+        evidence.insert_verified(
+            "untrusted.rs".into(),
+            version.stamp().clone(),
+            None,
+            Some(untrusted.clone()),
+        );
+        evidence.insert_verified(
+            "mismatched.rs".into(),
+            FileStamp { mtime: 0, size: 0 },
+            None,
+            Some(version.clone()),
+        );
+        assert!(evidence.versions.is_empty());
+
+        // Public maps may be edited directly; neither lookup nor serialization
+        // may turn incompatible entries into trusted evidence.
+        evidence.versions.insert("untrusted.rs".into(), untrusted);
+        evidence.versions.insert("mismatched.rs".into(), version);
+        assert!(evidence.version("untrusted.rs").is_none());
+        assert!(evidence.version("mismatched.rs").is_none());
+        write_file_evidence(&evidence, dir.path()).unwrap();
+        assert!(read_file_evidence(dir.path()).unwrap().versions.is_empty());
+    }
+
+    #[test]
+    fn version_timestamps_roundtrip_before_the_epoch() {
+        let mut version = test_version();
+        version.stamp.mtime = 0;
+        version.modified = Some(SystemTime::UNIX_EPOCH - std::time::Duration::from_nanos(1));
+        let persisted = version.persisted().unwrap();
+        assert_eq!(persisted.decode(version.stamp.clone()), Some(version));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_unix_change_nanoseconds_are_not_trusted() {
+        let mut version = test_version();
+        for nanos in [-1, 1_000_000_000] {
+            version.change_nanos = nanos;
+            assert!(!version.is_trusted());
+            assert!(version.persisted().is_none());
+        }
     }
 }

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -472,6 +472,9 @@ pub struct FileMeta {
     pub relative_path: String,
     pub mtime: u64,
     pub size: u64,
+    /// Precise scan metadata, not evidence of an indexed read. Unknown or
+    /// unsupported metadata must leave the path eligible for reindexing.
+    pub version: Option<crate::meta::FileVersion>,
 }
 
 /// Result of [`walk_file_metadata`]: per-file metadata plus the `.gitignore` /
@@ -660,10 +663,12 @@ pub fn walk_file_metadata_with_ignorecase(
             }
             listed_files.lock().unwrap().push(rel_path.clone());
             let stamp = crate::meta::file_stamp(&meta);
+            let version = crate::meta::file_version(&meta);
             results.lock().unwrap().push(FileMeta {
                 relative_path: rel_path,
                 mtime: stamp.mtime,
                 size: stamp.size,
+                version: version.is_trusted().then_some(version),
             });
 
             ignore::WalkState::Continue
@@ -682,6 +687,68 @@ pub fn walk_file_metadata_with_ignorecase(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn metadata_walk_reports_precise_same_second_versions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("same-second.rs");
+        std::fs::write(&path, b"old text").unwrap();
+        let base = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let set_modified = |time| {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .unwrap()
+                .set_modified(time)
+                .unwrap();
+        };
+        set_modified(base + std::time::Duration::from_millis(100));
+        let before = walk_file_metadata(dir.path(), &MetaWalkOptions::default());
+        std::fs::write(&path, b"new text").unwrap();
+        set_modified(base + std::time::Duration::from_millis(200));
+        let after = walk_file_metadata(dir.path(), &MetaWalkOptions::default());
+        assert_eq!(before.files.len(), 1);
+        assert_eq!(after.files.len(), 1);
+        let before = &before.files[0];
+        let after = &after.files[0];
+        assert_eq!((before.mtime, before.size), (after.mtime, after.size));
+        assert!(before.version.is_some());
+        assert_ne!(before.version, after.version);
+        assert_eq!(
+            after.version,
+            Some(crate::meta::file_version(&std::fs::metadata(path).unwrap()))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn metadata_walk_detects_same_size_write_with_restored_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("restored.rs");
+        std::fs::write(&path, b"old text").unwrap();
+        let original_mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+        let before = walk_file_metadata(dir.path(), &MetaWalkOptions::default());
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&path, b"new text").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(original_mtime)
+            .unwrap();
+        let after = walk_file_metadata(dir.path(), &MetaWalkOptions::default());
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            original_mtime
+        );
+        assert_eq!(before.files.len(), 1);
+        assert_eq!(after.files.len(), 1);
+        let before = &before.files[0];
+        let after = &after.files[0];
+        assert_eq!((before.mtime, before.size), (after.mtime, after.size));
+        assert!(before.version.is_some());
+        assert_ne!(before.version, after.version);
+    }
     use std::fs;
     use tempfile::TempDir;
 


### PR DESCRIPTION
## Summary

Fixes #141.

This is a standalone branch from `main` at `10c73887b6326f395afdf2853188dd398ca9bdfc`, not a continuation or stack of the earlier watcher PRs.

- Default `--watch-mode auto` retains native notifications while complete coverage fits a conservative **8,192-subscription process budget**. Budget preflight or native registration/constructor failures retire all of this server's native watches and enter sticky, whole-process polling. No repeated native registration attempts or partial native/polling coverage.
- `--watch-mode poll` creates no native watcher. `--poll-interval SECONDS` defaults to **120 seconds after reconciliation completes**; `--watch-budget N` controls the native ceiling. Explicit conflicting options are rejected. `--no-watch` remains the opt-out from all automatic refresh.
- Polling reuses the authoritative ignore-aware metadata walk and streaming delta merge, catches up after setup/handoff/build/reload, and is not deferred by search activity. Registration snapshots remain serialized; busy work and failed startup attempts cannot create competing polling loops. Queue overflow retains native reconciliation recovery.
- Full-resolution, read-bound file versions include Linux mtime/ctime and device/inode identity. Optional, validated `v` fields extend the existing filestamp JSON compatibly; the public `FileStamp` and index format remain unchanged. Unavailable/raced evidence fails open rather than acquiring a newer scan baseline. Existing content IDs, overlay deduplication and publication safeguards remain intact.
- Status/logs expose requested/active modes, fallback reason, last successful reconciliation, duration, failure, running/pending/overdue state. Obsolete read failures do not permanently poison status.

## Validation

Validated head: `fed7dd58a57e6b30eee283dff80901f49c1370b4`.

Windows local validation:

- `cargo fmt --all --check`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `cargo build --workspace --all-targets`: passed.
- `cargo test --workspace`: **825 passed, 0 failed, 1 ignored** (the opt-in measurement).
- Explicit `ripgrep_compat` and `ripgrep_parity` targets: **218/218** and **102/102** passed.
- Production scheduler/lifecycle regressions cover tiny budgets, constructor and partial-registration capacity failures, watcher retirement/sticky fallback, zero-watch polling, overflow separation, file/ignore changes, no-change persistence, busy/concurrent refreshes, failure recovery, and build/publication races.
- Mutation controls: temporarily disabling precise polling classification or budget preflight each produced the expected regression failure; both mutations were restored and the passing suite rerun.

The existing [platform CI run](https://github.com/microsoft/tgrep/actions/runs/34178180104) passed all build, bench-build, test, Format and Clippy jobs:

| Platform | Passed | Failed | Ignored |
|---|---:|---:|---:|
| Linux | 857 | 0 | 1 |
| macOS | 852 | 0 | 1 |
| Windows | 825 | 0 | 1 |

Linux CI explicitly passed the real server's one-watch-budget fallback/bootstrap test, zero remaining native-watch assertions, serialized registration snapshot regression, and restored-mtime/same-second polling/read-race regressions. The Unix timestamp regressions also passed on macOS. Linux was exercised by CI, not locally; no host quota/sysctl was changed or exhausted.

A bounded **Windows debug** fixture of 1,000 small files measured **50.05 ms** for a no-change poll (15 ms metadata walk) and **131.47 ms** for a 20-file changed batch (16 ms metadata walk). This is not a measurement of the customer's 414k-file corpus, which is unavailable. Small deltas still stream a replacement of the on-disk index; unchanged polls do not rewrite it.

## Operational limits

The budget is not free shared inotify capacity: same-user processes may exhaust the OS quota earlier. Polling cannot repair unreadable files or process-wide resource failures. Freshness includes the interval plus scan/update time and in-progress work; it is not a hard two-minute bound. Metadata-preserving changes beyond the available OS/filesystem evidence may still be missed, and reconciliation is not an atomic filesystem snapshot. README documents these semantics.