### PR TITLE
fix: report match counts in --stats for the local-index and brute-force paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "blake3",

--- a/tgrep-cli/src/matching.rs
+++ b/tgrep-cli/src/matching.rs
@@ -626,21 +626,51 @@ pub enum Emit<'a> {
 pub struct FileMatches<'a> {
     index: LineIndex<'a>,
     hits: Vec<LineHit>,
+    match_totals: (u64, u64),
 }
 
 impl<'a> FileMatches<'a> {
     pub fn find(content: &'a str, matcher: &SearchMatcher, opts: &MatchOptions) -> Result<Self> {
         let index = LineIndex::new(content);
-        let hits = if opts.max_count == Some(0) {
-            Vec::new()
+        let (hits, match_totals) = if opts.max_count == Some(0) {
+            (Vec::new(), (0, 0))
+        } else if opts.multiline && !opts.invert_match {
+            // Count original matches after the search limit, but before
+            // splitting, merging or clipping their spans for presentation.
+            let spans = matcher.find_spans(content)?;
+            let spans = limit_to_line_blocks(&index, &spans, opts.max_count);
+            let hits = group_spans_by_line(&index, &spans);
+            let totals = (spans.len() as u64, hits.len() as u64);
+            let hits = if opts.vimgrep {
+                group_spans_by_line(&index, &clip_spans_to_start_line(&index, &spans))
+            } else {
+                hits
+            };
+            (hits, totals)
         } else {
-            collect_hits(content, &index, matcher, opts)?
+            let hits = collect_hits(content, &index, matcher, opts)?;
+            let totals = (
+                hits.iter().map(|h| h.spans.len() as u64).sum(),
+                hits.len() as u64,
+            );
+            (hits, totals)
         };
-        Ok(Self { index, hits })
+        Ok(Self {
+            index,
+            hits,
+            match_totals,
+        })
     }
 
     pub fn is_empty(&self) -> bool {
         self.hits.is_empty()
+    }
+
+    /// Original regex matches and selected physical lines, before rendering.
+    /// Inverted lines contribute no regex matches. Requires `all_spans` for
+    /// complete match counts in line-oriented mode.
+    pub fn match_totals(&self) -> (u64, u64) {
+        self.match_totals
     }
 
     /// Number of matching lines, which is what `-c/--count` reports.
@@ -900,7 +930,7 @@ fn candidate_lines<'a>(
     )
 }
 
-/// Find every matching line together with the match ranges inside it.
+/// Find selected lines and their spans in line-oriented or inverted mode.
 fn collect_hits(
     content: &str,
     index: &LineIndex<'_>,
@@ -926,33 +956,6 @@ fn collect_hits(
             }
         }
         return Ok(out);
-    }
-
-    if opts.multiline {
-        // Match against the whole buffer so a single match can cross lines.
-        //
-        // ripgrep counts *matching lines* here rather than match spans: its
-        // multiline searcher reports one unit per contiguous block of lines
-        // that matches cover, and everything inside that block comes with it.
-        // So three matches on one line are a single unit under `-m 1` (all
-        // three are reported, which `--vimgrep` shows as three rows), and a
-        // match spanning two lines is also one unit (both lines print).
-        //
-        // Limiting the spans themselves would under-report the first case, and
-        // truncating the grouped lines would print a partial match — output
-        // that doesn't actually match the pattern, with its spans clipped.
-        let spans = matcher.find_spans(content)?;
-        let spans = limit_to_line_blocks(index, &spans, max);
-        if opts.vimgrep {
-            // `--vimgrep` wants one jump target per match, so a match that runs
-            // past the end of its line is reported only on the line it starts
-            // on rather than once per line it touches.
-            return Ok(group_spans_by_line(
-                index,
-                &clip_spans_to_start_line(index, &spans),
-            ));
-        }
-        return Ok(group_spans_by_line(index, &spans));
     }
 
     // Line-oriented mode: match each line separately so `^` and `$` anchor
