### PR TITLE
fix: support macOS checksum verification in installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Test Unix installer
+        if: runner.os != 'Windows'
+        run: bash scripts/test-install.sh
       - run: cargo build --workspace --verbose
       - run: cargo build --workspace --benches --verbose
       - run: cargo test --workspace --verbose

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,8 +93,8 @@ main() (
     curl -fsSL "${base_url}/${checksums}" -o "${tmpdir}/${checksums}"
 
     info "Verifying checksum..."
-    # Some non-GNU sha256sum implementations do not support --quiet.
-    (cd "$tmpdir" && grep "${archive}" "${checksums}" | "${checksum_cmd[@]}" -c >/dev/null) \
+    # BSD sha256sum needs explicit stdin and --strict to reject malformed entries.
+    (cd "$tmpdir" && grep "${archive}" "${checksums}" | "${checksum_cmd[@]}" -c --strict - >/dev/null) \
         || error "Checksum verification failed"
 
     info "Extracting..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,9 +93,26 @@ main() (
     curl -fsSL "${base_url}/${checksums}" -o "${tmpdir}/${checksums}"
 
     info "Verifying checksum..."
-    # BSD sha256sum needs explicit stdin and --strict to reject malformed entries.
-    (cd "$tmpdir" && grep "${archive}" "${checksums}" | "${checksum_cmd[@]}" -c --strict - >/dev/null) \
-        || error "Checksum verification failed"
+    (
+        cd "$tmpdir" || exit 1
+        local checksum_line="" line digest filename
+        while IFS= read -r line || [ -n "$line" ]; do
+            digest="${line%% *}"
+            filename="${line#* }"
+            case "$filename" in
+                " $archive"|"*$archive") ;;
+                *) continue ;;
+            esac
+            # Validate exactly one entry: not all verifiers support --strict.
+            if [ -n "$checksum_line" ] || [ "${#digest}" -ne 64 ] \
+                || [[ "$digest" == *[!0-9a-fA-F]* ]]; then
+                exit 1
+            fi
+            checksum_line="$line"
+        done < "$checksums"
+        [ -n "$checksum_line" ] || exit 1
+        printf '%s\n' "$checksum_line" | "${checksum_cmd[@]}" -c - >/dev/null
+    ) || error "Checksum verification failed"
 
     info "Extracting..."
     tar xzf "${tmpdir}/${archive}" -C "${tmpdir}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -61,7 +61,17 @@ pick_install_dir() {
     fi
 }
 
-main() {
+# Keep the temporary directory in scope for the EXIT trap.
+main() (
+    local -a checksum_cmd
+    if command -v sha256sum >/dev/null 2>&1; then
+        checksum_cmd=(sha256sum)
+    elif command -v shasum >/dev/null 2>&1; then
+        checksum_cmd=(shasum -a 256)
+    else
+        error "Checksum verification requires sha256sum or shasum; install one and try again"
+    fi
+
     local target version dir
     target="$(detect_target)"
     version="$(resolve_version)"
@@ -83,7 +93,7 @@ main() {
     curl -fsSL "${base_url}/${checksums}" -o "${tmpdir}/${checksums}"
 
     info "Verifying checksum..."
-    (cd "$tmpdir" && grep "${archive}" "${checksums}" | sha256sum -c --quiet) \
+    (cd "$tmpdir" && grep "${archive}" "${checksums}" | "${checksum_cmd[@]}" -c --quiet) \
         || error "Checksum verification failed"
 
     info "Extracting..."
@@ -97,6 +107,6 @@ main() {
         info "Installed tgrep to ${dir}/tgrep"
         info "Make sure ${dir} is in your PATH"
     fi
-}
+)
 
 main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,7 +93,8 @@ main() (
     curl -fsSL "${base_url}/${checksums}" -o "${tmpdir}/${checksums}"
 
     info "Verifying checksum..."
-    (cd "$tmpdir" && grep "${archive}" "${checksums}" | "${checksum_cmd[@]}" -c --quiet) \
+    # Some non-GNU sha256sum implementations do not support --quiet.
+    (cd "$tmpdir" && grep "${archive}" "${checksums}" | "${checksum_cmd[@]}" -c >/dev/null) \
         || error "Checksum verification failed"
 
     info "Extracting..."

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -22,6 +22,7 @@ archive="tgrep-v0.0.0-aarch64-apple-darwin.tar.gz"
 printf '#!%s\nprintf "tgrep 0.0.0\\n"\n' "$bash_bin" > "$tmpdir/fixture/tgrep"
 tar czf "$tmpdir/fixture/$archive" -C "$tmpdir/fixture" tgrep
 (cd "$tmpdir/fixture" && "${verifier[@]}" "$archive") > "$tmpdir/fixture/checksums.txt"
+read -r digest _ < "$tmpdir/fixture/checksums.txt"
 printf '%064d  unrelated.tar.gz\n' 0 >> "$tmpdir/fixture/checksums.txt"
 
 # An isolated PATH makes the cases independent of the host's installed tools.
@@ -49,6 +50,14 @@ case "$2:$SCENARIO" in
     *.tar.gz:corrupt) printf 'corruption\n' >> "$4" ;;
     */checksums.txt:missing) printf '%064d  unrelated.tar.gz\n' 0 > "$4" ;;
     */checksums.txt:malformed) printf 'invalid  %s\n' "$ARCHIVE" > "$4" ;;
