### PR TITLE
fix: print search stats after matches

### DIFF
--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -2,7 +2,7 @@
 ///
 /// If a running server is detected (via serve.json), the search is delegated
 /// over TCP. Otherwise, the on-disk index is loaded directly.
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -128,6 +128,14 @@ pub enum SortKey {
     Modified,
     Accessed,
     Created,
+}
+
+fn flush_before_stats(writer: &mut OutputWriter) -> Result<()> {
+    match writer.flush() {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(error.into()),
+    }
 }
 
 impl SortKey {
@@ -1085,7 +1093,7 @@ fn search_via_server(
         // Match output is buffered on stdout, while stats go straight to
         // stderr. Flush first so a combined stdout/stderr stream reports the
         // summary after the matches, as ripgrep does.
-        writer.flush()?;
+        flush_before_stats(writer)?;
         // Count the rows that survived scoping, not the server's `num_matches`.
         // The server searches the whole indexed tree and counts every row it
         // built, so that field includes files outside a subdirectory argument
@@ -1201,7 +1209,7 @@ fn search_local_index(
         // Match output is buffered on stdout, while stats go straight to
         // stderr. Flush first so a combined stdout/stderr stream reports the
         // summary after the matches, as ripgrep does.
-        writer.flush()?;
+        flush_before_stats(writer)?;
         eprintln!(
             "Query plan: {} (candidates: {}/{})",
             plan_summary(&plan),
@@ -1321,7 +1329,7 @@ fn brute_force_search(
             // Match output is buffered on stdout, while stats go straight to
             // stderr. Flush first so a combined stdout/stderr stream reports
             // the summary after the matches, as ripgrep does.
-            writer.flush()?;
+            flush_before_stats(writer)?;
             eprintln!(
                 "Brute-force search completed in {:.1}ms (1 file)",
                 elapsed.as_secs_f64() * 1000.0,
@@ -1366,7 +1374,7 @@ fn brute_force_search(
         // Match output is buffered on stdout, while stats go straight to
         // stderr. Flush first so a combined stdout/stderr stream reports the
         // summary after the matches, as ripgrep does.
-        writer.flush()?;
+        flush_before_stats(writer)?;
         eprintln!(
             "Brute-force search completed in {:.1}ms ({} files)",
             elapsed.as_secs_f64() * 1000.0,

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -1082,6 +1082,10 @@ fn search_via_server(
     if opts.stats
         && let Some(elapsed) = result.get("elapsed_ms").and_then(|e| e.as_f64())
     {
+        // Match output is buffered on stdout, while stats go straight to
+        // stderr. Flush first so a combined stdout/stderr stream reports the
+        // summary after the matches, as ripgrep does.
+        writer.flush()?;
         // Count the rows that survived scoping, not the server's `num_matches`.
         // The server searches the whole indexed tree and counts every row it
         // built, so that field includes files outside a subdirectory argument
@@ -1165,15 +1169,6 @@ fn search_local_index(
         sort.apply_indexed(&mut candidates, &index_root, &scope, |(_, rel)| rel);
     }
 
-    if opts.stats {
-        eprintln!(
-            "Query plan: {} (candidates: {}/{})",
-            plan_summary(&plan),
-            candidates.len(),
-            reader.num_files()
-        );
-    }
-
     let mut had_matches = false;
     // A single-file search root is a file the user named on the command line,
     // which is what makes binary files visible in ripgrep.
@@ -1203,6 +1198,16 @@ fn search_local_index(
 
     if opts.stats {
         let elapsed = start.elapsed();
+        // Match output is buffered on stdout, while stats go straight to
+        // stderr. Flush first so a combined stdout/stderr stream reports the
+        // summary after the matches, as ripgrep does.
+        writer.flush()?;
+        eprintln!(
+            "Query plan: {} (candidates: {}/{})",
+            plan_summary(&plan),
+            candidates.len(),
+            reader.num_files()
+        );
         eprintln!(
             "Search completed in {:.1}ms",
             elapsed.as_secs_f64() * 1000.0
@@ -1313,6 +1318,10 @@ fn brute_force_search(
 
         if opts.stats {
             let elapsed = start.elapsed();
+            // Match output is buffered on stdout, while stats go straight to
+            // stderr. Flush first so a combined stdout/stderr stream reports
+            // the summary after the matches, as ripgrep does.
+            writer.flush()?;
             eprintln!(
                 "Brute-force search completed in {:.1}ms (1 files)",
                 elapsed.as_secs_f64() * 1000.0,
@@ -1354,6 +1363,10 @@ fn brute_force_search(
 
     if opts.stats {
         let elapsed = start.elapsed();
+        // Match output is buffered on stdout, while stats go straight to
+        // stderr. Flush first so a combined stdout/stderr stream reports the
+        // summary after the matches, as ripgrep does.
+        writer.flush()?;
         eprintln!(
             "Brute-force search completed in {:.1}ms ({} files)",
             elapsed.as_secs_f64() * 1000.0,

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -1323,7 +1323,7 @@ fn brute_force_search(
             // the summary after the matches, as ripgrep does.
             writer.flush()?;
             eprintln!(
-                "Brute-force search completed in {:.1}ms (1 files)",
+                "Brute-force search completed in {:.1}ms (1 file)",
                 elapsed.as_secs_f64() * 1000.0,
             );
         }

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -167,22 +167,24 @@ fn missing_path_does_not_stop_remaining_paths() {
 fn stats_follow_matches_on_a_combined_output_stream() {
     let dir = setup_fixture();
     let merged_path = dir.path().join("merged-output.txt");
-    let merged = fs::File::create(&merged_path).unwrap();
-    let stdout = merged.try_clone().unwrap();
+    {
+        let merged = fs::File::create(&merged_path).unwrap();
+        let stdout = merged.try_clone().unwrap();
 
-    let status = ProcessCommand::new(env!("CARGO_BIN_EXE_tgrep"))
-        .args([
-            "--no-index",
-            "--stats",
-            "--no-heading",
-            "fn main",
-            &fixture_path(&dir),
-        ])
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(merged))
-        .status()
-        .unwrap();
-    assert!(status.success());
+        let status = ProcessCommand::new(env!("CARGO_BIN_EXE_tgrep"))
+            .args([
+                "--no-index",
+                "--stats",
+                "--no-heading",
+                "fn main",
+                &fixture_path(&dir),
+            ])
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(merged))
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
 
     let output = fs::read_to_string(merged_path).unwrap();
     let match_at = output
@@ -210,16 +212,25 @@ fn indexed_stats_follow_matches_on_a_combined_output_stream() {
         .success();
 
     let merged_path = dir.path().join("merged-indexed-output.txt");
-    let merged = fs::File::create(&merged_path).unwrap();
-    let stdout = merged.try_clone().unwrap();
+    {
+        let merged = fs::File::create(&merged_path).unwrap();
+        let stdout = merged.try_clone().unwrap();
 
-    let status = ProcessCommand::new(env!("CARGO_BIN_EXE_tgrep"))
-        .args(["--stats", "--no-heading", "--index-path", idx_str, "fn main", &root])
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(merged))
-        .status()
-        .unwrap();
-    assert!(status.success());
+        let status = ProcessCommand::new(env!("CARGO_BIN_EXE_tgrep"))
+            .args([
+                "--stats",
+                "--no-heading",
+                "--index-path",
+                idx_str,
+                "fn main",
+                &root,
+            ])
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(merged))
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
 
     let output = fs::read_to_string(merged_path).unwrap();
     let match_at = output

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -9,6 +9,7 @@ use predicates::prelude::*;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
+use std::process::{Command as ProcessCommand, Stdio};
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
@@ -160,6 +161,74 @@ fn missing_path_does_not_stop_remaining_paths() {
         .assert()
         .code(2)
         .stdout(predicate::str::contains("hello.rs"));
+}
+
+#[test]
+fn stats_follow_matches_on_a_combined_output_stream() {
+    let dir = setup_fixture();
+    let merged_path = dir.path().join("merged-output.txt");
+    let merged = fs::File::create(&merged_path).unwrap();
+    let stdout = merged.try_clone().unwrap();
+
+    let status = ProcessCommand::new(env!("CARGO_BIN_EXE_tgrep"))
+        .args([
+            "--no-index",
+            "--stats",
+            "--no-heading",
+            "fn main",
+            &fixture_path(&dir),
+        ])
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(merged))
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let output = fs::read_to_string(merged_path).unwrap();
+    let match_at = output
+        .find("fn main()")
+        .expect("search result should be present");
+    let stats_at = output
+        .find("Brute-force search completed")
+        .expect("stats should be present");
+    assert!(
+        match_at < stats_at,
+        "stats must follow buffered matches on a combined stream: {output:?}"
+    );
+}
+
+#[test]
+fn indexed_stats_follow_matches_on_a_combined_output_stream() {
+    let dir = setup_fixture();
+    let root = fixture_path(&dir);
+    tgrep().args(["index", &root]).assert().success();
+
+    let merged_path = dir.path().join("merged-indexed-output.txt");
+    let merged = fs::File::create(&merged_path).unwrap();
+    let stdout = merged.try_clone().unwrap();
+
+    let status = ProcessCommand::new(env!("CARGO_BIN_EXE_tgrep"))
+        .args(["--stats", "--no-heading", "fn main", &root])
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(merged))
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let output = fs::read_to_string(merged_path).unwrap();
+    let match_at = output
+        .find("fn main()")
+        .expect("search result should be present");
+    let plan_at = output
+        .find("Query plan:")
+        .expect("query plan stats should be present");
+    let elapsed_at = output
+        .find("Search completed")
+        .expect("elapsed stats should be present");
+    assert!(
+        match_at < plan_at && plan_at < elapsed_at,
+        "stats must follow buffered matches on a combined stream: {output:?}"
+    );
 }
 
 #[test]

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -201,14 +201,20 @@ fn stats_follow_matches_on_a_combined_output_stream() {
 fn indexed_stats_follow_matches_on_a_combined_output_stream() {
     let dir = setup_fixture();
     let root = fixture_path(&dir);
-    tgrep().args(["index", &root]).assert().success();
+
+    let idx = dir.path().join("idx");
+    let idx_str = idx.to_str().unwrap();
+    tgrep()
+        .args(["index", &root, "--index-path", idx_str])
+        .assert()
+        .success();
 
     let merged_path = dir.path().join("merged-indexed-output.txt");
     let merged = fs::File::create(&merged_path).unwrap();
     let stdout = merged.try_clone().unwrap();
 
     let status = ProcessCommand::new(env!("CARGO_BIN_EXE_tgrep"))
-        .args(["--stats", "--no-heading", "fn main", &root])
+        .args(["--stats", "--no-heading", "--index-path", idx_str, "fn main", &root])
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(merged))
         .status()


### PR DESCRIPTION
Closes #145

## Summary

- Flush buffered match output before human-readable `--stats` messages.
- Defer indexed-search query-plan stats until after matches are written.
- Add brute-force and indexed regression tests using a shared stdout/stderr stream.

Previously, stdout buffering caused `--stats` to appear before matches when stdout and stderr were combined, so the summary was easy to miss during large searches.

## Validation

- Regression test failed against the pre-change implementation with stats before the match.
- Targeted brute-force and indexed ordering tests pass after the fix.
- `cargo test --workspace` passes.
- `cargo fmt --all -- --check` passes.
- `cargo clippy --workspace --all-targets -- -D warnings` passes.
- Manual CLI verification confirms matches precede the final stats line.