@@ -1000,6 +1003,26 @@ fn collect_hits(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stats_keep_original_multiline_matches_and_physical_lines() {
+        let matcher = SearchMatcher::Standard(regex::Regex::new(r"hello\nworld").unwrap());
+        for vimgrep in [false, true] {
+            let found = FileMatches::find(
+                "hello\nworld\n",
+                &matcher,
+                &MatchOptions {
+                    multiline: true,
+                    vimgrep,
+                    all_spans: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            assert_eq!(found.match_totals(), (1, 2));
+            assert_eq!(found.matched_lines(), if vimgrep { 1 } else { 2 });
+        }
+    }
 
     // -----------------------------------------------------------------------
     // The whole-buffer line prescan

--- a/tgrep-cli/src/output.rs
+++ b/tgrep-cli/src/output.rs
@@ -260,7 +260,6 @@ pub struct OutputWriter {
     all_searches: u64,
     total_matches: u64,
     total_matched_lines: u64,
-    last_counted_match: Option<(String, usize)>,
 }
 
 impl OutputWriter {
@@ -297,12 +296,22 @@ impl OutputWriter {
             all_searches: 0,
             total_matches: 0,
             total_matched_lines: 0,
-            last_counted_match: None,
         }
     }
 
     pub fn match_totals(&self) -> (u64, u64) {
         (self.total_matches, self.total_matched_lines)
+    }
+
+    /// Text stats are per search root; JSON stats still span the invocation.
+    pub fn reset_match_totals(&mut self) {
+        self.total_matches = 0;
+        self.total_matched_lines = 0;
+    }
+
+    pub fn note_matches(&mut self, matches: u64, matched_lines: u64) {
+        self.total_matches += matches;
+        self.total_matched_lines += matched_lines;
     }
 
     pub fn is_json(&self) -> bool {
@@ -558,15 +567,6 @@ impl OutputWriter {
     pub fn write_match(&mut self, m: &Match) -> io::Result<()> {
         let (content, spans) = self.trim_adjust(&m.content, &m.spans);
         let content = content.to_string();
-        let already_counted = self
-            .last_counted_match
-            .as_ref()
-            .is_some_and(|(f, l)| f == &m.file && *l == m.line_number);
-        if !already_counted {
-            self.total_matched_lines += 1;
-            self.last_counted_match = Some((m.file.clone(), m.line_number));
-        }
-        self.total_matches += m.spans.len() as u64;
         match self.config.format {
             OutputFormat::Heading | OutputFormat::Flat => {
                 if !self.config.no_filename {

--- a/tgrep-cli/src/output.rs
+++ b/tgrep-cli/src/output.rs
@@ -258,6 +258,9 @@ pub struct OutputWriter {
     current_binary_offset: Option<u64>,
     all_bytes_searched: u64,
     all_searches: u64,
+    total_matches: u64,
+    total_matched_lines: u64,
+    last_counted_match: Option<(String, usize)>,
 }
 
 impl OutputWriter {
@@ -292,7 +295,14 @@ impl OutputWriter {
             current_binary_offset: None,
             all_bytes_searched: 0,
             all_searches: 0,
+            total_matches: 0,
+            total_matched_lines: 0,
+            last_counted_match: None,
         }
+    }
+
+    pub fn match_totals(&self) -> (u64, u64) {
+        (self.total_matches, self.total_matched_lines)
     }
 
     pub fn is_json(&self) -> bool {
@@ -548,6 +558,15 @@ impl OutputWriter {
     pub fn write_match(&mut self, m: &Match) -> io::Result<()> {
         let (content, spans) = self.trim_adjust(&m.content, &m.spans);
         let content = content.to_string();
+        let already_counted = self
+            .last_counted_match
+            .as_ref()
+            .is_some_and(|(f, l)| f == &m.file && *l == m.line_number);
+        if !already_counted {
+            self.total_matched_lines += 1;
+            self.last_counted_match = Some((m.file.clone(), m.line_number));
+        }
+        self.total_matches += spans.len() as u64;
         match self.config.format {
             OutputFormat::Heading | OutputFormat::Flat => {
                 if !self.config.no_filename {

--- a/tgrep-cli/src/output.rs
+++ b/tgrep-cli/src/output.rs
@@ -566,7 +566,7 @@ impl OutputWriter {
             self.total_matched_lines += 1;
             self.last_counted_match = Some((m.file.clone(), m.line_number));
         }
-        self.total_matches += spans.len() as u64;
+        self.total_matches += m.spans.len() as u64;
         match self.config.format {
             OutputFormat::Heading | OutputFormat::Flat => {
                 if !self.config.no_filename {

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -653,6 +653,7 @@ pub fn run(
     opts: &SearchOptions,
     writer: &mut OutputWriter,
 ) -> Result<bool> {
+    writer.reset_match_totals();
     let root = match std::fs::canonicalize(root) {
         Ok(root) => root,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
@@ -844,6 +845,7 @@ fn search_via_server(
             "vimgrep": opts.vimgrep,
             "detail": detail,
             "positions": positions,
+            "stats": opts.stats,
         },
         "id": 1,
     });
@@ -959,11 +961,8 @@ fn search_via_server(
     let had_matches = !matches.is_empty();
 
     if opts.quiet {
-        writer.flush()?;
-        return Ok(had_matches);
-    }
-
-    if opts.files_only {
+        // No output, but still report stats for the first matching file.
+    } else if opts.files_only {
         let mut seen = std::collections::HashSet::new();
         for m in matches {
             if let Some(file) = m.get("file").and_then(|f| f.as_str())
@@ -1094,11 +1093,34 @@ fn search_via_server(
         // stderr. Flush first so a combined stdout/stderr stream reports the
         // summary after the matches, as ripgrep does.
         flush_before_stats(writer)?;
-        // Count the rows that survived scoping, not the server's `num_matches`.
-        // The server searches the whole indexed tree and counts every row it
-        // built, so that field includes files outside a subdirectory argument
-        // and counts context lines as matches.
-        let (num, lines) = count_reported_matches(matches);
+        // Apply the same scope to per-file totals as to output rows. The
+        // server's `num_matches` includes context and out-of-scope rows, and
+        // rendered spans can split or merge the original matches.
+        let (num, lines) = if let Some(stats) = result.get("file_stats") {
+            let stats: Vec<FileMatchStats> = serde_json::from_value(stats.clone())?;
+            let first_file = matches
+                .first()
+                .and_then(|m| m.get("file"))
+                .and_then(|f| f.as_str());
+            stats
+                .iter()
+                .filter_map(|s| {
+                    if dropped_binary_files.contains(s.file.as_str()) {
+                        return None;
+                    }
+                    let rel = scope.relativize(&s.file, root)?;
+                    if !within_max_depth(&rel, opts)
+                        || (opts.quiet && first_file != Some(rel.as_str()))
+                    {
+                        return None;
+                    }
+                    Some((s.matches, s.matched_lines))
+                })
+                .fold((0, 0), |(m, l), (fm, fl)| (m + fm, l + fl))
+        } else {
+            // Older servers only provide rendered rows.
+            count_reported_matches(matches)
+        };
         eprintln!("{num} matches ({lines} matched lines) in {elapsed:.1}ms (via server)");
     }
 
@@ -1700,6 +1722,10 @@ fn search_decoded_file(
 
     let match_opts = opts.match_options();
     let found = crate::matching::FileMatches::find(content, matcher, &match_opts)?;
+    if opts.stats {
+        let (matches, matched_lines) = found.match_totals();
+        writer.note_matches(matches, matched_lines);
+    }
 
     let has_matches = !found.is_empty();
     if !has_matches {
@@ -1851,7 +1877,15 @@ pub fn build_type_filter(
     defs.build_filter(types, types_not)
 }
 
-/// Match and matched-line totals for `--stats`, counted from the rows the
+/// Optional per-file RPC metadata, independent of rendered match/context rows.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct FileMatchStats {
+    pub file: String,
+    pub matches: u64,
+    pub matched_lines: u64,
+}
+
+/// Legacy match and matched-line totals for `--stats`, counted from the rows the
 /// client is actually going to print.
 ///
 /// ripgrep reports these two numbers separately and neither of them counts

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -1713,9 +1713,9 @@ fn search_decoded_file(
         return Ok(FileOutcome::Skipped);
     }
 
-    // ripgrep's searcher quits at the NUL byte, so it reports only the bytes it
-    // got through rather than the file's full length. Both are counted on disk,
-    // so the whole-file case needs the same mapping the offset just got.
+    // Binary bytes_searched reports the detection offset, not a regex cutoff:
+    // ripgrep with memory-mapped input can count matches beyond the NUL while
+    // reporting that offset. Both byte counts refer to the source on disk.
     writer.note_bytes_searched(
         binary_offset.unwrap_or_else(|| fixups.to_source_offset(content.len())) as u64,
     );

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -1216,8 +1216,9 @@ fn search_local_index(
             candidates.len(),
             reader.num_files()
         );
+        let (matches, matched_lines) = writer.match_totals();
         eprintln!(
-            "Search completed in {:.1}ms",
+            "Search completed in {:.1}ms: {matches} matches ({matched_lines} matched lines)",
             elapsed.as_secs_f64() * 1000.0
         );
     }
@@ -1330,8 +1331,9 @@ fn brute_force_search(
             // stderr. Flush first so a combined stdout/stderr stream reports
             // the summary after the matches, as ripgrep does.
             flush_before_stats(writer)?;
+            let (matches, matched_lines) = writer.match_totals();
             eprintln!(
-                "Brute-force search completed in {:.1}ms (1 file)",
+                "Brute-force search completed in {:.1}ms (1 file): {matches} matches ({matched_lines} matched lines)",
                 elapsed.as_secs_f64() * 1000.0,
             );
         }
@@ -1375,8 +1377,9 @@ fn brute_force_search(
         // stderr. Flush first so a combined stdout/stderr stream reports the
         // summary after the matches, as ripgrep does.
         flush_before_stats(writer)?;
+        let (matches, matched_lines) = writer.match_totals();
         eprintln!(
-            "Brute-force search completed in {:.1}ms ({} files)",
+            "Brute-force search completed in {:.1}ms ({} files): {matches} matches ({matched_lines} matched lines)",
             elapsed.as_secs_f64() * 1000.0,
             walk.files.len()
         );

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -735,6 +735,8 @@ struct SearchOpts {
     ///
     /// Only `-b/--byte-offset` and `-M/--max-columns` look at them.
     positions: bool,
+    /// Return original per-file match totals independently of rendered rows.
+    stats: bool,
 }
 
 impl SearchOpts {
@@ -746,7 +748,7 @@ impl SearchOpts {
             only_matching: self.only_matching,
             before_context: self.before_context,
             after_context: self.after_context,
-            max_count: if self.files_only {
+            max_count: if self.files_only && !self.stats {
                 Some(1)
             } else {
                 self.max_count
@@ -755,7 +757,7 @@ impl SearchOpts {
             replace: self.replace.clone(),
             stop_on_nonmatch: self.stop_on_nonmatch,
             vimgrep: self.vimgrep,
-            all_spans: self.detail,
+            all_spans: self.detail || self.stats,
         }
     }
 }
@@ -1596,6 +1598,10 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
             vimgrep,
             detail,
             positions,
+            stats: params
+                .get("stats")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
         },
     })
 }
@@ -1777,16 +1783,22 @@ fn handle_search(
 
     // Parallel regex matching across candidate files
     let t_search = Instant::now();
-    let per_file: std::result::Result<Vec<Vec<serde_json::Value>>, String> = candidate_contents
+    let per_file: std::result::Result<Vec<FileSearchResult>, String> = candidate_contents
         .par_iter()
         .map(|(rel_path, content)| {
             search_file_matches(rel_path, content, &matcher, &opts).map_err(|e| format!("{e}"))
         })
         .collect();
-    let matches: Vec<serde_json::Value> = match per_file {
-        Ok(per_file) => per_file.into_iter().flatten().collect(),
+    let per_file = match per_file {
+        Ok(per_file) => per_file,
         Err(e) => return json_rpc_error(id, -32603, &e),
     };
+    let mut matches = Vec::new();
+    let mut file_stats = Vec::new();
+    for file in per_file {
+        matches.extend(file.rows);
+        file_stats.extend(file.stats);
+    }
 
     let search_ms = t_search.elapsed().as_secs_f64() * 1000.0;
     let elapsed = start.elapsed();
@@ -1805,15 +1817,18 @@ fn handle_search(
         search_ms,
     );
 
-    let result = serde_json::json!({
+    let mut result = serde_json::json!({
         "matches": matches,
         // The number of rows in `matches`, which is not a ripgrep-style match
         // count: it spans the whole indexed tree (the client applies any
-        // subdirectory argument to the reply) and includes context rows. A
-        // client reporting `--stats` has to count the rows it actually prints.
+        // subdirectory argument to the reply) and includes context rows.
+        // `file_stats`, when requested, carries the original match totals.
         "num_matches": matches.len(),
         "elapsed_ms": elapsed_ms,
     });
+    if opts.stats {
+        result["file_stats"] = serde_json::json!(file_stats);
+    }
 
     json_rpc_result(id, result)
 }
@@ -1861,12 +1876,18 @@ fn invalidate_cached_paths_locked<'a>(
     }
 }
 
+#[derive(Default)]
+struct FileSearchResult {
+    rows: Vec<serde_json::Value>,
+    stats: Option<crate::search::FileMatchStats>,
+}
+
 fn search_file_matches(
     rel_path: &str,
     file: &DecodedFile,
     matcher: &crate::matching::SearchMatcher,
     opts: &SearchOpts,
-) -> anyhow::Result<Vec<serde_json::Value>> {
+) -> anyhow::Result<FileSearchResult> {
     use crate::matching::FileMatches;
 
     let content = file.text.as_str();
@@ -1892,8 +1913,19 @@ fn search_file_matches(
 
     let found = FileMatches::find(content, matcher, &match_opts)?;
     if found.is_empty() {
-        return Ok(Vec::new());
+        return Ok(FileSearchResult::default());
     }
+    let mut result = FileSearchResult {
+        rows: Vec::new(),
+        stats: opts.stats.then(|| {
+            let (matches, matched_lines) = found.match_totals();
+            crate::search::FileMatchStats {
+                file: rel_path.to_string(),
+                matches,
+                matched_lines,
+            }
+        }),
+    };
 
     // Never stream raw binary back to the client; report a note instead, the
     // same way the local path does. Emitted for `-l`/`-c` too so the client can
@@ -1909,23 +1941,13 @@ fn search_file_matches(
         });
         // `--json` reports binary matches as ordinary match events carrying a
         // `binary_offset`, so those clients ask for the lines as well.
+        result.rows.push(marker);
         if !opts.binary_lines {
-            return Ok(vec![marker]);
+            return Ok(result);
         }
-        let mut results = vec![marker];
-        results.extend(collect_match_rows(
-            &found,
-            &match_opts,
-            matcher,
-            rel_path,
-            fixups,
-            opts.detail,
-            opts.positions,
-        )?);
-        return Ok(results);
     }
 
-    collect_match_rows(
+    result.rows.extend(collect_match_rows(
         &found,
         &match_opts,
         matcher,
@@ -1933,7 +1955,8 @@ fn search_file_matches(
         fixups,
         opts.detail,
         opts.positions,
-    )
+    )?);
+    Ok(result)
 }
 
 /// Turn a file's matches into the protocol's `match`/`context` rows.
@@ -8764,9 +8787,10 @@ mod tests {
         )
         .unwrap();
 
-        let rows = search_file_matches("f.txt", &file, &matcher, &SearchOpts::default()).unwrap();
+        let result = search_file_matches("f.txt", &file, &matcher, &SearchOpts::default()).unwrap();
 
-        let marker = rows
+        let marker = result
+            .rows
             .iter()
             .find(|r| r["type"] == "binary")
             .expect("a file containing a NUL is reported as binary");
@@ -8776,6 +8800,42 @@ mod tests {
             "offset must be the byte on disk (9), not the decoded position \
              (13): {marker}"
         );
+    }
+
+    #[test]
+    fn stats_binary_totals_are_independent_of_marker_and_match_rows() {
+        let file = DecodedFile::new(
+            b"hello hello\nhello\n\0tail\n".to_vec(),
+            tgrep_core::encoding::EncodingMode::Auto,
+        );
+        let matcher = crate::matching::build_search_matcher(
+            &["hello".to_string()],
+            &crate::matching::MatcherConfig::default(),
+        )
+        .unwrap();
+        for binary_lines in [false, true] {
+            for invert_match in [false, true] {
+                let result = search_file_matches(
+                    "binary.txt",
+                    &file,
+                    &matcher,
+                    &SearchOpts {
+                        stats: true,
+                        binary_lines,
+                        invert_match,
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+                let stats = result.stats.unwrap();
+                assert_eq!(
+                    (stats.matches, stats.matched_lines),
+                    if invert_match { (0, 1) } else { (3, 2) }
+                );
+                assert_eq!(result.rows[0]["type"], "binary");
+                assert_eq!(result.rows.len() > 1, binary_lines);
+            }
+        }
     }
 
     /// `reset_to_empty_index` runs after a failed build, when the index

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1942,9 +1942,20 @@ fn search_file_matches(
         // `--json` reports binary matches as ordinary match events carrying a
         // `binary_offset`, so those clients ask for the lines as well.
         result.rows.push(marker);
-        if !opts.binary_lines {
+        if !opts.binary_lines || (opts.files_only && opts.stats) {
             return Ok(result);
         }
+    }
+
+    if opts.files_only && opts.stats {
+        // Totals need the full search, but files-only clients consume just the
+        // path. Avoid rendering content or span arrays proportional to hits.
+        // Keep legacy replies unchanged when per-file stats were not requested.
+        result.rows.push(serde_json::json!({
+            "type": "match",
+            "file": rel_path,
+        }));
+        return Ok(result);
     }
 
     result.rows.extend(collect_match_rows(
@@ -8803,6 +8814,54 @@ mod tests {
     }
 
     #[test]
+    fn stats_files_only_reply_is_constant_size_per_file() {
+        let matcher = crate::matching::build_search_matcher(
+            &["hello".to_string()],
+            &crate::matching::MatcherConfig::default(),
+        )
+        .unwrap();
+        for repeats in [1, 4096] {
+            for terminator in [" ", "\n"] {
+                let file = DecodedFile::new(
+                    format!("hello hello{terminator}")
+                        .repeat(repeats)
+                        .into_bytes(),
+                    tgrep_core::encoding::EncodingMode::Auto,
+                );
+                let result = search_file_matches(
+                    "many.txt",
+                    &file,
+                    &matcher,
+                    &SearchOpts {
+                        files_only: true,
+                        stats: true,
+                        detail: true,
+                        positions: true,
+                        only_matching: true,
+                        replace: Some("replacement".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+                assert_eq!(
+                    result.rows,
+                    [serde_json::json!({"type": "match", "file": "many.txt"})]
+                );
+                let stats = result.stats.unwrap();
+                assert_eq!(stats.matches, (2 * repeats) as u64);
+                assert_eq!(
+                    stats.matched_lines,
+                    if terminator == "\n" {
+                        repeats as u64
+                    } else {
+                        1
+                    }
+                );
+            }
+        }
+    }
+
+    #[test]
     fn stats_binary_totals_are_independent_of_marker_and_match_rows() {
         let file = DecodedFile::new(
             b"hello hello\nhello\n\0tail\n".to_vec(),
@@ -8815,25 +8874,31 @@ mod tests {
         .unwrap();
         for binary_lines in [false, true] {
             for invert_match in [false, true] {
-                let result = search_file_matches(
-                    "binary.txt",
-                    &file,
-                    &matcher,
-                    &SearchOpts {
-                        stats: true,
-                        binary_lines,
-                        invert_match,
-                        ..Default::default()
-                    },
-                )
-                .unwrap();
-                let stats = result.stats.unwrap();
-                assert_eq!(
-                    (stats.matches, stats.matched_lines),
-                    if invert_match { (0, 1) } else { (3, 2) }
-                );
-                assert_eq!(result.rows[0]["type"], "binary");
-                assert_eq!(result.rows.len() > 1, binary_lines);
+                for files_only in [false, true] {
+                    let result = search_file_matches(
+                        "binary.txt",
+                        &file,
+                        &matcher,
+                        &SearchOpts {
+                            stats: true,
+                            binary_lines,
+                            invert_match,
+                            files_only,
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap();
+                    let stats = result.stats.unwrap();
+                    assert_eq!(
+                        (stats.matches, stats.matched_lines),
+                        if invert_match { (0, 1) } else { (3, 2) }
+                    );
+                    assert_eq!(result.rows[0]["type"], "binary");
+                    assert_eq!(result.rows.len() > 1, binary_lines && !files_only);
+                    if files_only {
+                        assert_eq!(result.rows.len(), 1);
+                    }
+                }
             }
         }
     }

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -349,6 +349,92 @@ fn stats_count_matches_independently_of_count_and_file_output() {
 }
 
 #[test]
+fn stats_files_only_server_rpc_returns_one_marker_per_file() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("many.txt"), "hello hello\n".repeat(4096)).unwrap();
+    fs::write(root.join("none.txt"), "goodbye\n").unwrap();
+    let index_dir = dir.path().join("idx");
+    let _server = start_passthru_server(&root, &index_dir);
+    let info: serde_json::Value =
+        serde_json::from_slice(&fs::read(index_dir.join("serve.json")).unwrap()).unwrap();
+    let port = info["port"].as_u64().unwrap() as u16;
+    for (limit, matches, lines) in [(None, 8192, 4096), (Some(1), 2, 1), (Some(0), 0, 0)] {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "search",
+            "params": {
+                "pattern": "hello",
+                "files_only": true,
+                "stats": true,
+                "detail": true,
+                "max_count": limit,
+            },
+            "id": 1,
+        });
+        let response = send_rpc_request(port, &request.to_string()).unwrap();
+        let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(response.get("error").is_none(), "{response}");
+        let result = &response["result"];
+        if matches == 0 {
+            assert_eq!(result["matches"], serde_json::json!([]));
+            assert_eq!(result["file_stats"], serde_json::json!([]));
+        } else {
+            assert_eq!(
+                result["matches"],
+                serde_json::json!([{"type": "match", "file": "many.txt"}])
+            );
+            assert_eq!(
+                result["file_stats"],
+                serde_json::json!([{
+                    "file": "many.txt",
+                    "matches": matches,
+                    "matched_lines": lines,
+                }])
+            );
+        }
+        assert_eq!(result["num_matches"], if matches == 0 { 0 } else { 1 });
+    }
+    tgrep()
+        .args(["--index-path", index_dir.to_str().unwrap(), "-l", "--stats"])
+        .args(["--", "hello", root.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(format!("{}\n", root.join("many.txt").display()))
+        .stderr(predicate::str::contains(
+            "8192 matches (4096 matched lines)",
+        ))
+        .stderr(predicate::str::contains("(via server)"));
+}
+
+#[test]
+fn stats_binary_file_counts_matches_on_both_sides_of_nul() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("binary.txt");
+    fs::write(&file, b"hello\0hello").unwrap();
+    // ripgrep 15.2.0 reports both matches for a memory-mapped explicit file,
+    // even though its JSON bytes_searched reports the NUL offset (5).
+    for flags in [
+        vec![],
+        vec!["--count-matches"],
+        vec!["--json"],
+        vec!["--text"],
+    ] {
+        let output = tgrep()
+            .args(["--no-index", "--stats"])
+            .args(&flags)
+            .args(["--", "hello"])
+            .arg(&file)
+            .assert()
+            .success()
+            .get_output()
+            .clone();
+        assert_eq!(stats_totals(&output.stderr), [(2, 1)], "{flags:?}");
+    }
+}
+
+#[test]
 fn stats_explicit_files_and_binary_notes_count_unrendered_matches() {
     let dir = TempDir::new().unwrap();
     for (name, contents) in [

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -248,6 +248,355 @@ fn indexed_stats_follow_matches_on_a_combined_output_stream() {
     );
 }
 
+fn with_stats_backends(
+    root: &std::path::Path,
+    index_dir: &std::path::Path,
+    mut check: impl FnMut(&[&str], &str),
+) {
+    check(&["--no-index"], "Brute-force search completed");
+    let index = index_dir.to_str().unwrap();
+    tgrep()
+        .args(["index", root.to_str().unwrap(), "--index-path", index])
+        .assert()
+        .success();
+    check(&["--index-path", index], "Search completed");
+    let _server = start_passthru_server(root, index_dir);
+    check(&["--index-path", index], "(via server)");
+}
+
+fn stats_totals(stderr: &[u8]) -> Vec<(u64, u64)> {
+    let stderr = String::from_utf8_lossy(stderr);
+    regex::Regex::new(r"(\d+) matches \((\d+) matched lines\)")
+        .unwrap()
+        .captures_iter(&stderr)
+        .map(|c| (c[1].parse().unwrap(), c[2].parse().unwrap()))
+        .collect()
+}
+
+fn stable_json_output(stdout: &[u8]) -> Vec<serde_json::Value> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .map(|line| {
+            let mut event: serde_json::Value = serde_json::from_str(line).unwrap();
+            if let Some(stats) = event["data"]["stats"].as_object_mut() {
+                stats.remove("elapsed");
+                stats.remove("bytes_printed");
+            }
+            event["data"]
+                .as_object_mut()
+                .unwrap()
+                .remove("elapsed_total");
+            event
+        })
+        .collect()
+}
+
+#[test]
+fn stats_count_matches_independently_of_count_and_file_output() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("counts.txt"), "hello hello\nhello\nbye\n").unwrap();
+
+    with_stats_backends(&root, &dir.path().join("idx"), |backend, marker| {
+        for (flags, expected, stdout) in [
+            (vec!["-c"], (3, 2), Some("2")),
+            (vec!["--count-matches"], (3, 2), Some("3")),
+            (vec!["-l"], (3, 2), None),
+            (vec!["-q"], (2, 1), Some("")),
+            (vec!["-c", "-v"], (0, 1), Some("1")),
+            (vec!["--count-matches", "-v"], (0, 1), Some("1")),
+            (vec!["-l", "-v"], (0, 1), None),
+            (vec!["-c", "-m", "1"], (2, 1), Some("1")),
+            (vec!["--count-matches", "-m", "1"], (2, 1), Some("2")),
+            (vec!["-l", "-m", "1"], (2, 1), None),
+        ] {
+            let output = tgrep()
+                .args(backend)
+                .args(["--stats", "--no-filename", "--color", "never"])
+                .args(&flags)
+                .args(["--", "hello", root.to_str().unwrap()])
+                .assert()
+                .success()
+                .stderr(predicate::str::contains(marker))
+                .get_output()
+                .clone();
+            assert_eq!(
+                stats_totals(&output.stderr),
+                [expected],
+                "{backend:?} {flags:?}"
+            );
+            if let Some(stdout) = stdout {
+                assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), stdout);
+            } else {
+                assert!(String::from_utf8_lossy(&output.stdout).contains("counts.txt"));
+            }
+        }
+
+        // This mode deliberately bypasses the server and stops after one hit
+        // in each file, even though matching files produce no output.
+        let output = tgrep()
+            .args(backend)
+            .args(["--stats", "--files-without-match", "--", "hello"])
+            .arg(&root)
+            .assert()
+            .code(1)
+            .stdout("")
+            .get_output()
+            .clone();
+        assert_eq!(stats_totals(&output.stderr), [(2, 1)]);
+    });
+}
+
+#[test]
+fn stats_explicit_files_and_binary_notes_count_unrendered_matches() {
+    let dir = TempDir::new().unwrap();
+    for (name, contents) in [
+        ("counts.txt", "hello hello\nhello\n"),
+        ("binary.txt", "hello hello\nhello\n\0tail\n"),
+    ] {
+        let file = dir.path().join(name);
+        fs::write(&file, contents).unwrap();
+        for (flags, expected) in [
+            (vec![], (3, 2)),
+            (vec!["-c"], (3, 2)),
+            (vec!["--count-matches"], (3, 2)),
+            (vec!["-l"], (3, 2)),
+            (vec!["-q"], (2, 1)),
+            (vec!["--json"], (3, 2)),
+        ] {
+            let output = tgrep()
+                .args(["--no-index", "--stats"])
+                .args(&flags)
+                .args(["--", "hello"])
+                .arg(&file)
+                .assert()
+                .success()
+                .get_output()
+                .clone();
+            assert_eq!(stats_totals(&output.stderr), [expected], "{name} {flags:?}");
+            if name == "binary.txt" && flags.is_empty() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                assert!(stdout.contains("binary file matches"));
+                assert!(!stdout.contains("hello"));
+            }
+        }
+    }
+}
+
+#[test]
+fn stats_are_scoped_to_each_root_without_colliding_relative_paths() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    for (name, contents) in [
+        ("one", "hello\n"),
+        ("two", "hello\n"),
+        ("empty", "goodbye\n"),
+    ] {
+        fs::create_dir_all(root.join(name)).unwrap();
+        fs::write(root.join(name).join("a.txt"), contents).unwrap();
+    }
+    with_stats_backends(&root, &dir.path().join("idx"), |backend, marker| {
+        for json in [false, true] {
+            let mut cmd = tgrep();
+            cmd.args(backend).args(["--stats", "--color", "never"]);
+            if json {
+                cmd.arg("--json");
+            }
+            let output = cmd
+                .args(["--", "hello"])
+                .arg(root.join("one"))
+                .arg(root.join("two"))
+                .arg(root.join("empty"))
+                .assert()
+                .success()
+                .stderr(predicate::str::contains(marker))
+                .get_output()
+                .clone();
+            assert_eq!(stats_totals(&output.stderr), [(1, 1), (1, 1), (0, 0)]);
+            if json {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let events: Vec<serde_json::Value> = stdout
+                    .lines()
+                    .map(|line| serde_json::from_str(line).unwrap())
+                    .collect();
+                let summaries: Vec<_> = events.iter().filter(|e| e["type"] == "summary").collect();
+                assert_eq!(summaries.len(), 1, "{stdout}");
+                assert_eq!(events.last().unwrap()["type"], "summary");
+                assert_eq!(summaries[0]["data"]["stats"]["matches"], 2);
+                assert_eq!(summaries[0]["data"]["stats"]["matched_lines"], 2);
+            }
+        }
+    });
+}
+
+#[test]
+fn stats_multiline_counts_original_matches_before_rendering() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("multiline.txt"),
+        "hello\nworld hello\nworld\nmiss\nhello\nworld\n",
+    )
+    .unwrap();
+    with_stats_backends(&root, &dir.path().join("idx"), |backend, marker| {
+        for (flags, expected) in [
+            (vec![], (3, 5)),
+            (vec!["-o"], (3, 5)),
+            (vec!["--json"], (3, 5)),
+            (vec!["--vimgrep"], (3, 5)),
+            (vec!["--replace", ""], (3, 5)),
+            (vec!["--trim"], (3, 5)),
+            (vec!["-C", "1"], (3, 5)),
+            (vec!["-m", "1", "-C", "2"], (2, 3)),
+            (vec!["-m", "1", "--vimgrep"], (2, 3)),
+            (vec!["-c"], (3, 5)),
+            (vec!["--count-matches"], (3, 5)),
+            (vec!["-l"], (3, 5)),
+            (vec!["-q"], (2, 3)),
+        ] {
+            let output = tgrep()
+                .args(backend)
+                .args(["--stats", "-U", "--color", "never"])
+                .args(&flags)
+                .args(["--", r"hello\r?\nworld", root.to_str().unwrap()])
+                .assert()
+                .success()
+                .stderr(predicate::str::contains(marker))
+                .get_output()
+                .clone();
+            assert_eq!(
+                stats_totals(&output.stderr),
+                [expected],
+                "{backend:?} {flags:?}"
+            );
+            let without_stats = tgrep()
+                .args(backend)
+                .args(["-U", "--color", "never"])
+                .args(&flags)
+                .args(["--", r"hello\r?\nworld", root.to_str().unwrap()])
+                .assert()
+                .success()
+                .get_output()
+                .stdout
+                .clone();
+            if flags.contains(&"--json") {
+                assert_eq!(
+                    stable_json_output(&output.stdout),
+                    stable_json_output(&without_stats)
+                );
+            } else {
+                assert_eq!(output.stdout, without_stats, "{backend:?} {flags:?}");
+            }
+        }
+        let output = tgrep()
+            .args(backend)
+            .args(["--stats", "-U", "-m", "0", "--", r"hello\r?\nworld"])
+            .arg(&root)
+            .assert()
+            .code(1)
+            .stdout("")
+            .get_output()
+            .clone();
+        assert_eq!(stats_totals(&output.stderr), [(0, 0)]);
+    });
+}
+
+#[test]
+fn stats_scope_depth_filters_and_quiet_early_exit_apply_to_server_totals() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    let scope = root.join("scope");
+    fs::create_dir_all(scope.join("nested")).unwrap();
+    fs::write(scope.join("a.txt"), "hello hello\nbye\nhello\n").unwrap();
+    fs::write(scope.join("b.txt"), "hello\n").unwrap();
+    fs::write(scope.join("zero.txt"), "bye\n").unwrap();
+    fs::write(scope.join("nested").join("deep.txt"), "hello\n").unwrap();
+    fs::write(root.join("outside.txt"), "hello\n").unwrap();
+    fs::write(scope.join("binary.txt"), "hello\0hello\n").unwrap();
+    with_stats_backends(&root, &dir.path().join("idx"), |backend, marker| {
+        for (flags, expected) in [
+            (vec!["--max-depth", "1"], (4, 3)),
+            (vec!["--max-depth", "1", "-q"], (2, 1)),
+            (vec!["-g", "a.txt", "--stop-on-nonmatch"], (2, 1)),
+            (vec!["-g", "zero.txt"], (0, 0)),
+        ] {
+            let output = tgrep()
+                .args(backend)
+                .args(["--stats", "--sort", "path", "--color", "never"])
+                .args(&flags)
+                .args(["--", "hello"])
+                .arg(&scope)
+                .assert()
+                .code(if expected.1 == 0 { 1 } else { 0 })
+                .stderr(predicate::str::contains(marker))
+                .get_output()
+                .clone();
+            assert_eq!(
+                stats_totals(&output.stderr),
+                [expected],
+                "{backend:?} {flags:?}"
+            );
+        }
+        // `--include-zero` deliberately bypasses the server.
+        let output = tgrep()
+            .args(backend)
+            .args([
+                "--stats",
+                "-c",
+                "--include-zero",
+                "-g",
+                "zero.txt",
+                "--",
+                "hello",
+            ])
+            .arg(&scope)
+            .assert()
+            .code(1)
+            .stdout(predicate::str::contains("zero.txt:0"))
+            .get_output()
+            .clone();
+        assert_eq!(stats_totals(&output.stderr), [(0, 0)]);
+    });
+}
+
+#[test]
+fn stats_ignore_trim_replacement_and_adjacent_span_merging() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("spans.txt"), "  hello hello\n").unwrap();
+    with_stats_backends(&root, &dir.path().join("idx"), |backend, marker| {
+        for (pattern, flags, expected) in [
+            (" +", vec!["--trim"], (2, 1)),
+            (" +", vec!["--trim", "--json"], (2, 1)),
+            ("hello", vec!["-o", "--replace", ""], (2, 1)),
+            ("hello", vec!["--replace", ""], (2, 1)),
+            ("hello", vec!["--max-columns", "1"], (2, 1)),
+            ("l", vec!["-U"], (4, 1)),
+            ("l", vec!["-U", "-o"], (4, 1)),
+            ("l", vec!["-U", "--vimgrep"], (4, 1)),
+        ] {
+            let output = tgrep()
+                .args(backend)
+                .args(["--stats", "--color", "never"])
+                .args(&flags)
+                .args(["--", pattern, root.to_str().unwrap()])
+                .assert()
+                .success()
+                .stderr(predicate::str::contains(marker))
+                .get_output()
+                .clone();
+            assert_eq!(
+                stats_totals(&output.stderr),
+                [expected],
+                "{backend:?} {flags:?}"
+            );
+        }
+    });
+}
+
 #[test]
 fn supports_negative_lookahead_fallback() {
     let dir = setup_fixture();


### PR DESCRIPTION
`--stats` reports a match count on the server-delegated search path, but the
local-index and brute-force paths — which cover the common case of an
unindexed or single-machine search — only ever printed timing, with no match
or line count. Confirmed against current `main`:

    $ tgrep hello . --stats
    Query plan: AND(3 trigrams) (candidates: 1/5)
    Search completed in 0.3ms

vs. the server path's

    2 matches (2 matched lines) in 0.3ms (via server)

This adds a format-agnostic match/line counter to `OutputWriter` (separate
from the JSON `Stats`/`file_stats` accounting already used for `--json`'s
`summary` event, so that path is untouched), and reports it from all three
`--stats` print sites in `search.rs`. All three now agree:

    Search completed in 0.3ms: 2 matches (2 matched lines)
    Brute-force search completed in 0.2ms (1 file): 2 matches (2 matched lines)
    2 matches (2 matched lines) in 0.3ms (via server)

Related to #145 — #146 fixed the print-ordering half of that issue; this
addresses the "more stats like `rg` supplies" half, which was still open
after #146.

Tested: `cargo test --workspace` (623 tests, 0 failures), manual verification
of all three search paths against ripgrep-style stats output.