+    */checksums.txt:bad-hex) printf 'g%s  %s\n' "${DIGEST:1}" "$ARCHIVE" > "$4" ;;
+    */checksums.txt:short-hash) printf '%s  %s\n' "${DIGEST%?}" "$ARCHIVE" > "$4" ;;
+    */checksums.txt:duplicate) printf '%s  %s\n' "$DIGEST" "$ARCHIVE" >> "$4" ;;
+    */checksums.txt:mixed-malformed) printf 'invalid  %s\n' "$ARCHIVE" >> "$4" ;;
+    */checksums.txt:binary) printf '%s *%s\n' "$DIGEST" "$ARCHIVE" > "$4" ;;
+    */checksums.txt:no-newline) printf '%s  %s' "$DIGEST" "$ARCHIVE" > "$4" ;;
+    */checksums.txt:suffix-only) printf '%s  %s.extra\n' "$DIGEST" "$ARCHIVE" > "$4" ;;
+    */checksums.txt:suffix-extra) printf '%s  %s.extra\n' "$DIGEST" "$ARCHIVE" >> "$4" ;;
 esac
 EOF
 } > "$tmpdir/tools/curl"
@@ -59,11 +68,15 @@ run_case() (
     scenario="$2"
     case_dir="$tmpdir/${tools// /-}-$scenario"
     mkdir -p "$case_dir/bin" "$case_dir/install" "$case_dir/tmp"
-    for tool in $tools; do
+    checksum_tools="$tools"
+    if [ "$tools" = busybox ]; then
+        checksum_tools=sha256sum
+    fi
+    for tool in $checksum_tools; do
         [ "$tool" != none ] || continue
         case "$tool" in
-            sha256sum) expected_args="-c --strict -" ;;
-            shasum) expected_args="-a 256 -c --strict -" ;;
+            sha256sum) expected_args="-c -" ;;
+            shasum) expected_args="-a 256 -c -" ;;
         esac
         backend=("${verifier[@]}")
         if command -v "$tool" >/dev/null 2>&1; then
