### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tgrep-cli"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["tgrep-core", "tgrep-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "1.0.7"
+version = "1.0.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/microsoft/tgrep"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "tgrep-core"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "blake3",


### PR DESCRIPTION
## Summary
- Bump the workspace version from 1.0.7 to 1.0.8 and synchronize the tgrep-cli/tgrep-core entries in Cargo.lock and fuzz/Cargo.lock.
- Prepare the next patch release to include the Windows NTFS index cleanup fix merged in #156. Based on current main, with no application code or third-party dependency changes.

## Validation
- Built and ran `cargo run --locked --offline --quiet --target-dir .\target -p tgrep-cli --bin tgrep -- --version`; output: `tgrep 1.0.8`.
- Windows executable FileVersion and ProductVersion both report `1.0.8`.
- `cargo metadata --locked --format-version 1 --filter-platform x86_64-pc-windows-msvc` succeeds for both the root and fuzz manifests; first-party release packages resolve to `1.0.8` and tgrep-fuzz remains `0.0.1`.
- `git diff --check` passes.

No tag or release is created by this PR.