### PR TITLE
fix: prevent read-only watcher events from causing overflow loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/README.md
+++ b/README.md
@@ -331,7 +331,10 @@ per admitted directory on Linux/Android; recursive backends count their single
 root subscription as one.
 
 The event buffer controlled by `--watcher-queue-cap` is separate: queue overflow
-triggers recovery reconciliation, not watch-budget fallback.
+triggers recovery reconciliation, not watch-budget fallback. Only create,
+modify, and remove events enter this buffer; read-only access notifications
+(including Linux directory-open events from tgrep's own walks) are discarded
+before queueing. Native rescan notifications still trigger recovery.
 
 Polling walks the admitted tree and checks metadata for additions, changes,
 and deletions. Its default cadence is completion-based: the next poll waits

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "blake3",

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -2294,10 +2294,7 @@ impl FsEventBurst {
 
     fn push(&mut self, event: Event) {
         self.event_count += 1;
-        if !matches!(
-            event.kind,
-            EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
-        ) {
+        if !event_changes_index(&event.kind) {
             return;
         }
 
@@ -2319,6 +2316,13 @@ impl FsEventBurst {
     fn into_paths(self) -> Vec<CoalescedFsEvent> {
         self.paths
     }
+}
+
+fn event_changes_index(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    )
 }
 
 fn event_introduces_dir(kind: &EventKind) -> bool {
@@ -2424,6 +2428,8 @@ fn recover_watcher_overflow(
     overflowed: &std::sync::atomic::AtomicBool,
     queue_cap: usize,
 ) {
+    // Clear before reconciling: real changes lost during the walk must be
+    // allowed to request another recovery.
     if !native_watching(state)
         || state.indexing.load(Ordering::SeqCst)
         || state.gitignore_pending.load(Ordering::SeqCst)
@@ -2498,6 +2504,35 @@ fn watch_failure_reason(error: &notify::Error) -> String {
     format!("{kind}: {error}")
 }
 
+fn enqueue_watcher_event(
+    tx: &std::sync::mpsc::SyncSender<Event>,
+    overflowed: &std::sync::atomic::AtomicBool,
+    watch_resubscribe: &std::sync::atomic::AtomicBool,
+    event: Event,
+) {
+    // Rescan flags report native event loss, even on otherwise ignored kinds
+    // (inotify uses Any with no paths). Handle them before filtering.
+    let lost_events = if event.need_rescan() {
+        true
+    } else {
+        // Linux reports Access(Open) for our own tree walks. Letting those
+        // fill the queue makes overflow recovery trigger its own next overflow.
+        if !event_changes_index(&event.kind) {
+            return;
+        }
+        // Never block the notification thread. A full queue needs a stale
+        // check rather than an attempt to replay an unknown set of lost events.
+        matches!(
+            tx.try_send(event),
+            Err(std::sync::mpsc::TrySendError::Full(_))
+        )
+    };
+    if lost_events {
+        overflowed.store(true, Ordering::SeqCst);
+        watch_resubscribe.store(true, Ordering::SeqCst);
+    }
+}
+
 fn start_file_watcher(state: Arc<ServerState>, root: &Path, queue_cap: usize) -> bool {
     start_file_watcher_using(state, root, queue_cap, notify::recommended_watcher)
 }
@@ -2510,8 +2545,6 @@ fn start_file_watcher_using(
         Box<dyn FnMut(notify::Result<Event>) + Send>,
     ) -> notify::Result<RecommendedWatcher>,
 ) -> bool {
-    use std::sync::mpsc::TrySendError;
-
     if !native_watching(&state) {
         return false;
     }
@@ -2534,27 +2567,14 @@ fn start_file_watcher_using(
                 return;
             }
             match result {
-                Ok(event) => match tx.try_send(event) {
-                    Ok(()) => {}
-                    // Don't block the notification thread waiting for room —
-                    // that's the stall this hand-off exists to avoid. Drop the
-                    // event and note that we did; the worker reconciles with a
-                    // stale check, which is cheaper and more reliable than
-                    // trying to replay an unknown number of lost events.
-                    Err(TrySendError::Full(_)) => {
-                        callback_overflow.store(true, Ordering::SeqCst);
-                        callback_state
-                            .watch_resubscribe
-                            .store(true, Ordering::SeqCst);
-                    }
-                    Err(TrySendError::Disconnected(_)) => {}
-                },
-                // A native drop is the same loss as a full channel, and the OS
-                // will not say what it lost — inotify's `IN_Q_OVERFLOW` and a
-                // dropped `ReadDirectoryChangesW` buffer both arrive here with no
-                // paths attached. Reconcile on them too: reporting without
-                // recovering left exactly one of the two overflow paths handled,
-                // and it was the one the kernel does not use.
+                Ok(event) => enqueue_watcher_event(
+                    &tx,
+                    &callback_overflow,
+                    &callback_state.watch_resubscribe,
+                    event,
+                ),
+                // Some backends report native event loss as an error rather
+                // than a rescan event. Both need the same repair as a full queue.
                 //
                 // Surfaced as well. A dropped buffer looks exactly like "the
                 // watcher stopped working" from the outside, and silence makes it
@@ -4385,11 +4405,7 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     if state.refresh.polling.load(Ordering::SeqCst) {
         return;
     }
-    let dominated_kinds = matches!(
-        event.kind,
-        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
-    );
-    if !dominated_kinds {
+    if !event_changes_index(&event.kind) {
         return;
     }
 
@@ -7961,6 +7977,7 @@ fn ctrlc_handler<F: Fn() + Send + Sync + 'static>(handler: F) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicBool;
     use tempfile::TempDir;
 
     fn watcher_event(kind: EventKind, paths: &[&str]) -> Event {
@@ -7968,6 +7985,124 @@ mod tests {
             kind,
             paths: paths.iter().map(PathBuf::from).collect(),
             attrs: Default::default(),
+        }
+    }
+
+    #[test]
+    fn watcher_queue_filters_read_only_events_before_the_bounded_channel() {
+        use notify::event::{AccessKind, AccessMode};
+
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let overflowed = AtomicBool::new(false);
+        let resubscribe = AtomicBool::new(false);
+        let change = watcher_event(
+            EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )),
+            &["source.rs"],
+        );
+        for queue_full in [false, true] {
+            if queue_full {
+                enqueue_watcher_event(&tx, &overflowed, &resubscribe, change.clone());
+            }
+            for _ in 0..64 {
+                for kind in [
+                    EventKind::Access(AccessKind::Any),
+                    EventKind::Access(AccessKind::Read),
+                    EventKind::Access(AccessKind::Open(AccessMode::Any)),
+                    EventKind::Access(AccessKind::Close(AccessMode::Read)),
+                    EventKind::Access(AccessKind::Close(AccessMode::Write)),
+                    EventKind::Access(AccessKind::Other),
+                    EventKind::Any,
+                    EventKind::Other,
+                ] {
+                    enqueue_watcher_event(
+                        &tx,
+                        &overflowed,
+                        &resubscribe,
+                        watcher_event(kind, &["src"]),
+                    );
+                }
+            }
+            assert!(!overflowed.load(Ordering::SeqCst));
+            assert!(!resubscribe.load(Ordering::SeqCst));
+            if queue_full {
+                assert_eq!(rx.try_recv().unwrap(), change);
+            }
+            assert!(matches!(
+                rx.try_recv(),
+                Err(std::sync::mpsc::TryRecvError::Empty)
+            ));
+        }
+    }
+
+    #[test]
+    fn watcher_queue_preserves_changes_and_reports_real_overflow() {
+        use notify::event::{
+            CreateKind, DataChange, MetadataKind, ModifyKind, RemoveKind, RenameMode,
+        };
+
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let overflowed = AtomicBool::new(false);
+        let resubscribe = AtomicBool::new(false);
+        for kind in [
+            EventKind::Create(CreateKind::File),
+            EventKind::Create(CreateKind::Folder),
+            EventKind::Modify(ModifyKind::Any),
+            EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+            EventKind::Modify(ModifyKind::Metadata(MetadataKind::Any)),
+            EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+            EventKind::Remove(RemoveKind::File),
+            EventKind::Remove(RemoveKind::Folder),
+        ] {
+            let event = watcher_event(kind, &["before.rs", "after.rs"]);
+            enqueue_watcher_event(&tx, &overflowed, &resubscribe, event.clone());
+            assert_eq!(rx.try_recv().unwrap(), event);
+            assert!(!overflowed.load(Ordering::SeqCst));
+            assert!(!resubscribe.load(Ordering::SeqCst));
+
+            enqueue_watcher_event(&tx, &overflowed, &resubscribe, event.clone());
+            enqueue_watcher_event(&tx, &overflowed, &resubscribe, event.clone());
+            assert!(overflowed.swap(false, Ordering::SeqCst));
+            assert!(resubscribe.swap(false, Ordering::SeqCst));
+            assert_eq!(rx.try_recv().unwrap(), event);
+        }
+    }
+
+    #[test]
+    fn watcher_queue_rescan_bypasses_kind_filter_and_channel_capacity() {
+        use notify::event::{AccessKind, AccessMode, Flag, ModifyKind};
+
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let overflowed = AtomicBool::new(false);
+        let resubscribe = AtomicBool::new(false);
+        let change = watcher_event(EventKind::Modify(ModifyKind::Any), &["source.rs"]);
+        for queue_full in [false, true] {
+            if queue_full {
+                enqueue_watcher_event(&tx, &overflowed, &resubscribe, change.clone());
+            }
+            for kind in [
+                EventKind::Any,
+                EventKind::Other,
+                EventKind::Access(AccessKind::Open(AccessMode::Any)),
+                EventKind::Modify(ModifyKind::Any),
+            ] {
+                enqueue_watcher_event(
+                    &tx,
+                    &overflowed,
+                    &resubscribe,
+                    Event::new(kind).set_flag(Flag::Rescan),
+                );
+                assert!(overflowed.swap(false, Ordering::SeqCst));
+                assert!(resubscribe.swap(false, Ordering::SeqCst));
+            }
+            if queue_full {
+                assert_eq!(rx.try_recv().unwrap(), change);
+            }
+            assert!(matches!(
+                rx.try_recv(),
+                Err(std::sync::mpsc::TryRecvError::Empty)
+            ));
         }
     }
 

--- a/tgrep-cli/src/serve/poll_tests.rs
+++ b/tgrep-cli/src/serve/poll_tests.rs
@@ -740,6 +740,43 @@ fn queue_overflow_repairs_content_but_does_not_abandon_native_watching() {
 }
 
 #[test]
+fn watcher_overflow_during_recovery_remains_pending() {
+    let fixture = Fixture::new(WatchMode::Auto, 4);
+    fixture.write("source.rs", "fn recovery_marker() {}\n");
+    assert!(background_refresh_stale(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        false,
+    ));
+    let overflowed = Arc::new(AtomicBool::new(true));
+    let during_walk = Arc::clone(&overflowed);
+    *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::BeforeWalk) {
+            during_walk.store(true, Ordering::SeqCst);
+        }
+    }));
+    recover_watcher_overflow(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        &overflowed,
+        1,
+    );
+    assert!(overflowed.load(Ordering::SeqCst));
+    *fixture.state.stale_refresh_hook.lock().unwrap() = None;
+    recover_watcher_overflow(
+        &fixture.state,
+        &fixture.root,
+        &fixture.state.index_dir,
+        &overflowed,
+        1,
+    );
+    assert!(!overflowed.load(Ordering::SeqCst));
+    fixture.assert_hit("recovery_marker", "source.rs");
+}
+
+#[test]
 fn explicit_poll_never_creates_a_watcher_or_starts_native_recovery() {
     let fixture = Fixture::new(WatchMode::Poll, 4);
     fixture.write("src/source.rs", "fn polled_marker() {}\n");

--- a/tgrep-cli/tests/watcher_watch_registration.rs
+++ b/tgrep-cli/tests/watcher_watch_registration.rs
@@ -285,6 +285,96 @@ fn inotify_watch_count(pid: u32) -> usize {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn watcher_read_only_walks_do_not_overflow_the_queue() {
+    const DIRS: usize = 128;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    // Keep index and log writes outside the watched tree so only reads occur.
+    let output = TempDir::new().unwrap();
+    let index_dir = output.path().join("index");
+    let log_path = output.path().join("serve.log");
+    fs::create_dir(root.join(".git")).unwrap();
+    for i in 0..DIRS {
+        let sub = root.join(format!("pkg{i}"));
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("source.txt"), "read_only_walk_marker\n").unwrap();
+    }
+    assert!(
+        Command::new(tgrep_bin())
+            .arg("index")
+            .arg(root)
+            .arg("--index-path")
+            .arg(&index_dir)
+            .status()
+            .unwrap()
+            .success()
+    );
+    let child = Command::new(tgrep_bin())
+        .args(["serve", "--watcher-queue-cap", "8"])
+        .arg("--index-path")
+        .arg(&index_dir)
+        .arg(root)
+        .stdout(std::process::Stdio::null())
+        .stderr(fs::File::create(&log_path).unwrap())
+        .spawn()
+        .unwrap();
+    let _server = ServerGuard { child };
+    let (pid, port) = wait_for_server(&index_dir);
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let status = server_status(port);
+        if status["watcher_active"] == true
+            && status["indexing"] == false
+            && status["reconcile_running"] == false
+            && status["last_reconcile_at"].is_u64()
+            && inotify_watch_count(pid) > DIRS
+        {
+            assert_eq!(status["watch_mode_active"], "native");
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "watcher did not finish startup: {status}\n{}",
+            fs::read_to_string(&log_path).unwrap()
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(search_matches(port, "read_only_walk_marker"), DIRS as u64);
+
+    // Reproduce directory opens from stale checks and subscription recovery.
+    // Each inotify watch sees opens on itself and on its children.
+    for _ in 0..4 {
+        for entry in fs::read_dir(root).unwrap() {
+            let path = entry.unwrap().path();
+            for file in fs::read_dir(path).unwrap() {
+                fs::read(file.unwrap().path()).unwrap();
+            }
+        }
+    }
+    // Allow several worker idle intervals, including time for a bad recovery
+    // walk to generate the next overflow.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        let log = fs::read_to_string(&log_path).unwrap();
+        assert!(
+            !log.contains("watcher queue overflowed"),
+            "read-only walks triggered overflow recovery:\n{log}"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    fs::write(root.join("pkg0").join("source.txt"), "actual_edit_marker\n").unwrap();
+    assert!(
+        wait_for_match(port, "actual_edit_marker", Duration::from_secs(15)),
+        "filtering read-only events must not suppress real edits"
+    );
+    let status = server_status(port);
+    assert_eq!(status["watch_mode_active"], "native");
+    assert_eq!(status["watcher_active"], true);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn watcher_does_not_subscribe_to_gitignored_directories() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();


### PR DESCRIPTION
## Summary
- Filter notifications before they enter the bounded watcher queue, sharing the worker's create/modify/remove predicate.
- Preserve native rescan signals and recovery requests raised during reconciliation; do not discard concurrent edits by draining the queue after a scan.
- Add deterministic queue/recovery coverage and a Linux regression using 128 watched directories with an eight-event queue.
- Document queue filtering and bump the workspace and both lockfiles to **1.0.7**.

Fixes #151.

## Validation
- Reproduced the read-only overflow on Linux before the fix; the regression passes afterward and confirms real edits remain searchable.
- Targeted watcher tests pass on Linux and Windows.
- Targeted Linux Clippy and Rust formatting checks pass.
- CLI reports `tgrep 1.0.7`.