@@ -72,14 +85,17 @@ run_case() (
                 backend+=(-a 256)
             fi
         fi
-        # Check the selected command and flags, then use a real SHA-256 backend.
+        if [ "$tools" = busybox ] && command -v busybox >/dev/null 2>&1; then
+            backend=("$(command -v busybox)" sha256sum)
+        fi
+        # Enforce BusyBox-compatible flags even when the real applet is unavailable.
         {
             printf '#!%s\n' "$bash_bin"
             printf 'printf "%%s\\n" %q >> "$CHECKSUM_CALLS"\n' "$tool"
             printf '[ "$*" = %q ] || exit 2\n' "$expected_args"
             printf 'exec '
             printf '%q ' "${backend[@]}"
-            printf '%s\n' '-c --strict -'
+            printf '%s\n' '-c -'
         } > "$case_dir/bin/$tool"
         chmod +x "$case_dir/bin/$tool"
     done
@@ -89,6 +105,7 @@ run_case() (
         TMPDIR="$case_dir/tmp" \
         FIXTURE="$tmpdir/fixture" \
         ARCHIVE="$archive" \
+        DIGEST="$digest" \
         SCENARIO="$scenario" \
         DOWNLOADS="$case_dir/downloads" \
         CHECKSUM_CALLS="$case_dir/checksum-calls" \
@@ -96,7 +113,17 @@ run_case() (
         TGREP_INSTALL_DIR="$case_dir/install" \
         "$bash_bin" "$installer" > "$case_dir/output" 2>&1 || status=$?
 
-    if [ "$scenario" = valid ] && [ "$tools" != none ]; then
+    case "$scenario" in
+        valid|binary|no-newline|suffix-extra) expect_success=true; expect_verifier=true ;;
+        corrupt) expect_success=false; expect_verifier=true ;;
+        *) expect_success=false; expect_verifier=false ;;
+    esac
+    if [ "$tools" = none ]; then
+        expect_success=false
+        expect_verifier=false
+    fi
+
+    if "$expect_success"; then
         if [ "$status" -ne 0 ] || [ ! -x "$case_dir/install/tgrep" ]; then
             cat "$case_dir/output"
             fail "$tools/$scenario: installation did not succeed"
@@ -118,8 +145,10 @@ run_case() (
             grep -q 'Checksum verification failed' "$case_dir/output" || fail "Missing checksum failure diagnostic"
         fi
     fi
-    if [ "$tools" != none ]; then
-        [ "$(cat "$case_dir/checksum-calls")" = "${tools%% *}" ] || fail "Wrong checksum tool selected"
+    if "$expect_verifier"; then
+        [ "$(cat "$case_dir/checksum-calls")" = "${checksum_tools%% *}" ] || fail "Wrong checksum tool selected"
+    else
+        [ ! -e "$case_dir/checksum-calls" ] || fail "Passed invalid checksum entries to the verifier"
     fi
     for leftover in "$case_dir/tmp/"*; do
         [ ! -e "$leftover" ] || fail "$tools/$scenario: temporary files were not cleaned up"
@@ -127,8 +156,8 @@ run_case() (
     printf 'PASS: %s/%s\n' "$tools" "$scenario"
 )
 
-for tools in shasum sha256sum "sha256sum shasum"; do
-    for scenario in valid corrupt missing malformed; do
+for tools in busybox shasum sha256sum "sha256sum shasum"; do
+    for scenario in valid corrupt missing malformed bad-hex short-hash duplicate mixed-malformed binary no-newline suffix-only suffix-extra; do
         run_case "$tools" "$scenario"
     done
 done

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -62,8 +62,8 @@ run_case() (
     for tool in $tools; do
         [ "$tool" != none ] || continue
         case "$tool" in
-            sha256sum) expected_args="-c --quiet" ;;
-            shasum) expected_args="-a 256 -c --quiet" ;;
+            sha256sum) expected_args="-c" ;;
+            shasum) expected_args="-a 256 -c" ;;
         esac
         backend=("${verifier[@]}")
         if command -v "$tool" >/dev/null 2>&1; then
@@ -79,7 +79,7 @@ run_case() (
             printf '[ "$*" = %q ] || exit 2\n' "$expected_args"
             printf 'exec '
             printf '%q ' "${backend[@]}"
-            printf '%s\n' '-c --quiet'
+            printf '%s\n' '-c'
         } > "$case_dir/bin/$tool"
         chmod +x "$case_dir/bin/$tool"
     done

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+installer="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/install.sh"
+bash_bin="$(command -v bash)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+if command -v sha256sum >/dev/null 2>&1; then
+    verifier=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+    verifier=(shasum -a 256)
+else
+    fail "Tests require sha256sum or shasum"
+fi
+verifier[0]="$(command -v "${verifier[0]}")"
+
+mkdir -p "$tmpdir/tools" "$tmpdir/fixture"
+archive="tgrep-v0.0.0-aarch64-apple-darwin.tar.gz"
+printf '#!%s\nprintf "tgrep 0.0.0\\n"\n' "$bash_bin" > "$tmpdir/fixture/tgrep"
+tar czf "$tmpdir/fixture/$archive" -C "$tmpdir/fixture" tgrep
+(cd "$tmpdir/fixture" && "${verifier[@]}" "$archive") > "$tmpdir/fixture/checksums.txt"
+printf '%064d  unrelated.tar.gz\n' 0 >> "$tmpdir/fixture/checksums.txt"
+
+# An isolated PATH makes the cases independent of the host's installed tools.
+for tool in cp grep gzip install mkdir mktemp rm tar; do
+    printf '#!%s\nexec %q "$@"\n' "$bash_bin" "$(command -v "$tool")" > "$tmpdir/tools/$tool"
+done
+{
+    printf '#!%s\n' "$bash_bin"
+    cat <<'EOF'
+case "$1" in
+    -s) printf 'Darwin\n' ;;
+    -m) printf 'arm64\n' ;;
+    *) exit 1 ;;
+esac
+EOF
+} > "$tmpdir/tools/uname"
+{
+    printf '#!%s\n' "$bash_bin"
+    cat <<'EOF'
+set -eu
+[ "$1" = -fsSL ] && [ "$3" = -o ]
+printf '%s\n' "$2" >> "$DOWNLOADS"
+cp "$FIXTURE/${2##*/}" "$4"
+case "$2:$SCENARIO" in
+    *.tar.gz:corrupt) printf 'corruption\n' >> "$4" ;;
+    */checksums.txt:missing) printf '%064d  unrelated.tar.gz\n' 0 > "$4" ;;
+    */checksums.txt:malformed) printf 'invalid  %s\n' "$ARCHIVE" > "$4" ;;
+esac
+EOF
+} > "$tmpdir/tools/curl"
+chmod +x "$tmpdir/tools/"*
+
+run_case() (
+    tools="$1"
+    scenario="$2"
+    case_dir="$tmpdir/${tools// /-}-$scenario"
+    mkdir -p "$case_dir/bin" "$case_dir/install" "$case_dir/tmp"
+    for tool in $tools; do
+        [ "$tool" != none ] || continue
+        case "$tool" in
+            sha256sum) expected_args="-c --quiet" ;;
+            shasum) expected_args="-a 256 -c --quiet" ;;
+        esac
+        backend=("${verifier[@]}")
+        if command -v "$tool" >/dev/null 2>&1; then
+            backend=("$(command -v "$tool")")
+            if [ "$tool" = shasum ]; then
+                backend+=(-a 256)
+            fi
+        fi
+        # Check the selected command and flags, then use a real SHA-256 backend.
+        {
+            printf '#!%s\n' "$bash_bin"
+            printf 'printf "%%s\\n" %q >> "$CHECKSUM_CALLS"\n' "$tool"
+            printf '[ "$*" = %q ] || exit 2\n' "$expected_args"
+            printf 'exec '
+            printf '%q ' "${backend[@]}"
+            printf '%s\n' '-c --quiet'
+        } > "$case_dir/bin/$tool"
+        chmod +x "$case_dir/bin/$tool"
+    done
+
+    status=0
+    PATH="$case_dir/bin:$tmpdir/tools" \
+        TMPDIR="$case_dir/tmp" \
+        FIXTURE="$tmpdir/fixture" \
+        ARCHIVE="$archive" \
+        SCENARIO="$scenario" \
+        DOWNLOADS="$case_dir/downloads" \
+        CHECKSUM_CALLS="$case_dir/checksum-calls" \
+        TGREP_VERSION=v0.0.0 \
+        TGREP_INSTALL_DIR="$case_dir/install" \
+        "$bash_bin" "$installer" > "$case_dir/output" 2>&1 || status=$?
+
+    if [ "$scenario" = valid ] && [ "$tools" != none ]; then
+        if [ "$status" -ne 0 ] || [ ! -x "$case_dir/install/tgrep" ]; then
+            cat "$case_dir/output"
+            fail "$tools/$scenario: installation did not succeed"
+        fi
+        cmp "$tmpdir/fixture/tgrep" "$case_dir/install/tgrep"
+    else
+        [ "$status" -ne 0 ] || fail "$tools/$scenario: installer should fail"
+        [ ! -e "$case_dir/install/tgrep" ] || fail "$tools/$scenario: installed an unverified binary"
+        if grep -q 'Extracting' "$case_dir/output"; then
+            fail "$tools/$scenario: extracted an unverified archive"
+        fi
+        if [ "$tools" = none ]; then
+            grep -q 'requires sha256sum or shasum' "$case_dir/output" || fail "Missing dependency diagnostic"
+            [ ! -e "$case_dir/downloads" ] || fail "Downloaded before checking checksum tools"
+            if grep -q 'Checksum verification failed' "$case_dir/output"; then
+                fail "Reported missing tools as a checksum failure"
+            fi
+        else
+            grep -q 'Checksum verification failed' "$case_dir/output" || fail "Missing checksum failure diagnostic"
+        fi
+    fi
+    if [ "$tools" != none ]; then
+        [ "$(cat "$case_dir/checksum-calls")" = "${tools%% *}" ] || fail "Wrong checksum tool selected"
+    fi
+    for leftover in "$case_dir/tmp/"*; do
+        [ ! -e "$leftover" ] || fail "$tools/$scenario: temporary files were not cleaned up"
+    done
+    printf 'PASS: %s/%s\n' "$tools" "$scenario"
+)
+
+for tools in shasum sha256sum "sha256sum shasum"; do
+    for scenario in valid corrupt missing malformed; do
+        run_case "$tools" "$scenario"
+    done
+done
+run_case none valid

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -62,8 +62,8 @@ run_case() (
     for tool in $tools; do
         [ "$tool" != none ] || continue
         case "$tool" in
-            sha256sum) expected_args="-c" ;;
-            shasum) expected_args="-a 256 -c" ;;
+            sha256sum) expected_args="-c --strict -" ;;
+            shasum) expected_args="-a 256 -c --strict -" ;;
         esac
         backend=("${verifier[@]}")
         if command -v "$tool" >/dev/null 2>&1; then
@@ -79,7 +79,7 @@ run_case() (
             printf '[ "$*" = %q ] || exit 2\n' "$expected_args"
             printf 'exec '
             printf '%q ' "${backend[@]}"
-            printf '%s\n' '-c'
+            printf '%s\n' '-c --strict -'
         } > "$case_dir/bin/$tool"
         chmod +x "$case_dir/bin/$tool"
     done


### PR DESCRIPTION
## Summary
- Prefer `sha256sum` when available, falling back to macOS's `shasum -a 256`.
- Validate exactly one matching archive entry with a 64-digit hexadecimal checksum, then use portable `-c -` verification compatible with GNU, BSD, and BusyBox tools.
- Report missing checksum tools explicitly before downloading; reject missing, malformed, duplicate, or mismatched checksums before extraction or installation.
- Keep the temporary directory in scope for the exit trap so successful and failed installs clean up correctly.
- Add local-fixture installer regression coverage and run it in Linux and macOS CI.

## Validation
- All 49 installer scenarios passed under Git Bash on Windows and Ubuntu via WSL, including a real BusyBox 1.36.1 applet and GNU `sha256sum`/Perl `shasum` backends.
- Covers tool preference, shasum-only and BusyBox-compatible installations, corrupted archives, malformed/duplicate/missing entries, exact filename selection, text/binary checksum formats, final lines without a newline, missing tools, and cleanup.
- The BusyBox-compatible wrapper rejects nonportable flags even when the native applet is unavailable.

Fixes #153