### PR TITLE
Support indexed hidden-file searches while preserving ignore rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,8 @@ hidden-file filtering, including Windows hidden attributes. `--hidden` searches
 and `--files --hidden` use compatible local/server indexes without disabling
 ignore rules. Negative-only globs such as `--glob '!.git'` also stay indexed.
 The configured index directory and all its staging/retired generations are
-excluded from indexing and watcher processing, even with a custom path.
+excluded from indexing, watcher processing, and query filesystem walks, even
+with a custom path.
 
 Legacy or incomplete indexes, and older servers that cannot confirm hidden-file
 coverage, fall back to scanning. A current server upgrades legacy coverage by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,19 +22,18 @@ A search resolves in this order:
    notification is repaired only by periodic reconciliation (scheduled hourly
    and deferrable for up to four hours while queried); `--no-watch` disables it.
 2. **On-disk index** but no server: read `.tgrep/` directly. Fast, but only as
-   fresh as the last successful index publication. If a `serve` was interrupted
-   during its first build, an index marked incomplete can remain on disk, and a
-   search may still try to use it without warning even though it can be empty or
-   partial. Rebuild with `tgrep index .` or resume `tgrep serve .` before an exhaustive search.
+   fresh as the last successful index publication. Legacy indexes without
+   hidden-file coverage metadata and incomplete builds fall back to scanning.
+   Rebuild with `tgrep index .` or resume `tgrep serve .` to enable indexed queries.
 3. **No index**: scan every file, like grep. Correct but slow on large trees.
    tgrep prints a warning on stderr when this happens.
 
 An agent never has to choose between these; the command is the same. Results
 can differ, though. An on-disk index omits changes since its last build. A
-server started with no index at all answers from an empty index, so every
-search returns nothing, until the first build completes. A server resuming a
-partial index answers from what it has so far. `tgrep status .` shows
-`Indexing: complete` once the initial build is done. Do not read it as a
+server started with no index, a partial index, or legacy hidden-file coverage
+lets clients fall back to scanning until it establishes the full corpus.
+`tgrep status .` shows `Hidden coverage: complete` once indexed queries are
+available, and `Indexing: complete` once the initial build is done. Do not read either as a
 freshness signal: a server that starts on an existing index reconciles it
 against the filesystem in the background while already reporting complete,
 and it never covers watcher events missed later. When a search must reflect current file
@@ -98,8 +97,9 @@ Rules of thumb for agents:
   the pattern and paths, so all flags must come before it.
 - **Prefer `-F`** when the query is a symbol or a string the user typed. It
   avoids regex-escaping mistakes.
-- **Narrow with `-t` or `-g`** before adding `-m`. The index makes scoping
-  cheap; `-m` only trims output.
+- **Narrow with `-t`** before adding `-m`. Negative `-g` filters stay indexed;
+  positive glob overrides may widen the corpus and require a full scan.
+  `-m` only trims output.
 - **Use `-l` first** on a broad query, then search the specific files. This
   keeps output small.
 - **Use `-C 2` or `-C 3`** when you need to read the surrounding code.
@@ -147,12 +147,30 @@ as ripgrep.
 These fall back to a full scan even with a server running, because they widen
 the file set the index was built over:
 
-- `--hidden`, `--no-ignore` and variants, `-u`/`-uu`/`-uuu`
+- `--no-ignore` and variants, `-u`/`-uu`/`-uuu`
+- positive `--glob`/`--iglob` overrides (they can reinclude ignored files)
 - `-a`/`--text`, `--binary`, `-E`/`--encoding`
 - `--no-index` (explicit)
 - naming a single file instead of a directory
 
 Avoid these on large repositories unless you need them.
+
+`index` and `serve` include hidden, non-ignored files by default; passing
+`--hidden` to either is redundant. Queries without `--hidden` still apply normal
+hidden-file filtering, including Windows hidden attributes. `--hidden` searches
+and `--files --hidden` use compatible local/server indexes without disabling
+ignore rules. Negative-only globs such as `--glob '!.git'` also stay indexed.
+The configured index directory and all its staging/retired generations are
+excluded from indexing and watcher processing, even with a custom path.
+
+Legacy or incomplete indexes, and older servers that cannot confirm hidden-file
+coverage, fall back to scanning. A current server upgrades legacy coverage by
+reconciling the tree; `tgrep index .` can rebuild it explicitly.
+
+New indexes have a format boundary that older local readers reject instead of
+exposing hidden paths without filtering. Downgrading requires rebuilding with
+the older binary, preferably using a separate `--index-path`. New readers retain
+legacy-format support for migration.
 
 ## Freshness
 

--- a/README.md
+++ b/README.md
@@ -689,7 +689,8 @@ still hide hidden files and directories; `-./--hidden` includes them using the
 index or server, for content searches and `--files`. Visibility is relative to
 the requested search root and includes Windows hidden attributes. Ignore rules
 inside hidden directories remain active. The configured index directory,
-including its staging and retired generations, is always excluded from indexing.
+including its staging and retired generations, is always excluded from indexing
+and query filesystem walks.
 
 Flags that widen or re-interpret the indexed corpus still walk the tree:
 `-E/--encoding`, `-a/--text`, `--binary`, every `--no-ignore*` variant, and

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ tgrep <pattern> ---TCP---> tgrep serve (multi-client)
 - **LiveIndex** — in-memory overlay for files modified after server start, or
   being built by the background indexer
 - **HybridIndex** — merges both layers; overlay takes precedence
-- **Background Indexer** — builds the index in parallel batches of 1,024 files 
-  (with additional byte-based splitting); a cold start serves an empty index until
-  the first build is published, while a resumed partial index is processed at 500 files
+- **Background Indexer** — builds the index in parallel batches of 1,024 files
+  (with additional byte-based splitting); resumed partial indexes use batches of
+  500 files. Clients scan until complete hidden-file coverage is published
 - **Periodic Flush** — every 50K files or 5 minutes, the in-memory index is
   flushed to disk and the reader is swapped, keeping memory bounded
 - **Automatic refresh** — native `notify` subscriptions update LiveIndex in
@@ -96,8 +96,8 @@ tgrep is designed to be significantly faster than ripgrep on large repos:
   (`--no-max-filesize` removes it)
 - **Lock-free reads** — `RwLock<HashMap>` cache allows concurrent reads
   without contention
-- **Hot serving** — queries work immediately during background index building;
-  no need to wait for full index
+- **Hot serving** — queries work immediately during background index building,
+  falling back to filesystem scans until the index is ready
 
 See [BENCHMARKS.md](BENCHMARKS.md) for end-to-end large-repo benchmarks and
 Criterion microbenchmarks for query execution, trigram extraction, and index
@@ -270,9 +270,9 @@ other. See
 `tgrep serve` uses the same bounded builder when it has to create an index from
 scratch, so starting a server on an unindexed repo costs the same memory as
 `tgrep index` (**148.6 MiB** rather than 1.6 GiB on the Linux kernel, and 2.6x
-faster). While that first build runs the server answers from an empty index
-rather than a partial one; incremental updates after it completes are
-unaffected.
+faster). While that first build runs, clients fall back to filesystem scans
+rather than returning partial results; incremental updates after it completes
+are unaffected.
 
 ### Start the server
 
@@ -286,11 +286,11 @@ tgrep serve . --no-watch              # disable all automatic refresh
 tgrep serve . --exclude node_modules   # exclude directories from indexing
 ```
 
-The server builds the index in the background if none exists. During that
-first build, queries are answered from an empty index and return nothing;
-`tgrep status` reports that indexing is in progress. When the server resumes a partial
-index instead, queries are answered from the files already indexed. Multiple
-clients can connect simultaneously.
+The server builds the index in the background if none exists and resumes
+incomplete builds. Clients scan the filesystem until the full corpus is ready;
+`tgrep status` reports indexing progress and hidden-file coverage. Legacy
+indexes are upgraded by startup reconciliation. Multiple clients can connect
+simultaneously.
 
 On Windows, replaced index generations remain under the index directory's
 `.retired` folder while readers still have them memory-mapped. Cleanup uses
@@ -683,11 +683,38 @@ restriction, and `--files` never applies it.
 
 ### Flags that bypass the index
 
-The index is built over text files only, skipping hidden and ignored ones, so
-flags that widen or re-interpret that set are answered by walking the tree
-instead: `-E/--encoding`, `-a/--text`, `--binary`, `-./--hidden`, and every
-`--no-ignore*` variant. Naming a single file also skips the index, since
-reading one file directly is cheaper than loading one.
+`index` and `serve` include hidden, **non-ignored** files by default.
+`--hidden` is accepted on either command but is redundant. Ordinary queries
+still hide hidden files and directories; `-./--hidden` includes them using the
+index or server, for content searches and `--files`. Visibility is relative to
+the requested search root and includes Windows hidden attributes. Ignore rules
+inside hidden directories remain active. The configured index directory,
+including its staging and retired generations, is always excluded from indexing.
+
+Flags that widen or re-interpret the indexed corpus still walk the tree:
+`-E/--encoding`, `-a/--text`, `--binary`, every `--no-ignore*` variant, and
+positive `--glob`/`--iglob` overrides, which can explicitly reinclude ignored
+files. Negative-only globs, such as `--glob '!.git'`, remain index-compatible
+and exclude entire matching directory subtrees. `--hidden` never disables
+ignore rules. Naming a single file also skips the index, since reading one
+file directly is cheaper than loading one.
+
+Legacy indexes without proven hidden-file coverage and incomplete builds fall
+back to a filesystem scan, rather than returning partial results. Run
+`tgrep index` to rebuild, or start a current `tgrep serve` to reconcile and
+upgrade an existing index automatically. Queries keep scanning until coverage
+is established. A current client also falls back when an older server cannot
+confirm that capability. As before, a completed on-disk index is a snapshot,
+not a guarantee that later filesystem changes have been indexed.
+
+New indexes use a versioned file table and filename sidecar so older clients
+cannot silently expose hidden files by ignoring visibility metadata. Older
+binaries reject the new local content index; filename listing can fall back to
+walking. New binaries still read older formats to migrate them. To downgrade,
+rebuild with the older binary, preferably at a separate `--index-path`.
+Visibility is bound to the path table, and filename-only membership is
+published together with its visibility; mismatched generations fall back to
+scanning rather than guessing.
 
 ### Invalid UTF-8
 
@@ -779,9 +806,9 @@ exit code determined by the search alone. Suppress the message with
 
 3. **Serving** — `tgrep serve` wraps the index in a HybridIndex, watches for
    filesystem changes, and serves queries over TCP. If no index exists, it
-   builds one in the background (batches of 1,024 files and may split sooner 
-   by byte budgets); queries see an empty index until that first build is published, 
-   and see partial data only when a partial index is being resumed. The index is 
+   builds one in the background (batches of 1,024 files, split sooner by byte
+   budgets); clients scan until complete coverage is published, including when
+   resuming a partial index;
    after the initial build, pending changes are auto-saved when 5,000 content mutations accumulate by default, or on the first periodic check at least 10 minutes after startup or the last successful save. Multiple clients connect simultaneously;
 
    searches use read locks for zero contention.
@@ -792,9 +819,9 @@ exit code determined by the search alone. Suppress the message with
 |------|-------------|
 | `lookup.bin` | Sorted 16-byte entries: `trigram(u32) + offset(u64) + length(u32)` |
 | `index.bin` | Concatenated posting lists: `file_id(u32)` per entry |
-| `files.bin` | File ID→path mapping: `file_id(u32) + path_len(u16) + path_bytes` |
-| `files-extra.bin` | Paths included by `--files` but absent from `files.bin` |
-| `meta.json` | Version, file/trigram counts, timestamps |
+| `files.bin` | Version 3 header, then `file_id(u32) + path_len(u16) + path_bytes`; legacy headerless tables remain readable |
+| `files-extra.bin` | Version 2 filename-only paths, visibility, and file-table identity |
+| `meta.json` | Version, file/trigram counts, timestamps, coverage, visibility, and file-table identity |
 | `serve.json` | Server PID and TCP port (for client discovery) |
 
 ## Project Structure

--- a/tgrep-cli/src/glob_filter.rs
+++ b/tgrep-cli/src/glob_filter.rs
@@ -1,23 +1,21 @@
-/// Compiled glob filter backed by the `globset` crate (same engine as ripgrep).
-///
-/// Glob patterns are compiled once at construction time and reused for all
-/// subsequent matches. Supports include/exclude semantics:
-/// - Patterns prefixed with `!` act as exclusions
-/// - Other patterns act as inclusions
-/// - If only exclusions exist, paths pass unless they match an exclusion
-/// - If inclusions exist, a path must match at least one inclusion AND
-///   must not match any exclusion
-///
-/// Matching is case-sensitive by default, as in ripgrep. `--glob-case-insensitive`
-/// flips that for every `-g` pattern, and `--iglob` patterns are always
-/// case-insensitive regardless.
-use anyhow::Result;
-use globset::{GlobBuilder, GlobMatcher};
+/// Ripgrep-style glob overrides, shared by indexed filtering and full walks.
+use std::path::Path;
 
-#[derive(Default)]
+use anyhow::Result;
+use tgrep_core::walker::{Override, OverrideBuilder};
+
 pub struct GlobFilter {
-    includes: Vec<GlobMatcher>,
-    excludes: Vec<GlobMatcher>,
+    overrides: Override,
+    globs: Vec<(String, bool)>,
+}
+
+impl Default for GlobFilter {
+    fn default() -> Self {
+        Self {
+            overrides: Override::empty(),
+            globs: Vec::new(),
+        }
+    }
 }
 
 impl GlobFilter {
@@ -27,26 +25,34 @@ impl GlobFilter {
     /// `case_insensitive` applies to `globs` only — `iglobs` are always
     /// case-insensitive. Returns an error if any pattern fails to compile.
     pub fn new(globs: &[String], iglobs: &[String], case_insensitive: bool) -> Result<Self> {
-        let mut filter = Self::default();
-        filter.push_all(globs, case_insensitive)?;
-        filter.push_all(iglobs, true)?;
+        let mut filter = Self {
+            globs: globs
+                .iter()
+                .map(|glob| (glob.replace('\\', "/"), case_insensitive))
+                .chain(iglobs.iter().map(|glob| (glob.replace('\\', "/"), true)))
+                .collect(),
+            ..Default::default()
+        };
+        filter.overrides = filter.walk_overrides(Path::new(""))?;
         Ok(filter)
     }
 
-    fn push_all(&mut self, globs: &[String], case_insensitive: bool) -> Result<()> {
-        for g in globs {
-            if let Some(neg) = g.strip_prefix('!') {
-                self.excludes.push(compile_glob(neg, case_insensitive)?);
-            } else {
-                self.includes.push(compile_glob(g, case_insensitive)?);
-            }
+    pub fn walk_overrides(&self, root: &Path) -> Result<Override> {
+        let mut builder = OverrideBuilder::new(root);
+        for (glob, case_insensitive) in &self.globs {
+            builder.case_insensitive(*case_insensitive)?.add(glob)?;
         }
-        Ok(())
+        Ok(builder.build()?)
+    }
+
+    /// Positive overrides may reinclude ignored files absent from the index.
+    pub fn has_includes(&self) -> bool {
+        self.overrides.num_whitelists() > 0
     }
 
     /// Returns true if the glob list is empty (no filtering needed).
     pub fn is_empty(&self) -> bool {
-        self.includes.is_empty() && self.excludes.is_empty()
+        self.overrides.is_empty()
     }
 
     /// Check if a path passes this glob filter.
@@ -62,34 +68,14 @@ impl GlobFilter {
         } else {
             path
         };
-        for m in &self.excludes {
-            if m.is_match(path) {
+        // A directory exclusion prunes its whole subtree in a filesystem walk.
+        for (end, _) in path.match_indices('/') {
+            if self.overrides.matched(&path[..end], true).is_ignore() {
                 return false;
             }
         }
-        if self.includes.is_empty() {
-            return true;
-        }
-        self.includes.iter().any(|m| m.is_match(path))
+        !self.overrides.matched(path, false).is_ignore()
     }
-}
-
-/// Compile a single glob pattern into a `GlobMatcher`.
-fn compile_glob(pattern: &str, case_insensitive: bool) -> Result<GlobMatcher> {
-    // Normalize backslashes so Windows-style globs work uniformly
-    let pattern = pattern.replace('\\', "/");
-    // Patterns without a path separator should match at any depth,
-    // e.g. "*.rs" behaves like "**/*.rs" (consistent with ripgrep --glob)
-    let pattern = if !pattern.contains('/') {
-        format!("**/{pattern}")
-    } else {
-        pattern
-    };
-    let glob = GlobBuilder::new(&pattern)
-        .case_insensitive(case_insensitive)
-        .literal_separator(true)
-        .build()?;
-    Ok(glob.compile_matcher())
 }
 
 #[cfg(test)]

--- a/tgrep-cli/src/main.rs
+++ b/tgrep-cli/src/main.rs
@@ -982,14 +982,11 @@ impl Cli {
     /// `tgrep search` over the same tree. That is indistinguishable from a
     /// corpus with no matches, so the only safe answer is to refuse.
     ///
-    /// `--hidden` is honoured by `index` but not by `serve`, hence the
-    /// parameter. `--threads` is excluded deliberately: it is documented as
+    /// Both builders include hidden files by default, so `--hidden` is accepted
+    /// as a redundant flag. `--threads` is excluded deliberately: it is documented as
     /// accepted-for-compatibility and ignored everywhere, not just here.
-    fn unsupported_discovery_flags(&self, hidden_supported: bool) -> Vec<&'static str> {
+    fn unsupported_discovery_flags(&self) -> Vec<&'static str> {
         let mut out = Vec::new();
-        if self.hidden && !hidden_supported {
-            out.push("--hidden");
-        }
         if self.follow {
             out.push("--follow");
         }
@@ -1029,8 +1026,8 @@ impl Cli {
 
 /// Exit with a clear error rather than building an index under settings the
 /// caller did not ask for. See [`Cli::unsupported_discovery_flags`].
-fn reject_unsupported_discovery_flags(cli: &Cli, subcommand: &str, hidden_supported: bool) {
-    let unsupported = cli.unsupported_discovery_flags(hidden_supported);
+fn reject_unsupported_discovery_flags(cli: &Cli, subcommand: &str) {
+    let unsupported = cli.unsupported_discovery_flags();
     if unsupported.is_empty() {
         return;
     }
@@ -1108,8 +1105,8 @@ fn run_cli() {
     // Refuse discovery flags the index-building subcommands can't honour. Done
     // before the match so the arms keep consuming `cli.command` by value.
     match &cli.command {
-        Some(Command::Index { .. }) => reject_unsupported_discovery_flags(&cli, "index", true),
-        Some(Command::Serve { .. }) => reject_unsupported_discovery_flags(&cli, "serve", false),
+        Some(Command::Index { .. }) => reject_unsupported_discovery_flags(&cli, "index"),
+        Some(Command::Serve { .. }) => reject_unsupported_discovery_flags(&cli, "serve"),
         _ => {}
     }
 
@@ -1124,7 +1121,7 @@ fn run_cli() {
             index::run(index::RunOptions {
                 root: &path,
                 index_path: cli.index_path.as_deref(),
-                include_hidden: cli.hidden,
+                include_hidden: true,
                 no_ignore,
                 no_require_git: cli.no_require_git,
                 exclude_dirs: &exclude,

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -453,14 +453,6 @@ pub fn list_files(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) 
     let glob_filter = opts.glob_filter()?;
     let type_filter = opts.type_filter()?;
 
-    // `--files` lists what would be searched without reading anything, so it
-    // must not drop files on an extension guess the way a search does.
-    let walk_opts = walker::WalkOptions {
-        search_binary: true,
-        overrides: Some(glob_filter.walk_overrides(&root)?),
-        ..opts.walk_options()
-    };
-
     if root.is_file() {
         let rel_path = explicit_file_display_path(&root);
 
@@ -531,6 +523,14 @@ pub fn list_files(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) 
         }
     }
 
+    // `--files` lists what would be searched without reading anything, so it
+    // must not drop files on an extension guess the way a search does.
+    let walk_opts = walker::WalkOptions {
+        search_binary: true,
+        exclude_paths: index_storage_exclusions(&index_dir)?,
+        overrides: Some(glob_filter.walk_overrides(&root)?),
+        ..opts.walk_options()
+    };
     let walk = walker::walk_dir(&root, &walk_opts);
     let paths = walk.files.iter().map(|path| {
         path.strip_prefix(&root)
@@ -592,14 +592,16 @@ fn load_indexed_file_paths(
     };
     let mut extra_paths = filename_index.paths;
     let meta = IndexMeta::load(index_dir)?;
-    if !meta.complete || !meta.hidden_complete || !visibility.hidden_complete {
+    if !meta.complete
+        || !meta.hidden_complete
+        || meta.version != tgrep_core::meta::INDEX_FORMAT_VERSION
+        || !visibility.hidden_complete
+    {
         return Ok(None);
     }
 
     let reader = IndexReader::open(index_dir)?;
-    if meta.file_table_id != Some(reader.file_table_id())
-        || visibility.file_table_id != reader.file_table_id()
-    {
+    if !visibility.covers_index(&meta, reader.file_table_id()) {
         return Ok(None);
     }
     let mut paths = Vec::with_capacity(reader.num_files() + extra_paths.len());
@@ -774,11 +776,11 @@ pub fn run(
 
     // No server — use on-disk index directly (or brute force)
     if opts.no_index || bypass_index {
-        return brute_force_search(&root, opts, ci, writer);
+        return brute_force_search(&root, &index_dir, opts, ci, writer);
     }
     if !index_dir.join("lookup.bin").exists() {
         warn_missing_index(&index_dir, index_path.is_some(), opts.quiet);
-        return brute_force_search(&root, opts, ci, writer);
+        return brute_force_search(&root, &index_dir, opts, ci, writer);
     }
 
     search_local_index(&root, &index_dir, opts, ci, writer)
@@ -1213,7 +1215,7 @@ fn search_local_index(
                     "warning: index coverage metadata unavailable ({error}) - scanning filesystem"
                 );
             }
-            return brute_force_search(root, opts, ci, writer);
+            return brute_force_search(root, index_dir, opts, ci, writer);
         }
     };
     if !meta.complete
@@ -1225,7 +1227,7 @@ fn search_local_index(
                 "warning: index lacks complete hidden-file coverage - scanning filesystem; rebuild with `tgrep index` or upgrade with `tgrep serve`"
             );
         }
-        return brute_force_search(root, opts, ci, writer);
+        return brute_force_search(root, index_dir, opts, ci, writer);
     }
     let reader = IndexReader::open(index_dir)?;
     let filename_visibility = match tgrep_core::path_index::read_filename_index(index_dir) {
@@ -1236,18 +1238,15 @@ fn search_local_index(
         if !opts.quiet && !opts.no_messages {
             eprintln!("warning: atomic index visibility unavailable - scanning filesystem");
         }
-        return brute_force_search(root, opts, ci, writer);
+        return brute_force_search(root, index_dir, opts, ci, writer);
     };
-    if meta.file_table_id != Some(reader.file_table_id())
-        || filename_visibility.file_table_id != reader.file_table_id()
-        || !filename_visibility.hidden_complete
-    {
+    if !filename_visibility.covers_index(&meta, reader.file_table_id()) {
         if !opts.quiet && !opts.no_messages {
             eprintln!(
                 "warning: index visibility, coverage, and path table differ - scanning filesystem"
             );
         }
-        return brute_force_search(root, opts, ci, writer);
+        return brute_force_search(root, index_dir, opts, ci, writer);
     }
     let visibility = filename_visibility.paths;
 
@@ -1257,7 +1256,7 @@ fn search_local_index(
     // silently reports nothing.
     let Some((index_root, scope)) = resolve_scope(index_dir, root) else {
         // The index covers an unrelated tree, so it cannot answer this search.
-        return brute_force_search(root, opts, ci, writer);
+        return brute_force_search(root, index_dir, opts, ci, writer);
     };
 
     let glob_filter = opts.glob_filter()?;
@@ -1447,8 +1446,17 @@ fn within_max_depth(rel: &str, opts: &SearchOptions) -> bool {
     }
 }
 
+fn index_storage_exclusions(index_dir: &Path) -> Result<Vec<PathBuf>> {
+    match std::fs::canonicalize(index_dir) {
+        Ok(path) => Ok(vec![path]),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(Vec::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
 fn brute_force_search(
     root: &Path,
+    index_dir: &Path,
     opts: &SearchOptions,
     ci: bool,
     writer: &mut OutputWriter,
@@ -1490,6 +1498,7 @@ fn brute_force_search(
     let mut walk = walker::walk_dir(
         root,
         &walker::WalkOptions {
+            exclude_paths: index_storage_exclusions(index_dir)?,
             overrides: Some(glob_filter.walk_overrides(root)?),
             ..opts.walk_options()
         },

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -583,15 +583,16 @@ fn load_indexed_file_paths(
     if !index_dir.join("lookup.bin").exists() {
         return Ok(None);
     }
-    let Some(filename_index) = tgrep_core::path_index::read_filename_index(index_dir)? else {
-        return Ok(None);
+    let filename_index = match tgrep_core::path_index::read_filename_index(index_dir) {
+        Ok(Some(index)) => index,
+        Ok(None) | Err(_) => return Ok(None),
     };
     let Some(visibility) = filename_index.visibility else {
         return Ok(None);
     };
     let mut extra_paths = filename_index.paths;
     let meta = IndexMeta::load(index_dir)?;
-    if !meta.complete || !meta.hidden_complete {
+    if !meta.complete || !meta.hidden_complete || !visibility.hidden_complete {
         return Ok(None);
     }
 
@@ -1227,12 +1228,28 @@ fn search_local_index(
         return brute_force_search(root, opts, ci, writer);
     }
     let reader = IndexReader::open(index_dir)?;
-    if meta.file_table_id != Some(reader.file_table_id()) {
+    let filename_visibility = match tgrep_core::path_index::read_filename_index(index_dir) {
+        Ok(Some(index)) => index.visibility,
+        Ok(None) | Err(_) => None,
+    };
+    let Some(filename_visibility) = filename_visibility else {
         if !opts.quiet && !opts.no_messages {
-            eprintln!("warning: index visibility and path table differ - scanning filesystem");
+            eprintln!("warning: atomic index visibility unavailable - scanning filesystem");
+        }
+        return brute_force_search(root, opts, ci, writer);
+    };
+    if meta.file_table_id != Some(reader.file_table_id())
+        || filename_visibility.file_table_id != reader.file_table_id()
+        || !filename_visibility.hidden_complete
+    {
+        if !opts.quiet && !opts.no_messages {
+            eprintln!(
+                "warning: index visibility, coverage, and path table differ - scanning filesystem"
+            );
         }
         return brute_force_search(root, opts, ci, writer);
     }
+    let visibility = filename_visibility.paths;
 
     // Index paths are relative to the root the index was built for, which is
     // not necessarily the directory being searched. Without translating between
@@ -1285,7 +1302,7 @@ fn search_local_index(
         .iter()
         .filter_map(|&fid| {
             let indexed = reader.file_path(fid)?;
-            meta.visibility
+            visibility
                 .is_visible(indexed, scope.prefix(), opts.hidden)
                 .then_some(())?;
             let rel = scope.relativize(indexed, root)?;

--- a/tgrep-cli/src/search.rs
+++ b/tgrep-cli/src/search.rs
@@ -444,6 +444,7 @@ pub fn new_writer(opts: &SearchOptions) -> OutputWriter {
 
 /// List files that would be searched (`--files` mode).
 pub fn list_files(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) -> Result<()> {
+    let start = Instant::now();
     let root = match std::fs::canonicalize(root) {
         Ok(root) => root,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -456,6 +457,7 @@ pub fn list_files(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) 
     // must not drop files on an extension guess the way a search does.
     let walk_opts = walker::WalkOptions {
         search_binary: true,
+        overrides: Some(glob_filter.walk_overrides(&root)?),
         ..opts.walk_options()
     };
 
@@ -474,34 +476,50 @@ pub fn list_files(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) 
         .map(Path::to_path_buf)
         .unwrap_or_else(|| builder::default_index_dir(&root));
 
-    if filename_index_compatible(opts) {
+    if filename_index_compatible(opts) && !glob_filter.has_includes() {
         if let Ok(info) = ServerInfo::load(&index_dir)
             && let Some((index_root, scope)) = resolve_scope(&index_dir, &root)
-            && let Ok(paths) = list_files_via_server(&info)
+            && let Ok(paths) = list_files_via_server(&info, &scope, opts)
         {
-            return write_indexed_file_paths(
+            write_indexed_file_paths(
                 &index_root,
                 &root,
                 &scope,
                 paths,
+                None,
                 &glob_filter,
                 &type_filter,
                 opts,
-            );
+            )?;
+            if opts.stats {
+                eprintln!(
+                    "Filename search completed in {:.1}ms (via server)",
+                    start.elapsed().as_secs_f64() * 1000.0
+                );
+            }
+            return Ok(());
         }
 
         match load_indexed_file_paths(&index_dir) {
-            Ok(Some(paths)) => {
+            Ok(Some((paths, visibility))) => {
                 if let Some((index_root, scope)) = resolve_scope(&index_dir, &root) {
-                    return write_indexed_file_paths(
+                    write_indexed_file_paths(
                         &index_root,
                         &root,
                         &scope,
                         paths,
+                        Some(&visibility),
                         &glob_filter,
                         &type_filter,
                         opts,
-                    );
+                    )?;
+                    if opts.stats {
+                        eprintln!(
+                            "Filename search completed in {:.1}ms (via local index)",
+                            start.elapsed().as_secs_f64() * 1000.0
+                        );
+                    }
+                    return Ok(());
                 }
             }
             Ok(None) => {}
@@ -525,17 +543,24 @@ pub fn list_files(root: &Path, index_path: Option<&Path>, opts: &SearchOptions) 
         &root,
         &IndexScope::Whole,
         paths,
+        None,
         &glob_filter,
         &type_filter,
         opts,
-    )
+    )?;
+    if opts.stats {
+        eprintln!(
+            "Filename search completed in {:.1}ms (via filesystem walk)",
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+    Ok(())
 }
 
 /// Whether an existing index was built under traversal rules that can answer
 /// this invocation without silently omitting files.
 fn filename_index_compatible(opts: &SearchOptions) -> bool {
     !opts.no_index
-        && !opts.hidden
         && !opts.no_ignore
         && !opts.no_ignore_dot
         && !opts.no_ignore_exclude
@@ -552,30 +577,44 @@ fn filename_index_compatible(opts: &SearchOptions) -> bool {
 
 /// Load a complete local filename index, including the paths deliberately
 /// omitted from the content index.
-fn load_indexed_file_paths(index_dir: &Path) -> Result<Option<Vec<String>>> {
+fn load_indexed_file_paths(
+    index_dir: &Path,
+) -> Result<Option<(Vec<String>, tgrep_core::visibility::PathVisibility)>> {
     if !index_dir.join("lookup.bin").exists() {
         return Ok(None);
     }
-    let Some(mut extra_paths) = tgrep_core::path_index::read_extra_paths(index_dir)? else {
+    let Some(filename_index) = tgrep_core::path_index::read_filename_index(index_dir)? else {
         return Ok(None);
     };
-    if !IndexMeta::load(index_dir)?.complete {
+    let Some(visibility) = filename_index.visibility else {
+        return Ok(None);
+    };
+    let mut extra_paths = filename_index.paths;
+    let meta = IndexMeta::load(index_dir)?;
+    if !meta.complete || !meta.hidden_complete {
         return Ok(None);
     }
 
     let reader = IndexReader::open(index_dir)?;
+    if meta.file_table_id != Some(reader.file_table_id())
+        || visibility.file_table_id != reader.file_table_id()
+    {
+        return Ok(None);
+    }
     let mut paths = Vec::with_capacity(reader.num_files() + extra_paths.len());
     paths.extend(reader.all_paths().iter().cloned());
     paths.append(&mut extra_paths);
-    Ok(Some(paths))
+    Ok(Some((paths, visibility.paths)))
 }
 
 /// Apply search-root scoping and CLI filters to index-root-relative paths.
+#[allow(clippy::too_many_arguments)]
 fn write_indexed_file_paths(
     index_root: &Path,
     search_root: &Path,
     scope: &IndexScope,
     paths: impl IntoIterator<Item = String>,
+    visibility: Option<&tgrep_core::visibility::PathVisibility>,
     glob_filter: &crate::glob_filter::GlobFilter,
     type_filter: &filetypes::TypeFilter,
     opts: &SearchOptions,
@@ -584,6 +623,10 @@ fn write_indexed_file_paths(
     let mut paths: Vec<String> = paths
         .into_iter()
         .filter(|path| seen.insert(path.clone()))
+        .filter(|path| {
+            visibility
+                .is_none_or(|visibility| visibility.is_visible(path, scope.prefix(), opts.hidden))
+        })
         .filter_map(|path| scope.relativize(&path, search_root))
         .filter(|path| within_max_depth(path, opts))
         .filter(|path| passes_filters(path, glob_filter, type_filter))
@@ -601,7 +644,11 @@ fn write_indexed_file_paths(
     Ok(())
 }
 
-fn list_files_via_server(info: &ServerInfo) -> Result<Vec<String>> {
+fn list_files_via_server(
+    info: &ServerInfo,
+    scope: &IndexScope,
+    opts: &SearchOptions,
+) -> Result<Vec<String>> {
     let mut stream = TcpStream::connect(format!("127.0.0.1:{}", info.port))?;
     stream.set_read_timeout(Some(std::time::Duration::from_secs(300)))?;
     writeln!(
@@ -610,6 +657,7 @@ fn list_files_via_server(info: &ServerInfo) -> Result<Vec<String>> {
         serde_json::json!({
             "jsonrpc": "2.0",
             "method": "files",
+            "params": { "hidden": opts.hidden, "scope": scope.prefix() },
             "id": 1,
         })
     )?;
@@ -627,9 +675,12 @@ fn list_files_via_server(info: &ServerInfo) -> Result<Vec<String>> {
         anyhow::bail!("server error: {message}");
     }
 
-    response
+    let result = response
         .get("result")
-        .and_then(|result| result.get("files"))
+        .ok_or_else(|| anyhow::anyhow!("server response did not contain a result"))?;
+    require_server_coverage(result)?;
+    result
+        .get("files")
         .and_then(|files| files.as_array())
         .ok_or_else(|| anyhow::anyhow!("server response did not contain files"))?
         .iter()
@@ -639,6 +690,17 @@ fn list_files_via_server(info: &ServerInfo) -> Result<Vec<String>> {
                 .ok_or_else(|| anyhow::anyhow!("server returned a non-string file path"))
         })
         .collect()
+}
+
+fn require_server_coverage(result: &serde_json::Value) -> Result<()> {
+    if result
+        .get("hidden_complete")
+        .and_then(|value| value.as_bool())
+        != Some(true)
+    {
+        anyhow::bail!("server does not support complete hidden-file coverage");
+    }
+    Ok(())
 }
 
 /// Run one search path's worth of work, writing through the caller's `writer`.
@@ -670,9 +732,9 @@ pub fn run(
     // nothing but NUL-interleaved bytes) is absent from the index entirely, so
     // even a full-scan plan cannot reach it. The only way `-E` means the same
     // thing with and without an index is to walk the tree. `-a`/`--binary` are
-    // the same story, as is anything that widens the walk: the index was built
-    // skipping hidden and ignored files, so `--hidden`/`--no-ignore` can only
-    // find them by walking.
+    // the same story, as is anything that widens the walk into ignored files.
+    // Positive globs can explicitly reinclude those files, unlike --hidden,
+    // which only selects visibility within the normally eligible corpus.
     //
     // A single named file is bypassed too. The index deliberately omits binary
     // and ignored files, but naming one explicitly is exactly how ripgrep asks
@@ -681,7 +743,7 @@ pub fn run(
         || opts.encoding.may_differ_from_index()
         || opts.text
         || opts.binary
-        || opts.hidden
+        || opts.glob_filter()?.has_includes()
         || opts.no_ignore
         || opts.no_ignore_dot
         || opts.no_ignore_exclude
@@ -706,7 +768,7 @@ pub fn run(
         {
             return Ok(had_matches);
         }
-        eprintln!("Server unreachable, falling back to local index");
+        eprintln!("Server unavailable or index coverage not ready, falling back to local index");
     }
 
     // No server — use on-disk index directly (or brute force)
@@ -802,7 +864,7 @@ fn search_via_server(
     let detail = opts.wants_match_detail();
     let positions = opts.wants_position_detail();
 
-    let request = serde_json::json!({
+    let mut request = serde_json::json!({
         "jsonrpc": "2.0",
         "method": "search",
         "params": {
@@ -849,6 +911,9 @@ fn search_via_server(
         },
         "id": 1,
     });
+    request["params"]["hidden"] = serde_json::json!(opts.hidden);
+    request["params"]["scope"] = serde_json::json!(scope.prefix());
+    request["params"]["max_depth"] = serde_json::json!(opts.max_depth);
     writeln!(stream, "{}", request)?;
     stream.flush()?;
 
@@ -869,6 +934,9 @@ fn search_via_server(
     let result = response
         .get("result")
         .ok_or_else(|| anyhow::anyhow!("no result in response"))?;
+    // Older servers ignore unknown request fields. Validate before writing any
+    // rows, so an old/partial server can never silently answer --hidden.
+    require_server_coverage(result)?;
 
     let empty_vec = Vec::new();
     let matches = result
@@ -876,9 +944,9 @@ fn search_via_server(
         .and_then(|m| m.as_array())
         .unwrap_or(&empty_vec);
 
-    // The server always searches its whole indexed tree and reports paths
-    // relative to the index root, so a subdirectory argument and `--max-depth`
-    // have to be applied to the reply.
+    // The server scopes candidates before searching but still reports paths
+    // relative to the index root. Translate those paths for output and apply
+    // the same scope defensively to all reply rows.
     //
     // ripgrep only surfaces a binary file when the user named it explicitly, so
     // `binary` rows for anything reached by traversal are dropped here — along
@@ -1094,7 +1162,7 @@ fn search_via_server(
         // summary after the matches, as ripgrep does.
         flush_before_stats(writer)?;
         // Apply the same scope to per-file totals as to output rows. The
-        // server's `num_matches` includes context and out-of-scope rows, and
+        // server's `num_matches` includes context rows, and
         // rendered spans can split or merge the original matches.
         let (num, lines) = if let Some(stats) = result.get("file_stats") {
             let stats: Vec<FileMatchStats> = serde_json::from_value(stats.clone())?;
@@ -1136,7 +1204,35 @@ fn search_local_index(
     writer: &mut OutputWriter,
 ) -> Result<bool> {
     let start = Instant::now();
+    let meta = match IndexMeta::load(index_dir) {
+        Ok(meta) => meta,
+        Err(error) => {
+            if !opts.quiet && !opts.no_messages {
+                eprintln!(
+                    "warning: index coverage metadata unavailable ({error}) - scanning filesystem"
+                );
+            }
+            return brute_force_search(root, opts, ci, writer);
+        }
+    };
+    if !meta.complete
+        || !meta.hidden_complete
+        || meta.version != tgrep_core::meta::INDEX_FORMAT_VERSION
+    {
+        if !opts.quiet && !opts.no_messages {
+            eprintln!(
+                "warning: index lacks complete hidden-file coverage - scanning filesystem; rebuild with `tgrep index` or upgrade with `tgrep serve`"
+            );
+        }
+        return brute_force_search(root, opts, ci, writer);
+    }
     let reader = IndexReader::open(index_dir)?;
+    if meta.file_table_id != Some(reader.file_table_id()) {
+        if !opts.quiet && !opts.no_messages {
+            eprintln!("warning: index visibility and path table differ - scanning filesystem");
+        }
+        return brute_force_search(root, opts, ci, writer);
+    }
 
     // Index paths are relative to the root the index was built for, which is
     // not necessarily the directory being searched. Without translating between
@@ -1189,6 +1285,9 @@ fn search_local_index(
         .iter()
         .filter_map(|&fid| {
             let indexed = reader.file_path(fid)?;
+            meta.visibility
+                .is_visible(indexed, scope.prefix(), opts.hidden)
+                .then_some(())?;
             let rel = scope.relativize(indexed, root)?;
             within_max_depth(&rel, opts).then_some(())?;
             Some((fid, rel))
@@ -1261,6 +1360,13 @@ enum IndexScope {
 }
 
 impl IndexScope {
+    fn prefix(&self) -> &str {
+        match self {
+            Self::Subtree(prefix) => prefix,
+            Self::Whole | Self::File(_) => "",
+        }
+    }
+
     /// `None` when `search_root` lies outside the indexed tree, which means the
     /// index cannot answer the search at all.
     fn resolve(index_root: &Path, search_root: &Path) -> Option<Self> {
@@ -1364,7 +1470,13 @@ fn brute_force_search(
         return Ok(had_matches);
     }
 
-    let mut walk = walker::walk_dir(root, &opts.walk_options());
+    let mut walk = walker::walk_dir(
+        root,
+        &walker::WalkOptions {
+            overrides: Some(glob_filter.walk_overrides(root)?),
+            ..opts.walk_options()
+        },
+    );
     if let Some(sort) = opts.sort {
         sort.apply(&mut walk.files);
     }
@@ -2142,7 +2254,7 @@ mod tests {
     // --- `--stats` counting -------------------------------------------------
     //
     // These pin the reply-row semantics that `--stats` reports over the server.
-    // The server counts every row it built across the whole indexed tree, so
+    // The server counts every row it built, so
     // reporting its `num_matches` made `--stats` disagree with both the printed
     // output and ripgrep. Verified against ripgrep 15.2.0.
 
@@ -2153,6 +2265,18 @@ mod tests {
             "line": line,
             "spans": (0..spans).map(|i| serde_json::json!([i, i + 1])).collect::<Vec<_>>(),
         })
+    }
+
+    #[test]
+    fn server_response_requires_explicit_complete_hidden_coverage() {
+        for response in [
+            serde_json::json!({}),
+            serde_json::json!({"hidden_complete": false}),
+            serde_json::json!({"hidden_complete": null}),
+        ] {
+            assert!(require_server_coverage(&response).is_err());
+        }
+        assert!(require_server_coverage(&serde_json::json!({"hidden_complete": true})).is_ok());
     }
 
     #[test]

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -1060,12 +1060,12 @@ impl StartupDiscovery {
         let Some(meta) = meta else {
             return Self::default();
         };
+        let metadata_hidden_complete = meta.complete
+            && meta.hidden_complete
+            && meta.version == tgrep_core::meta::INDEX_FORMAT_VERSION
+            && meta.file_table_id == Some(file_table_id);
         let mut discovery = Self {
             visibility: meta.visibility,
-            hidden_complete: meta.complete
-                && meta.hidden_complete
-                && meta.version == tgrep_core::meta::INDEX_FORMAT_VERSION
-                && meta.file_table_id == Some(file_table_id),
             ..Default::default()
         };
         if meta.complete {
@@ -1076,7 +1076,11 @@ impl StartupDiscovery {
                     {
                         // The sidecar can be newer than meta.json after an
                         // interrupted filename-only publication. Keep its
-                        // membership and visibility together on restart too.
+                        // membership, visibility, and coverage together on
+                        // restart so stale metadata cannot advertise a partial
+                        // filename snapshot as complete.
+                        discovery.hidden_complete =
+                            metadata_hidden_complete && visibility.hidden_complete;
                         discovery.visibility = visibility.paths;
                         discovery.filename_extra_paths = index.paths.into_iter().collect();
                         discovery.filename_index_ready = true;
@@ -5790,6 +5794,7 @@ fn stage_filename_extra_paths(
     staging_dir: &Path,
     visibility: &tgrep_core::visibility::PathVisibility,
     file_table_id: tgrep_core::meta::FileTableId,
+    hidden_complete: bool,
 ) -> Result<()> {
     let mut paths: Vec<String> = state
         .filename_extra_paths
@@ -5804,6 +5809,7 @@ fn stage_filename_extra_paths(
         &paths,
         visibility,
         file_table_id,
+        hidden_complete,
     )?;
     Ok(())
 }
@@ -5835,7 +5841,13 @@ fn persist_filename_discovery(
         } else {
             meta.hidden_complete = meta.complete && state.hidden_complete.load(Ordering::SeqCst);
         }
-        stage_filename_extra_paths(state, &staging_dir, &meta.visibility, file_table_id)?;
+        stage_filename_extra_paths(
+            state,
+            &staging_dir,
+            &meta.visibility,
+            file_table_id,
+            meta.hidden_complete,
+        )?;
         meta.save(&staging_dir)?;
         Ok(meta)
     })();
@@ -7790,10 +7802,17 @@ fn publish_staged_index(
             &paths,
             &meta.visibility,
             file_table_id,
+            meta.hidden_complete,
         )
         .map_err(Into::into)
     } else if state.filename_index_ready.load(Ordering::SeqCst) {
-        stage_filename_extra_paths(state, staging_dir, &meta.visibility, file_table_id)
+        stage_filename_extra_paths(
+            state,
+            staging_dir,
+            &meta.visibility,
+            file_table_id,
+            meta.hidden_complete,
+        )
     } else {
         Ok(())
     };

--- a/tgrep-cli/src/serve.rs
+++ b/tgrep-cli/src/serve.rs
@@ -34,6 +34,10 @@ mod poll_tests;
 #[path = "serve/recovery_tests.rs"]
 mod recovery_tests;
 
+#[cfg(test)]
+#[path = "serve/hidden_tests.rs"]
+mod hidden_tests;
+
 const CACHE_CAPACITY: usize = 50_000;
 /// Total decoded bytes the content cache may hold. The entry-count limit above
 /// says nothing about memory; without this a handful of large files can pin
@@ -88,8 +92,8 @@ const WATCHER_BURST_MAX: Duration = Duration::from_millis(100);
 const WATCHER_BURST_EVENT_CAP: usize = 1024;
 const WATCHER_BURST_PATH_CAP: usize = 4096;
 
-/// Git's index is hidden from the repository watcher. Poll its metadata only
-/// when the case-insensitive tracked-file exemption is active.
+/// Git's index may be excluded or outside the watched worktree. Poll its
+/// metadata only when the case-insensitive tracked-file exemption is active.
 const TRACKED_INDEX_POLL: Duration = Duration::from_secs(2);
 
 /// How long a file the watcher never heard about can stay wrong in the index.
@@ -232,7 +236,7 @@ fn try_acquire_server_lock(index_dir: &Path) -> Result<File> {
 ///   2. `gitignore`     — guards the watcher matcher; drop before file/index work
 ///   3. `publish_lock`  — serializes on-disk index publication
 ///   4. `index`         — guards the in-memory HybridIndex (read-heavy)
-///   5. `filename_extra_paths` — guards paths omitted from the content index
+///   5. `visibility`, then `filename_extra_paths` — guards path discovery metadata
 ///   6. `cache`         — guards the file content LRU cache
 ///   7. `file_evidence` — guards per-file stamps and content identities
 ///   8. `recent_reindexes` — guards exact duplicate evidence
@@ -447,6 +451,10 @@ impl RecentReindexCache {
 
 struct ServerState {
     index: RwLock<HybridIndex>,
+    /// Read under the index lock so visibility and content change together at
+    /// publication. Native events update it using metadata they already read.
+    visibility: RwLock<tgrep_core::visibility::PathVisibility>,
+    hidden_complete: std::sync::atomic::AtomicBool,
     /// Paths admitted by traversal but deliberately absent from the content
     /// index. Unioning these with `HybridIndex::all_paths` answers `--files`
     /// without duplicating every searchable path in memory.
@@ -454,8 +462,8 @@ struct ServerState {
     /// False for legacy/partial indexes until a complete filesystem walk has
     /// established the extra-path set.
     filename_index_ready: std::sync::atomic::AtomicBool,
-    /// The in-memory extra-path set differs from the last sidecar successfully
-    /// published to disk. Authoritative walks retry while this remains set.
+    /// Filename membership or visibility differs from its persisted snapshot.
+    /// Authoritative walks retry while this remains set.
     filename_index_dirty: std::sync::atomic::AtomicBool,
     cache: RwLock<ContentCache>,
     cache_generation: std::sync::atomic::AtomicU64,
@@ -634,7 +642,7 @@ struct ServerState {
     /// Built asynchronously after the server starts so large repos don't block
     /// `serve ready` on a full-tree `.gitignore` discovery walk. `None` while
     /// loading or if no matcher could be built; during that window the watcher
-    /// falls back to hidden / exclude filtering.
+    /// falls back to storage / exclude filtering.
     gitignore: RwLock<Option<tgrep_core::gitignore::IgnoreMatcher>>,
     /// Maximum RSS budget (bytes). When the process exceeds this during the
     /// initial build, the indexer flushes the overlay to disk and continues so
@@ -677,6 +685,8 @@ enum StaleRefreshPhase {
     BeforeRefreshLock,
     BeforeWalk,
     AfterBuildBeforeStampPublish,
+    BeforeCoverageReconcile,
+    AfterFilenameSidecarPublish,
     AfterConcreteRead,
     BeforeConcreteCommit,
     AfterMatcherPublish,
@@ -809,6 +819,11 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     // Ensure only one server runs per index directory.
     // The lock file is held for the lifetime of the server and released on exit.
     let _lock_file = try_acquire_server_lock(&index_dir)?;
+    let index_dir = std::fs::canonicalize(&index_dir)?;
+    anyhow::ensure!(
+        !root.starts_with(&index_dir),
+        "index directory must not contain the source root"
+    );
     index_cleanup::cleanup_retired(&index_dir);
 
     let has_index = index_dir.join("lookup.bin").exists();
@@ -835,21 +850,10 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     let existing_files = hybrid.num_files();
 
     // Check meta.json complete flag to decide whether to rebuild
-    let index_complete = tgrep_core::meta::IndexMeta::load(&index_dir)
-        .map(|m| m.complete)
-        .unwrap_or(false);
-    let (filename_extra_paths, filename_index_ready) = if index_complete {
-        match tgrep_core::path_index::read_extra_paths(&index_dir) {
-            Ok(Some(paths)) => (paths.into_iter().collect(), true),
-            Ok(None) => (std::collections::HashSet::new(), false),
-            Err(error) => {
-                eprintln!("[trace] filename index failed to load ({error}); rebuilding");
-                (std::collections::HashSet::new(), false)
-            }
-        }
-    } else {
-        (std::collections::HashSet::new(), false)
-    };
+    let index_meta = tgrep_core::meta::IndexMeta::load(&index_dir).ok();
+    let index_complete = index_meta.as_ref().is_some_and(|meta| meta.complete);
+    let discovery =
+        StartupDiscovery::load(&index_dir, index_meta, hybrid.reader_arc().file_table_id());
 
     let needs_build = needs_build || !index_complete;
 
@@ -867,8 +871,10 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
 
     let state = Arc::new(ServerState {
         index: RwLock::new(hybrid),
-        filename_extra_paths: RwLock::new(filename_extra_paths),
-        filename_index_ready: std::sync::atomic::AtomicBool::new(filename_index_ready),
+        visibility: RwLock::new(discovery.visibility),
+        hidden_complete: std::sync::atomic::AtomicBool::new(discovery.hidden_complete),
+        filename_extra_paths: RwLock::new(discovery.filename_extra_paths),
+        filename_index_ready: std::sync::atomic::AtomicBool::new(discovery.filename_index_ready),
         filename_index_dirty: std::sync::atomic::AtomicBool::new(false),
         cache: RwLock::new(ContentCache::new(
             CACHE_CAPACITY,
@@ -1035,6 +1041,59 @@ pub fn run(root: &Path, index_path: Option<&Path>, options: ServeOptions<'_>) ->
     }
 
     Ok(())
+}
+
+#[derive(Default)]
+struct StartupDiscovery {
+    visibility: tgrep_core::visibility::PathVisibility,
+    hidden_complete: bool,
+    filename_extra_paths: std::collections::HashSet<String>,
+    filename_index_ready: bool,
+}
+
+impl StartupDiscovery {
+    fn load(
+        index_dir: &Path,
+        meta: Option<tgrep_core::meta::IndexMeta>,
+        file_table_id: tgrep_core::meta::FileTableId,
+    ) -> Self {
+        let Some(meta) = meta else {
+            return Self::default();
+        };
+        let mut discovery = Self {
+            visibility: meta.visibility,
+            hidden_complete: meta.complete
+                && meta.hidden_complete
+                && meta.version == tgrep_core::meta::INDEX_FORMAT_VERSION
+                && meta.file_table_id == Some(file_table_id),
+            ..Default::default()
+        };
+        if meta.complete {
+            match tgrep_core::path_index::read_filename_index(index_dir) {
+                Ok(Some(index)) => {
+                    if let Some(visibility) = index.visibility
+                        && visibility.file_table_id == file_table_id
+                    {
+                        // The sidecar can be newer than meta.json after an
+                        // interrupted filename-only publication. Keep its
+                        // membership and visibility together on restart too.
+                        discovery.visibility = visibility.paths;
+                        discovery.filename_extra_paths = index.paths.into_iter().collect();
+                        discovery.filename_index_ready = true;
+                    } else {
+                        eprintln!(
+                            "[trace] filename visibility unavailable or mismatched; rebuilding"
+                        );
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    eprintln!("[trace] filename index failed to load ({error}); rebuilding");
+                }
+            }
+        }
+        discovery
+    }
 }
 
 /// Build the ignore matcher used by the watcher from files discovered by a walk
@@ -1346,30 +1405,95 @@ fn process_request(request: &str, state: &Arc<ServerState>) -> String {
 
     match method {
         "search" => handle_search(id, &params, state),
-        "files" => handle_files(id, state),
+        "files" => handle_files(id, &params, state),
         "status" => handle_status(id, state),
         "reload" => handle_reload(id, state),
         _ => json_rpc_error(id, -32601, &format!("Method not found: {method}")),
     }
 }
 
-fn handle_files(id: Option<serde_json::Value>, state: &ServerState) -> String {
+fn handle_files(
+    id: Option<serde_json::Value>,
+    params: &serde_json::Value,
+    state: &ServerState,
+) -> String {
     state.note_search();
-    if state.indexing.load(Ordering::SeqCst) || !state.filename_index_ready.load(Ordering::SeqCst) {
-        return json_rpc_error(id, -32001, "filename index is not ready");
-    }
+    let scope = match SearchScope::parse(params) {
+        Ok(scope) => scope,
+        Err(error) => return json_rpc_error(id, -32602, &error),
+    };
 
     let mut files = {
         // Keep the documented index -> filename lock order.
         let index = state.index.read().unwrap();
+        if state.indexing.load(Ordering::SeqCst)
+            || !state.hidden_complete.load(Ordering::SeqCst)
+            || !state.filename_index_ready.load(Ordering::SeqCst)
+        {
+            return json_rpc_error(id, -32001, "filename index is not ready");
+        }
+        let visibility = state.visibility.read().unwrap();
         let extra = state.filename_extra_paths.read().unwrap();
         let mut files = index.all_paths();
         files.extend(extra.iter().cloned());
+        files.retain(|path| {
+            scope.relative(path).is_some()
+                && visibility.is_visible(path, &scope.prefix, scope.hidden)
+        });
         files
     };
     files.sort_unstable();
     files.dedup();
-    json_rpc_result(id, serde_json::json!({ "files": files }))
+    json_rpc_result(
+        id,
+        serde_json::json!({ "files": files, "hidden_complete": true }),
+    )
+}
+
+#[derive(Default)]
+struct SearchScope {
+    prefix: String,
+    hidden: bool,
+    max_depth: Option<usize>,
+}
+
+impl SearchScope {
+    fn parse(params: &serde_json::Value) -> std::result::Result<Self, String> {
+        let prefix = params
+            .get("scope")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if prefix.starts_with('/')
+            || prefix.contains('\\')
+            || prefix.split('/').any(|part| matches!(part, "." | ".."))
+        {
+            return Err("scope must be an index-relative directory".to_string());
+        }
+        let prefix = prefix.trim_end_matches('/');
+        Ok(Self {
+            prefix: if prefix.is_empty() {
+                String::new()
+            } else {
+                format!("{prefix}/")
+            },
+            // Absence means ordinary ripgrep visibility, including old clients.
+            hidden: params
+                .get("hidden")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false),
+            max_depth: params
+                .get("max_depth")
+                .and_then(|value| value.as_u64())
+                .map(|depth| usize::try_from(depth).unwrap_or(usize::MAX)),
+        })
+    }
+
+    fn relative<'a>(&self, indexed: &'a str) -> Option<&'a str> {
+        let relative = indexed.strip_prefix(&self.prefix)?;
+        self.max_depth
+            .is_none_or(|max| relative.matches('/').count() < max)
+            .then_some(relative)
+    }
 }
 
 /// Parsed and validated search request parameters.
@@ -1382,6 +1506,7 @@ struct SearchRequest {
     type_filter: tgrep_core::filetypes::TypeFilter,
     encoding: tgrep_core::encoding::EncodingMode,
     opts: SearchOpts,
+    scope: SearchScope,
 }
 
 /// Parse and validate all search parameters from a JSON-RPC request.
@@ -1584,6 +1709,7 @@ fn parse_search_params(params: &serde_json::Value) -> std::result::Result<Search
         glob_filter,
         type_filter,
         encoding,
+        scope: SearchScope::parse(params)?,
         opts: SearchOpts {
             files_only,
             invert_match,
@@ -1632,6 +1758,7 @@ fn handle_search(
     let opts = req.opts;
     let pattern = req.pattern;
     let case_insensitive = req.case_insensitive;
+    let scope = req.scope;
 
     // The index build already dropped everything above the server's own cap, so
     // re-checking a query cap that is no stricter can never reject a candidate
@@ -1647,6 +1774,11 @@ fn handle_search(
     let t_index = Instant::now();
     let (candidate_info, raw_candidate_count): (Vec<(String, PathBuf)>, usize) = {
         let index = state.index.read().unwrap();
+        // Check the same generation whose candidates and visibility we read.
+        if state.indexing.load(Ordering::SeqCst) || !state.hidden_complete.load(Ordering::SeqCst) {
+            return json_rpc_error(id, -32001, "hidden-inclusive index coverage is not ready");
+        }
+        let visibility = state.visibility.read().unwrap();
 
         // The reader snapshot is returned alongside the file IDs so that
         // path resolution below uses the *same* reader that produced the
@@ -1672,11 +1804,15 @@ fn handle_search(
                         return None;
                     }
                 };
-                if !type_filter.matches(&rel_path) {
+                let scoped = scope.relative(&rel_path)?;
+                if !visibility.is_visible(&rel_path, &scope.prefix, scope.hidden) {
+                    return None;
+                }
+                if !type_filter.matches(scoped) {
                     type_filtered_count += 1;
                     return None;
                 }
-                if !glob_filter.is_empty() && !glob_filter.matches(&rel_path) {
+                if !glob_filter.is_empty() && !glob_filter.matches(scoped) {
                     glob_filtered_count += 1;
                     if first_glob_rejected.is_none() {
                         first_glob_rejected = Some(rel_path);
@@ -1828,6 +1964,7 @@ fn handle_search(
         // `file_stats`, when requested, carries the original match totals.
         "num_matches": matches.len(),
         "elapsed_ms": elapsed_ms,
+        "hidden_complete": true,
     });
     if opts.stats {
         result["file_stats"] = serde_json::json!(file_stats);
@@ -2076,6 +2213,7 @@ fn handle_status(id: Option<serde_json::Value>, state: &ServerState) -> String {
         "reconcile_pending": refresh.catch_up,
         "reconcile_overdue": state.watch_enabled && (refresh.catch_up || refresh.finished.elapsed() >= if state.refresh.polling.load(Ordering::SeqCst) { state.refresh.poll_interval } else { RECONCILE_DEADLINE }),
         "indexing": indexing,
+        "hidden_complete": state.hidden_complete.load(Ordering::SeqCst) && !indexing,
         "index_progress": state.index_progress.load(std::sync::atomic::Ordering::Relaxed),
         "index_total": state.index_total.load(std::sync::atomic::Ordering::Relaxed),
     });
@@ -2115,6 +2253,7 @@ fn handle_reload(id: Option<serde_json::Value>, state: &Arc<ServerState>) -> Str
             no_require_git: state.no_require_git,
             max_file_size: state.max_file_size,
             exclude_dirs: state.exclude_dirs.clone(),
+            exclude_paths: vec![state.index_dir.clone()],
             collect_gitignore_files: !state.no_ignore,
             ..Default::default()
         },
@@ -2570,12 +2709,19 @@ fn start_file_watcher_using(
                 return;
             }
             match result {
-                Ok(event) => enqueue_watcher_event(
-                    &tx,
-                    &callback_overflow,
-                    &callback_state.watch_resubscribe,
-                    event,
-                ),
+                Ok(mut event) => {
+                    event
+                        .paths
+                        .retain(|path| !path.starts_with(&callback_state.index_dir));
+                    if !event.paths.is_empty() || event.need_rescan() {
+                        enqueue_watcher_event(
+                            &tx,
+                            &callback_overflow,
+                            &callback_state.watch_resubscribe,
+                            event,
+                        );
+                    }
+                }
                 // Some backends report native event loss as an error rather
                 // than a rescan event. Both need the same repair as a full queue.
                 //
@@ -2788,11 +2934,9 @@ fn run_stale_refresh_hook(state: &ServerState, phase: StaleRefreshPhase) {
 
 /// Decide whether the file watcher should skip a path entirely.
 ///
-/// Mirrors the file walker's hidden-path, `--exclude` directory filtering,
+/// Mirrors the file walker's `--exclude` directory filtering,
 /// and `.gitignore` rules so the watcher does not reindex files that the
 /// initial walk would never have indexed for those reasons:
-///   * any path component starting with `.` (matches `WalkBuilder::hidden(true)`),
-///     including the file name itself (e.g. `.envrc`).
 ///   * any *ancestor directory* component matching one of the configured
 ///     `--exclude` names. The walker only treats `--exclude` names as
 ///     directory subtree filters (it skips the whole subtree when the entry
@@ -2840,8 +2984,7 @@ fn should_skip_watcher_entry(
     is_dir: bool,
 ) -> bool {
     // Single streaming pass over path components — no Vec allocation
-    // on the hot watcher path. The hidden-component check applies to
-    // every segment (including the basename); the exclude_dirs check
+    // on the hot watcher path. The exclude_dirs check
     // applies only to *ancestor* directory components, so we test
     // "is there a next segment?" via Peekable to skip the basename.
     let mut segments = rel_path
@@ -2850,9 +2993,6 @@ fn should_skip_watcher_entry(
         .peekable();
 
     while let Some(seg) = segments.next() {
-        if seg.starts_with('.') {
-            return true;
-        }
         // An ancestor is always a directory; the final segment is one only
         // when the caller says so.
         let segment_is_dir = segments.peek().is_some() || is_dir;
@@ -3274,9 +3414,16 @@ fn watchable_dirs(
     start: &Path,
     exclude_dirs: &[String],
     gitignore: Option<&tgrep_core::gitignore::IgnoreMatcher>,
+    index_dir: &Path,
 ) -> WatchableDirs {
     let mut found = std::collections::HashSet::new();
     let mut completeness = TraversalCompleteness::Complete;
+    if start.starts_with(index_dir) {
+        return WatchableDirs {
+            dirs: found,
+            completeness,
+        };
+    }
     found.insert(start.to_path_buf());
 
     let mut stack = vec![start.to_path_buf()];
@@ -3300,6 +3447,9 @@ fn watchable_dirs(
                 continue;
             }
             let path = entry.path();
+            if path.starts_with(index_dir) {
+                continue;
+            }
             let Ok(rel) = path.strip_prefix(root) else {
                 completeness = TraversalCompleteness::Incomplete;
                 continue;
@@ -3394,12 +3544,21 @@ fn sync_watch_registrations(state: &ServerState, root: &Path) -> (Vec<PathBuf>, 
     let start = Instant::now();
     let mut desired = {
         let gitignore = state.gitignore.read().unwrap();
-        watchable_dirs(root, root, &state.exclude_dirs, gitignore.as_ref())
+        watchable_dirs(
+            root,
+            root,
+            &state.exclude_dirs,
+            gitignore.as_ref(),
+            &state.index_dir,
+        )
     };
     if !state.no_ignore {
         let sources = state.ignore_sources.read().unwrap();
         desired.dirs.extend(ignore_target_dirs(root, &sources));
     }
+    desired
+        .dirs
+        .retain(|path| !path.starts_with(&state.index_dir));
     // Hold the registry through enumeration and application. Startup does not
     // hold snapshot_gate, and an older complete scan must not prune watches
     // established by a newer matcher publication or subtree registration.
@@ -3566,10 +3725,9 @@ fn changed_ignore_rules_in(
 /// nothing.
 ///
 /// `since` is when the walk behind `dirs` began — the start of the window this
-/// is closing. It is only consulted for ignore-rules files, where "did this
-/// arrive after the matcher was decided" cannot be answered from the stamps:
-/// the dot-prefixed ones are hidden, so they are never indexed and never have
-/// one. The opposite case — one that was *deleted* in the window — is handled
+/// is closing. It is only consulted for ignore-rules files, where content
+/// stamps do not prove which version the published matcher used. The opposite
+/// case — one that was *deleted* in the window — is handled
 /// separately, from `state.ignore_sources`, since a deleted file leaves nothing
 /// to stat.
 ///
@@ -3650,10 +3808,16 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
     let mut unreadable_dirs: Vec<String> = Vec::new();
 
     for dir in dirs {
+        if dir.starts_with(&state.index_dir) {
+            continue;
+        }
         let Ok(rel_dir) = dir.strip_prefix(root) else {
             continue;
         };
         let rel_dir = rel_dir.to_string_lossy().replace('\\', "/");
+        if let Ok(metadata) = std::fs::metadata(dir) {
+            record_path_visibility(state, &rel_dir, &metadata);
+        }
         let Ok(entries) = std::fs::read_dir(dir) else {
             // No listing means no evidence, and the sweep below must not treat
             // silence as absence. Whether the directory is gone or merely
@@ -3674,6 +3838,9 @@ fn reindex_files_in(state: &Arc<ServerState>, root: &Path, dirs: &[PathBuf], sin
                 continue;
             };
             let path = entry.path();
+            if path.starts_with(&state.index_dir) {
+                continue;
+            }
             let Ok(rel) = path.strip_prefix(root) else {
                 continue;
             };
@@ -3933,7 +4100,7 @@ fn sweep_removed_files(
 /// window is small but it is exactly the one a checkout or a build fills, and
 /// anything lost in it stays invisible until the hourly reconcile.
 fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
-    if !native_watching(state) {
+    if !native_watching(state) || dir.starts_with(&state.index_dir) {
         return;
     }
     // `is_dir` follows symlinks; the walker does not. Refuse a symlinked
@@ -4004,6 +4171,15 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
             if !seen.insert(subdir.clone()) {
                 continue;
             }
+            if let Ok(metadata) = std::fs::metadata(&subdir)
+                && let Ok(relative) = subdir.strip_prefix(root)
+            {
+                record_path_visibility(
+                    state,
+                    &relative.to_string_lossy().replace('\\', "/"),
+                    &metadata,
+                );
+            }
             let Ok(entries) = std::fs::read_dir(&subdir) else {
                 continue;
             };
@@ -4012,15 +4188,16 @@ fn watch_new_subtree(state: &Arc<ServerState>, root: &Path, dir: &Path) {
                     continue;
                 };
                 let path = entry.path();
+                if path.starts_with(&state.index_dir) {
+                    continue;
+                }
                 let Ok(rel) = path.strip_prefix(root) else {
                     continue;
                 };
                 let rel = rel.to_string_lossy().replace('\\', "/");
                 // A subtree that arrives whole — a clone, a `mv`, a branch
-                // switch — can carry its own ignore rules. Those files are
-                // dot-prefixed, so the scan below would silently drop them and
-                // index the rest of the subtree against rules that do not know
-                // about them.
+                // switch — can carry its own ignore rules. Refresh the matcher
+                // before indexing the rest of the subtree against stale rules.
                 //
                 // Ahead of the type dispatch, and following links: the walker
                 // collects rule files with `Path::is_file`, which resolves
@@ -4204,6 +4381,9 @@ fn defer_events_during_build(state: &ServerState, event: &Event) -> bool {
     // trigger a subtree walk on replay. See `ServerState::deferred_events`.
     let introduces_dir = event_introduces_dir(&event.kind);
     for path in &event.paths {
+        if path.starts_with(&state.index_dir) {
+            continue;
+        }
         // A path seen both ways keeps the stronger claim: a directory that was
         // created and then chmod'd still needs its subtree picked up.
         let entry = paths.entry(path.clone()).or_insert(false);
@@ -4271,18 +4451,7 @@ fn replay_deferred_events(state: &Arc<ServerState>, root: &Path) {
         if !is_real_dir(&path)
             && path.strip_prefix(root).is_ok_and(|rel| {
                 let rel = rel.to_string_lossy().replace('\\', "/");
-                let has_content_descendant = {
-                    let index = state.index.read().unwrap();
-                    index.reader_has_descendant_path(&rel) || index.live.has_descendant_path(&rel)
-                };
-                let prefix = format!("{rel}/");
-                has_content_descendant
-                    || state
-                        .filename_extra_paths
-                        .read()
-                        .unwrap()
-                        .iter()
-                        .any(|path| path.starts_with(&prefix))
+                has_indexed_descendant(state, &rel)
             })
         {
             // A single directory removal/rename event names no descendants.
@@ -4404,6 +4573,20 @@ fn recovery_scan_dirs(state: &ServerState, root: &Path, mut dirs: Vec<PathBuf>) 
     dirs
 }
 
+fn has_indexed_descendant(state: &ServerState, relative: &str) -> bool {
+    let index = state.index.read().unwrap();
+    if index.reader_has_descendant_path(relative) || index.live.has_descendant_path(relative) {
+        return true;
+    }
+    let prefix = format!("{relative}/");
+    state
+        .filename_extra_paths
+        .read()
+        .unwrap()
+        .iter()
+        .any(|path| path.starts_with(&prefix))
+}
+
 fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     if state.refresh.polling.load(Ordering::SeqCst) {
         return;
@@ -4431,10 +4614,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
     let ignore_rules_changed = !state.no_ignore && {
         let stamps = state.ignore_source_stamps.read().unwrap();
         event.paths.iter().any(|path| {
-            is_ignore_rules_file(root, path)
-                || path
-                    .strip_prefix(root)
-                    .is_ok_and(|rel| stamps.contains_key(&rel.to_string_lossy().replace('\\', "/")))
+            !path.starts_with(&state.index_dir)
+                && (is_ignore_rules_file(root, path)
+                    || path.strip_prefix(root).is_ok_and(|rel| {
+                        stamps.contains_key(&rel.to_string_lossy().replace('\\', "/"))
+                    }))
         })
     };
     if ignore_rules_changed {
@@ -4477,10 +4661,7 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
 
     for path in &event.paths {
         // Skip the index directory itself
-        if path
-            .to_string_lossy()
-            .contains(&format!("{}.tgrep", std::path::MAIN_SEPARATOR))
-        {
+        if path.starts_with(&state.index_dir) {
             continue;
         }
 
@@ -4490,9 +4671,7 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         };
 
         // Mirror the walker's filtering so the watcher does not reindex
-        // files the initial walk would have skipped — most notably
-        // hidden directories like `.git/`, which fire frequent
-        // `index.lock`/HEAD/refs writes during normal git operations.
+        // files the initial walk would have skipped.
         let should_skip = {
             let gitignore = state.gitignore.read().unwrap();
             should_skip_watcher_path(&rel_path, &state.exclude_dirs, gitignore.as_ref())
@@ -4509,7 +4688,11 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         // that was still perfectly valid. `reindex_file` deliberately preserves
         // entries through exactly those failures, but it never got the chance:
         // the drop happens here, before it is ever called.
-        let target = classify_event_target(&std::fs::metadata(path));
+        let metadata = std::fs::metadata(path);
+        let target = classify_event_target(&metadata);
+        if let Ok(metadata) = &metadata {
+            record_path_visibility(state, &rel_path, metadata);
+        }
         if target == EventTarget::Unknown {
             // Unreadable right now is not proof of anything. Leave what is
             // indexed alone; the stale path keeps such files and retries them.
@@ -4519,6 +4702,13 @@ fn handle_fs_event(state: &Arc<ServerState>, root: &Path, event: &Event) {
         let is_remove = matches!(event.kind, EventKind::Remove(_)) || target == EventTarget::Gone;
 
         if is_remove {
+            if has_indexed_descendant(state, &rel_path) {
+                // Directory renames/removals can name only the directory,
+                // not its children. Reuse the coalesced recovery path to
+                // reconcile descendants, ignore sources and subscriptions.
+                state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+                schedule_ignore_rules_refresh(Arc::clone(state), root.to_path_buf());
+            }
             // A watched directory that disappears takes its descriptor with
             // it, but not its entry in the registry. Clearing that entry is
             // what lets the path be subscribed again if it comes back — and
@@ -5073,6 +5263,9 @@ fn content_id_matches(
 /// The caller must hold `snapshot_gate`: the read, the commit, and the stamp
 /// update have to be atomic with respect to a flush or auto-save.
 fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bool) {
+    if path.starts_with(&state.index_dir) {
+        return;
+    }
     // Against other indexers, not against searches. The gate above is held for
     // read, so without this a recovery scan and the watcher worker can both be
     // here for the same path, both read, and the one that read the *older*
@@ -5108,6 +5301,9 @@ fn reindex_file(state: &Arc<ServerState>, path: &Path, rel_path: &str, force: bo
         retry_failed_reindex(state, rel_path, "the opened file could not be inspected");
         return;
     };
+    // Attribute-only changes must update visibility even if version/content
+    // evidence lets the rest of this reindex return early.
+    record_path_visibility(state, rel_path, &meta);
     let mut version = tgrep_core::builder::file_version(&meta);
     let mut current = version.stamp().clone();
 
@@ -5476,6 +5672,7 @@ fn persist_pending_index_changes(state: &Arc<ServerState>) -> bool {
                 operation: "auto-save",
                 authoritative_membership: false,
                 authoritative_listed_files: None,
+                visibility: None,
                 scanned_files: &[],
             },
         );
@@ -5535,15 +5732,6 @@ fn auto_save_loop(state: Arc<ServerState>) {
     }
 }
 
-/// Check whether `path` passes the glob filter list.
-///
-/// Glob semantics:
-/// - Patterns starting with `!` are **exclusion** patterns (path must NOT match).
-/// - All other patterns are **inclusion** patterns (path must match at least one).
-/// - If only exclusion patterns are present, the path passes unless it matches
-///   an exclusion.
-/// - If inclusion patterns are present, the path must match at least one AND
-///   must not match any exclusion.
 fn json_rpc_result(id: Option<serde_json::Value>, result: serde_json::Value) -> String {
     serde_json::json!({
         "jsonrpc": "2.0",
@@ -5568,22 +5756,28 @@ fn json_rpc_error(id: Option<serde_json::Value>, code: i32, message: &str) -> St
 /// Replace the filename-only delta from an authoritative filesystem path set.
 ///
 /// Returns whether the delta changed and therefore needs to be persisted.
-fn replace_filename_extra_paths(state: &ServerState, listed_files: &[String]) -> bool {
-    let content_paths: std::collections::HashSet<String> = state
-        .index
-        .read()
-        .unwrap()
-        .all_paths()
-        .into_iter()
-        .collect();
+fn replace_filename_extra_paths(
+    state: &ServerState,
+    listed_files: &[String],
+    visibility: &tgrep_core::visibility::PathVisibility,
+) -> bool {
+    // Queries take index before both leaf locks, so the exclusive guard makes
+    // membership and visibility one snapshot without changing content.
+    #[allow(clippy::readonly_write_lock)]
+    let index = state.index.write().unwrap();
+    let content_paths: std::collections::HashSet<String> = index.all_paths().into_iter().collect();
     let next: std::collections::HashSet<String> = listed_files
         .iter()
         .filter(|path| !content_paths.contains(path.as_str()))
         .cloned()
         .collect();
+    let mut current_visibility = state.visibility.write().unwrap();
     let mut current = state.filename_extra_paths.write().unwrap();
-    let changed = *current != next || !state.filename_index_ready.load(Ordering::SeqCst);
+    let changed = *current != next
+        || *current_visibility != *visibility
+        || !state.filename_index_ready.load(Ordering::SeqCst);
     if changed {
+        *current_visibility = visibility.clone();
         *current = next;
         state.filename_index_dirty.store(true, Ordering::SeqCst);
     }
@@ -5591,7 +5785,12 @@ fn replace_filename_extra_paths(state: &ServerState, listed_files: &[String]) ->
     changed
 }
 
-fn stage_filename_extra_paths(state: &ServerState, staging_dir: &Path) -> Result<()> {
+fn stage_filename_extra_paths(
+    state: &ServerState,
+    staging_dir: &Path,
+    visibility: &tgrep_core::visibility::PathVisibility,
+    file_table_id: tgrep_core::meta::FileTableId,
+) -> Result<()> {
     let mut paths: Vec<String> = state
         .filename_extra_paths
         .read()
@@ -5600,45 +5799,122 @@ fn stage_filename_extra_paths(state: &ServerState, staging_dir: &Path) -> Result
         .cloned()
         .collect();
     paths.sort_unstable();
-    tgrep_core::path_index::write_extra_paths(staging_dir, &paths)?;
+    tgrep_core::path_index::write_extra_paths_with_visibility(
+        staging_dir,
+        &paths,
+        visibility,
+        file_table_id,
+    )?;
     Ok(())
 }
 
 /// Publish just the filename sidecar after an authoritative walk that did not
 /// otherwise need to rewrite the content index.
 fn persist_filename_extra_paths(state: &ServerState, index_dir: &Path) -> bool {
-    let staging_dir = index_dir.join(".filename-index-staging");
-    index_cleanup::cleanup_staging(&staging_dir);
-    if let Err(error) = stage_filename_extra_paths(state, &staging_dir) {
-        eprintln!("[trace] warning: could not stage filename index: {error}");
-        index_cleanup::cleanup_staging(&staging_dir);
-        return false;
-    }
-
-    let published = {
-        let _publish = state.publish_lock.lock().unwrap();
-        let src = staging_dir.join(tgrep_core::path_index::EXTRA_PATHS_FILENAME);
-        let dst = index_dir.join(tgrep_core::path_index::EXTRA_PATHS_FILENAME);
-        match publish_file(&src, &dst) {
-            Ok(()) => true,
-            Err(error) => {
-                eprintln!("[trace] warning: could not publish filename index: {error}");
-                false
-            }
-        }
-    };
-    index_cleanup::cleanup_staging(&staging_dir);
-    if published {
-        state.filename_index_dirty.store(false, Ordering::SeqCst);
-    }
-    published
+    persist_filename_discovery(state, index_dir, None)
 }
 
-fn refresh_filename_index(state: &ServerState, index_dir: &Path, listed_files: &[String]) {
-    let changed = replace_filename_extra_paths(state, listed_files);
-    if changed || state.filename_index_dirty.load(Ordering::SeqCst) {
-        persist_filename_extra_paths(state, index_dir);
+fn persist_filename_discovery(
+    state: &ServerState,
+    index_dir: &Path,
+    authoritative_coverage: Option<bool>,
+) -> bool {
+    let staging_dir = index_dir.join(".filename-index-staging");
+    index_cleanup::cleanup_staging(&staging_dir);
+    let staged = (|| -> Result<tgrep_core::meta::IndexMeta> {
+        let mut meta = tgrep_core::meta::IndexMeta::load(index_dir)?;
+        let upgraded = builder::stage_file_table_upgrade(index_dir, &staging_dir)?;
+        let file_table_id =
+            tgrep_core::meta::read_file_table_id(if upgraded { &staging_dir } else { index_dir })?;
+        meta.version = tgrep_core::meta::INDEX_FORMAT_VERSION;
+        meta.file_table_id = Some(file_table_id);
+        meta.visibility = state.visibility.read().unwrap().clone();
+        if let Some(complete) = authoritative_coverage {
+            meta.complete = true;
+            meta.hidden_complete = complete;
+        } else {
+            meta.hidden_complete = meta.complete && state.hidden_complete.load(Ordering::SeqCst);
+        }
+        stage_filename_extra_paths(state, &staging_dir, &meta.visibility, file_table_id)?;
+        meta.save(&staging_dir)?;
+        Ok(meta)
+    })();
+    let meta = match staged {
+        Ok(meta) => meta,
+        Err(error) => {
+            eprintln!("[trace] warning: could not stage filename visibility: {error}");
+            index_cleanup::cleanup_staging(&staging_dir);
+            return false;
+        }
+    };
+
+    let published = (|| -> Result<()> {
+        let _publish = state.publish_lock.lock().unwrap();
+        let files = staging_dir.join("files.bin");
+        if files.exists() {
+            // Only the header changes; files.bin is read into memory, not mapped.
+            publish_file(&files, &index_dir.join("files.bin"))?;
+        }
+        let src = staging_dir.join(tgrep_core::path_index::EXTRA_PATHS_FILENAME);
+        let dst = index_dir.join(tgrep_core::path_index::EXTRA_PATHS_FILENAME);
+        publish_file(&src, &dst)?;
+        #[cfg(test)]
+        run_stale_refresh_hook(state, StaleRefreshPhase::AfterFilenameSidecarPublish);
+        publish_file(&staging_dir.join("meta.json"), &index_dir.join("meta.json"))?;
+        let _index = state.index.write().unwrap();
+        state
+            .hidden_complete
+            .store(meta.hidden_complete, Ordering::SeqCst);
+        state.filename_index_dirty.store(false, Ordering::SeqCst);
+        Ok(())
+    })();
+    index_cleanup::cleanup_staging(&staging_dir);
+    if let Err(error) = published {
+        eprintln!("[trace] warning: could not publish filename index: {error}");
+        return false;
     }
+    true
+}
+
+fn refresh_filename_index(
+    state: &ServerState,
+    index_dir: &Path,
+    listed_files: &[String],
+    visibility: &tgrep_core::visibility::PathVisibility,
+) -> bool {
+    let changed = replace_filename_extra_paths(state, listed_files, visibility);
+    let hidden_complete = state.unreadable.read().unwrap().is_empty();
+    if changed
+        || state.filename_index_dirty.load(Ordering::SeqCst)
+        || state.hidden_complete.load(Ordering::SeqCst) != hidden_complete
+    {
+        return persist_filename_discovery(state, index_dir, Some(hidden_complete));
+    }
+    true
+}
+
+fn record_path_visibility(state: &ServerState, relative: &str, metadata: &std::fs::Metadata) {
+    let ignore = state.gitignore.read().unwrap();
+    if state.visibility.write().unwrap().record(
+        relative,
+        metadata.is_dir(),
+        Some(metadata),
+        ignore.as_ref(),
+    ) {
+        state.filename_index_dirty.store(true, Ordering::SeqCst);
+    }
+}
+
+fn stage_index_visibility(
+    index_dir: &Path,
+    visibility: &tgrep_core::visibility::PathVisibility,
+    hidden_complete: bool,
+) -> Result<tgrep_core::meta::IndexMeta> {
+    let mut meta = tgrep_core::meta::IndexMeta::load(index_dir)?;
+    meta.visibility = visibility.clone();
+    meta.hidden_complete = meta.complete && hidden_complete;
+    meta.save(index_dir)?;
+    Ok(meta)
 }
 
 /// Create a minimal empty on-disk index so HybridIndex::open() succeeds.
@@ -5857,6 +6133,7 @@ struct StaleMergePolicy<'a> {
     operation: &'a str,
     authoritative_membership: bool,
     authoritative_listed_files: Option<&'a [String]>,
+    visibility: Option<&'a tgrep_core::visibility::PathVisibility>,
     /// Pre-read scan metadata for failure memoization, never indexed evidence.
     scanned_files: &'a [tgrep_core::walker::FileMeta],
 }
@@ -5888,6 +6165,7 @@ fn stream_merge_stale_changes(
         operation,
         authoritative_membership,
         authoritative_listed_files,
+        visibility,
         scanned_files,
     } = policy;
     let stamps = &evidence.stamps;
@@ -6047,6 +6325,12 @@ fn stream_merge_stale_changes(
         }
 
         builder::merge_index_with_delta(root, &staging_dir, &reader, &delta, &removed, true)?;
+        let hidden_complete = state.hidden_complete.load(Ordering::SeqCst)
+            || (visibility.is_some() && unreadable.is_empty() && preserved.is_empty());
+        let visibility = visibility
+            .cloned()
+            .unwrap_or_else(|| state.visibility.read().unwrap().clone());
+        stage_index_visibility(&staging_dir, &visibility, hidden_complete)?;
         tgrep_core::meta::write_file_evidence(&published_evidence, &staging_dir)?;
         let removed_reader_files = reader
             .all_paths()
@@ -6398,6 +6682,7 @@ fn refresh_stale_locked(
         root,
         &walker::MetaWalkOptions {
             exclude_dirs: state.exclude_dirs.clone(),
+            exclude_paths: vec![state.index_dir.clone()],
             no_ignore: state.no_ignore,
             no_require_git: state.no_require_git,
             max_file_size: state.max_file_size,
@@ -6494,9 +6779,8 @@ fn refresh_stale_locked(
         paths
     };
     if old_evidence.stamps.is_empty() && indexed_paths.is_empty() && current_meta.is_empty() {
-        refresh_filename_index(state, index_dir, listed_files);
         eprintln!("[trace] stale check: no indexed files or filesystem files, skipping");
-        return true;
+        return refresh_filename_index(state, index_dir, listed_files, &walk.visibility);
     }
 
     let (mut changed, mut added, deleted) = classify_evidence_changes(
@@ -6529,13 +6813,12 @@ fn refresh_stale_locked(
     let total_changes = changed.len() + added.len() + deleted.len();
     let live_pending = state.index.read().unwrap().live.has_pending_changes();
     if total_changes == 0 && !live_pending {
-        refresh_filename_index(state, index_dir, listed_files);
         eprintln!(
             "[trace] stale check: index is up-to-date ({} files checked in {}ms)",
             current_meta.len(),
             walk_ms
         );
-        return true;
+        return refresh_filename_index(state, index_dir, listed_files, &walk.visibility);
     }
 
     if total_changes == 0 {
@@ -6585,6 +6868,7 @@ fn refresh_stale_locked(
             operation: "stale check",
             authoritative_membership: true,
             authoritative_listed_files: Some(listed_files),
+            visibility: Some(&walk.visibility),
             scanned_files: current_meta,
         },
     ) {
@@ -6600,6 +6884,7 @@ fn refresh_stale_locked(
 /// partway through can leave truncated files that the currently mmap'd reader
 /// no longer matches. Resetting gives the fallback build a clean base.
 fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
+    state.hidden_complete.store(false, Ordering::SeqCst);
     state.file_evidence.write().unwrap().clear();
     if let Err(e) = create_empty_index(index_dir) {
         eprintln!("[trace] warning: could not reset the index directory ({e})");
@@ -6608,6 +6893,7 @@ fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
     match HybridIndex::open(index_dir, root) {
         Ok(empty) => {
             let mut index = state.index.write().unwrap();
+            *state.visibility.write().unwrap() = Default::default();
             let mut extra = state.filename_extra_paths.write().unwrap();
             let mut cache = state.cache.write().unwrap();
             *index = empty;
@@ -6631,10 +6917,9 @@ fn reset_to_empty_index(state: &ServerState, root: &Path, index_dir: &Path) {
 /// memory to the arena budget instead, and is also faster, because it writes
 /// the index once rather than growing an overlay and then flushing it.
 ///
-/// The trade-off is that queries see an empty index until the build finishes
-/// rather than a growing partial one. That is deliberate: results from a
-/// fraction of the repository are misleading, and `status` already reports
-/// that indexing is in progress.
+/// Clients scan until complete coverage is published. Results from a fraction
+/// of the repository would be misleading, and `status` reports that indexing
+/// is in progress.
 ///
 /// Only used when nothing has been indexed yet. Resuming a partial index still
 /// takes the incremental path, which can skip the files already on disk.
@@ -6661,15 +6946,12 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         root,
         Some(index_dir),
         &builder::BuildOptions {
-            include_hidden: false,
+            include_hidden: true,
             no_ignore: state.no_ignore,
             no_require_git: state.no_require_git,
             max_file_size: state.max_file_size,
             exclude_dirs: state.exclude_dirs.clone(),
-            // Match the walk `background_index_build` would have run, and the
-            // dot-prefix rule `should_skip_watcher_path` applies, so the
-            // watcher can maintain every file this build indexes. Also makes
-            // the walk hand back the .gitignore paths for the matcher below.
+            exclude_paths: vec![state.index_dir.clone()],
             collect_gitignore_files: true,
             strategy: builder::IndexStrategy::External,
             buffer_bytes: builder::DEFAULT_INDEX_BUFFER_BYTES,
@@ -6682,6 +6964,14 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
                 "[trace] warning: external bootstrap build failed ({e}); \
                  falling back to the in-heap build"
             );
+            reset_to_empty_index(state, root, index_dir);
+            return false;
+        }
+    };
+    let meta = match tgrep_core::meta::IndexMeta::load(index_dir) {
+        Ok(meta) => meta,
+        Err(error) => {
+            eprintln!("[trace] warning: bootstrapped coverage failed to load: {error}");
             reset_to_empty_index(state, root, index_dir);
             return false;
         }
@@ -6723,6 +7013,10 @@ fn bootstrap_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Path
         let mut extra = state.filename_extra_paths.write().unwrap();
         let mut cache = state.cache.write().unwrap();
         *index = opened;
+        *state.visibility.write().unwrap() = meta.visibility;
+        state
+            .hidden_complete
+            .store(meta.complete && meta.hidden_complete, Ordering::SeqCst);
         forget_recent_reindexes(state);
         if let Some(paths) = filename_extra_paths {
             *extra = paths;
@@ -6935,12 +7229,13 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     let walk = walker::walk_dir_with_ignorecase(
         root,
         &WalkOptions {
-            include_hidden: false,
+            include_hidden: true,
             no_ignore: state.no_ignore,
             no_require_git: state.no_require_git,
             max_file_size: state.max_file_size,
             collect_gitignore_files: !state.no_ignore,
             exclude_dirs: state.exclude_dirs.clone(),
+            exclude_paths: vec![state.index_dir.clone()],
             ..Default::default()
         },
         ignorecase.clone(),
@@ -7174,12 +7469,18 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
         root,
         &tgrep_core::walker::MetaWalkOptions {
             exclude_dirs: state.exclude_dirs.clone(),
+            exclude_paths: vec![state.index_dir.clone()],
             no_ignore: state.no_ignore,
             no_require_git: state.no_require_git,
             max_file_size: state.max_file_size,
         },
     );
     let metadata_errors = walk_meta.skipped_error;
+    let visibility = if metadata_errors == 0 {
+        walk_meta.visibility
+    } else {
+        walk.visibility
+    };
     let listed_files = complete_background_listed_files(
         root,
         walk.listed_files,
@@ -7243,8 +7544,13 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     // (not skip) until the flush publishes, after which it applies safely to
     // the newly published reader; no event is lost.
     let gate = state.snapshot_gate.write().unwrap();
+    // Seeded entries may be stale or no longer eligible. A successful final
+    // reconciliation, not merely appending the missing files, proves coverage.
+    state.hidden_complete.store(false, Ordering::SeqCst);
     if let Some(listed_files) = &listed_files {
-        replace_filename_extra_paths(state, listed_files);
+        replace_filename_extra_paths(state, listed_files, &visibility);
+    } else {
+        *state.visibility.write().unwrap() = visibility;
     }
     state.flushing.store(true, Ordering::SeqCst);
 
@@ -7288,16 +7594,16 @@ fn background_index_build(state: &Arc<ServerState>, root: &Path, index_dir: &Pat
     drop(gate);
 
     state.flushing.store(false, Ordering::SeqCst);
-    if !state.watch_enabled {
-        if !catch_up_unwatched_build(state, root, index_dir) {
-            state.ignore_rules_dirty.store(true, Ordering::SeqCst);
-            eprintln!(
-                "[trace] warning: unwatched background-build catch-up was incomplete; \
-                 leaving stamps invalid for the scheduled stale check"
-            );
-        }
-        state.indexing.store(false, Ordering::SeqCst);
+    #[cfg(test)]
+    run_stale_refresh_hook(state, StaleRefreshPhase::BeforeCoverageReconcile);
+    if !catch_up_unwatched_build(state, root, index_dir) {
+        state.ignore_rules_dirty.store(true, Ordering::SeqCst);
+        eprintln!(
+            "[trace] warning: background-build catch-up was incomplete; \
+             hidden searches will scan until coverage is established"
+        );
     }
+    state.indexing.store(false, Ordering::SeqCst);
 
     // Reclaim memory held by the indexing-time live overlay — but only when
     // the flush actually completed and `prune_persisted_entries` ran. If the
@@ -7372,7 +7678,7 @@ fn flush_append_only_overlay_locked(
     }
     let num_files = reader.num_files() + overlay_paths.len();
 
-    let staging_dir = index_dir.with_file_name(".tgrep_flush_staging");
+    let staging_dir = index_dir.join(".flush-staging");
     index_cleanup::cleanup_staging(&staging_dir);
 
     // Stream-merge overlay onto the existing on-disk index. Incremental
@@ -7391,6 +7697,15 @@ fn flush_append_only_overlay_locked(
         return false;
     }
     drop(reader);
+    if let Err(error) = stage_index_visibility(
+        &staging_dir,
+        &state.visibility.read().unwrap(),
+        state.hidden_complete.load(Ordering::SeqCst),
+    ) {
+        eprintln!("[trace] warning: could not stage hidden-file coverage: {error}");
+        index_cleanup::cleanup_staging(&staging_dir);
+        return false;
+    }
 
     // Stage filestamps alongside the final complete index. If this fails we
     // still publish the index: losing incremental stale-check state on next
@@ -7452,14 +7767,33 @@ fn publish_staged_index(
     preserve_overlay_paths: &std::collections::HashSet<String>,
     filename_extra_paths: Option<&std::collections::HashSet<String>>,
 ) -> PublishStatus {
+    let meta = match tgrep_core::meta::IndexMeta::load(staging_dir) {
+        Ok(meta) => meta,
+        Err(error) => {
+            eprintln!("[trace] warning: could not read staged coverage: {error}");
+            index_cleanup::cleanup_staging(staging_dir);
+            return PublishStatus::Failed;
+        }
+    };
     let stage_filename_index =
         filename_extra_paths.is_some() || state.filename_index_ready.load(Ordering::SeqCst);
+    let Some(file_table_id) = meta.file_table_id else {
+        eprintln!("[trace] warning: staged index has no file-table identity");
+        index_cleanup::cleanup_staging(staging_dir);
+        return PublishStatus::Failed;
+    };
     let filename_stage_result = if let Some(paths) = filename_extra_paths {
         let mut paths: Vec<String> = paths.iter().cloned().collect();
         paths.sort_unstable();
-        tgrep_core::path_index::write_extra_paths(staging_dir, &paths).map_err(Into::into)
+        tgrep_core::path_index::write_extra_paths_with_visibility(
+            staging_dir,
+            &paths,
+            &meta.visibility,
+            file_table_id,
+        )
+        .map_err(Into::into)
     } else if state.filename_index_ready.load(Ordering::SeqCst) {
-        stage_filename_extra_paths(state, staging_dir)
+        stage_filename_extra_paths(state, staging_dir, &meta.visibility, file_table_id)
     } else {
         Ok(())
     };
@@ -7504,6 +7838,10 @@ fn publish_staged_index(
     // observe the new posting set with bytes from the old cache generation.
     {
         let mut index = state.index.write().unwrap();
+        *state.visibility.write().unwrap() = meta.visibility;
+        state
+            .hidden_complete
+            .store(meta.hidden_complete, Ordering::SeqCst);
         if let Some(paths) = filename_extra_paths {
             *state.filename_extra_paths.write().unwrap() = paths.clone();
             state.filename_index_ready.store(true, Ordering::SeqCst);
@@ -7543,6 +7881,14 @@ fn publish_reloaded_index(
     staging_dir: &Path,
     num_files: usize,
 ) -> bool {
+    let meta = match tgrep_core::meta::IndexMeta::load(staging_dir) {
+        Ok(meta) => meta,
+        Err(error) => {
+            eprintln!("[trace] warning: could not read reloaded coverage: {error}");
+            index_cleanup::cleanup_staging(staging_dir);
+            return false;
+        }
+    };
     let filename_extra_paths = match tgrep_core::path_index::read_extra_paths(staging_dir) {
         Ok(Some(paths)) => paths.into_iter().collect(),
         Ok(None) => {
@@ -7583,6 +7929,10 @@ fn publish_reloaded_index(
     // both in that order makes the complete reload visible as one generation.
     {
         let mut index = state.index.write().unwrap();
+        *state.visibility.write().unwrap() = meta.visibility;
+        state
+            .hidden_complete
+            .store(meta.hidden_complete, Ordering::SeqCst);
         *state.filename_extra_paths.write().unwrap() = filename_extra_paths;
         state.filename_index_ready.store(true, Ordering::SeqCst);
         state.filename_index_dirty.store(false, Ordering::SeqCst);
@@ -8642,6 +8992,8 @@ mod tests {
         let hybrid = HybridIndex::open(index_dir, root).expect("open empty index");
         Arc::new(ServerState {
             index: RwLock::new(hybrid),
+            visibility: RwLock::new(Default::default()),
+            hidden_complete: std::sync::atomic::AtomicBool::new(true),
             filename_extra_paths: RwLock::new(Default::default()),
             filename_index_ready: std::sync::atomic::AtomicBool::new(false),
             filename_index_dirty: std::sync::atomic::AtomicBool::new(false),
@@ -8829,7 +9181,7 @@ mod tests {
         assert_eq!(value.pointer("/result/status").unwrap(), "reloaded");
         assert!(state.filename_index_ready.load(Ordering::SeqCst));
 
-        let response = handle_files(Some(serde_json::json!(2)), &state);
+        let response = handle_files(Some(serde_json::json!(2)), &serde_json::Value::Null, &state);
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert_eq!(
             value.pointer("/result/files").unwrap(),
@@ -8899,7 +9251,12 @@ mod tests {
         state.filename_index_dirty.store(true, Ordering::SeqCst);
         tgrep_core::path_index::write_extra_paths(&index_dir, &[]).unwrap();
 
-        refresh_filename_index(state.as_ref(), &index_dir, &["asset.bin".to_string()]);
+        refresh_filename_index(
+            state.as_ref(),
+            &index_dir,
+            &["asset.bin".to_string()],
+            &Default::default(),
+        );
 
         assert_eq!(
             tgrep_core::path_index::read_extra_paths(&index_dir).unwrap(),
@@ -9129,29 +9486,32 @@ mod tests {
     }
 
     #[test]
-    fn skip_watcher_path_skips_dot_components() {
+    fn skip_watcher_path_keeps_nonignored_dot_components() {
         let no_exclude: Vec<String> = Vec::new();
-        // A leading dot dir is the canonical case (.git, .hg, .svn, ...).
-        assert!(should_skip_watcher_path(
+        assert!(!should_skip_watcher_path(
             ".git/index.lock",
             &no_exclude,
             None
         ));
-        assert!(should_skip_watcher_path(".git/HEAD", &no_exclude, None));
-        assert!(should_skip_watcher_path(
+        assert!(!should_skip_watcher_path(".git/HEAD", &no_exclude, None));
+        assert!(!should_skip_watcher_path(
             ".hg/store/data",
             &no_exclude,
             None
         ));
-        // A dot component anywhere in the path skips, not just the leading one.
-        assert!(should_skip_watcher_path(
+        assert!(!should_skip_watcher_path(
             "src/.cache/build.tmp",
             &no_exclude,
             None
         ));
-        assert!(should_skip_watcher_path(
+        assert!(!should_skip_watcher_path(
             "a/b/.hidden/c.txt",
             &no_exclude,
+            None
+        ));
+        assert!(should_skip_watcher_path(
+            ".git/HEAD",
+            &[".git".to_string()],
             None
         ));
     }
@@ -9405,7 +9765,7 @@ mod tests {
     }
 
     #[test]
-    fn watchable_dirs_prunes_ignored_and_hidden_subtrees() {
+    fn watchable_dirs_prunes_ignored_and_storage_subtrees() {
         // The point of the subscription set: an ignored directory costs one
         // inotify watch descriptor per directory inside it, so pruning has to
         // happen before the subtree is walked, not after its events arrive.
@@ -9421,6 +9781,8 @@ mod tests {
             "build/a",
             "build/a/deep",
             ".git/objects",
+            ".github/workflows",
+            "custom-index/.retired/generation-1",
             "vendor",
             "vendor/pkg",
         ] {
@@ -9429,7 +9791,7 @@ mod tests {
 
         let gi = tgrep_core::gitignore::build_matcher(root).expect("matcher should build");
         let exclude = vec!["vendor".to_string()];
-        let dirs = watchable_dirs(root, root, &exclude, Some(&gi));
+        let dirs = watchable_dirs(root, root, &exclude, Some(&gi), &root.join("custom-index"));
 
         let rel: std::collections::HashSet<String> = dirs
             .dirs
@@ -9456,9 +9818,11 @@ mod tests {
         assert!(!rel.contains("build/a"));
         assert!(!rel.contains("build/a/deep"));
 
-        // Hidden directories, which the walker skips too.
-        assert!(!rel.contains(".git"));
-        assert!(!rel.contains(".git/objects"));
+        assert!(rel.contains(".git"));
+        assert!(rel.contains(".git/objects"));
+        assert!(rel.contains(".github/workflows"));
+        assert!(!rel.contains("custom-index"));
+        assert!(!rel.contains("custom-index/.retired/generation-1"));
 
         // `--exclude` names prune the directory itself, not just its children.
         assert!(!rel.contains("vendor"), "excluded dir was watched: {rel:?}");
@@ -9468,14 +9832,14 @@ mod tests {
     #[test]
     fn watchable_dirs_without_a_matcher_keeps_everything_visible() {
         // `--no-ignore` publishes no matcher. The subscription set must then
-        // be the whole tree minus hidden paths, matching what the walk indexes;
+        // be the whole tree minus storage, matching what the walk indexes;
         // silently narrowing it would drop events for files that ARE indexed.
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("build/a")).unwrap();
         std::fs::create_dir_all(root.join(".hidden")).unwrap();
 
-        let dirs = watchable_dirs(root, root, &[], None);
+        let dirs = watchable_dirs(root, root, &[], None, &root.join(".tgrep"));
         let rel: std::collections::HashSet<String> = dirs
             .dirs
             .iter()
@@ -9489,7 +9853,7 @@ mod tests {
 
         assert!(rel.contains("build"));
         assert!(rel.contains("build/a"));
-        assert!(!rel.contains(".hidden"));
+        assert!(rel.contains(".hidden"));
     }
 
     #[test]
@@ -9508,7 +9872,13 @@ mod tests {
         }
 
         let gi = tgrep_core::gitignore::build_matcher(root).expect("matcher should build");
-        let dirs = watchable_dirs(root, &root.join("src/fresh"), &[], Some(&gi));
+        let dirs = watchable_dirs(
+            root,
+            &root.join("src/fresh"),
+            &[],
+            Some(&gi),
+            &root.join(".tgrep"),
+        );
         let rel: std::collections::HashSet<String> = dirs
             .dirs
             .iter()
@@ -9601,6 +9971,7 @@ mod tests {
                     operation: "test stale check",
                     authoritative_membership: true,
                     authoritative_listed_files: Some(&listed_files),
+                    visibility: None,
                     scanned_files: &[],
                 },
             ));
@@ -9644,6 +10015,7 @@ mod tests {
                     operation: "test retry",
                     authoritative_membership: true,
                     authoritative_listed_files: None,
+                    visibility: None,
                     scanned_files: &[],
                 },
             ));
@@ -9727,6 +10099,7 @@ mod tests {
                     operation: "test evidence merge",
                     authoritative_membership: true,
                     authoritative_listed_files: None,
+                    visibility: None,
                     scanned_files: &[],
                 },
             ));
@@ -9915,7 +10288,9 @@ mod tests {
                 StaleRefreshPhase::BeforeRefreshLock => {}
                 StaleRefreshPhase::AfterBuildBeforeStampPublish => {}
                 StaleRefreshPhase::AfterConcreteRead => {}
-                StaleRefreshPhase::BeforeConcreteCommit => {}
+                StaleRefreshPhase::BeforeConcreteCommit
+                | StaleRefreshPhase::BeforeCoverageReconcile
+                | StaleRefreshPhase::AfterFilenameSidecarPublish => {}
             })
         };
         *state.stale_refresh_hook.lock().unwrap() = Some(hook);
@@ -10055,7 +10430,9 @@ mod tests {
                 StaleRefreshPhase::BeforeRefreshLock => {}
                 StaleRefreshPhase::AfterBuildBeforeStampPublish => {}
                 StaleRefreshPhase::AfterConcreteRead => {}
-                StaleRefreshPhase::BeforeConcreteCommit => {}
+                StaleRefreshPhase::BeforeConcreteCommit
+                | StaleRefreshPhase::BeforeCoverageReconcile
+                | StaleRefreshPhase::AfterFilenameSidecarPublish => {}
             })
         };
         *state.stale_refresh_hook.lock().unwrap() = Some(hook);
@@ -10229,7 +10606,9 @@ mod tests {
                 StaleRefreshPhase::BeforeRefreshLock => {}
                 StaleRefreshPhase::AfterBuildBeforeStampPublish => {}
                 StaleRefreshPhase::AfterConcreteRead => {}
-                StaleRefreshPhase::BeforeConcreteCommit => {}
+                StaleRefreshPhase::BeforeConcreteCommit
+                | StaleRefreshPhase::BeforeCoverageReconcile
+                | StaleRefreshPhase::AfterFilenameSidecarPublish => {}
             })
         };
         *state.stale_refresh_hook.lock().unwrap() = Some(hook);
@@ -10561,7 +10940,7 @@ mod tests {
 
         let response = handle_reload(None, &state);
         assert!(response.contains("\"status\":\"reloaded\""), "{response}");
-        let response = handle_files(None, &state);
+        let response = handle_files(None, &serde_json::Value::Null, &state);
         let value: serde_json::Value = serde_json::from_str(&response).unwrap();
         assert_eq!(
             value.pointer("/result/files").unwrap(),
@@ -11049,6 +11428,9 @@ mod tests {
         assert_eq!(index.live.file_id_for_path("recycled.rs"), Some(first_id));
         assert_eq!(index.live.dirty_count(), 1);
         drop(index);
+        assert!(!state.hidden_complete.load(Ordering::SeqCst));
+        // The synthetic one-file corpus is now fully restored.
+        state.hidden_complete.store(true, Ordering::SeqCst);
         let found = handle_search(
             None,
             &serde_json::json!({"pattern": "recycled_marker"}),
@@ -13729,6 +14111,9 @@ mod tests {
         );
         let old_bytes = std::fs::read(index_dir.join("index.bin")).unwrap();
         create_empty_index(&staging).unwrap();
+        let mut staged_meta = tgrep_core::meta::IndexMeta::load(&staging).unwrap();
+        staged_meta.file_table_id = Some(tgrep_core::meta::read_file_table_id(&staging).unwrap());
+        staged_meta.save(&staging).unwrap();
 
         assert_eq!(
             publish_staged_index(

--- a/tgrep-cli/src/serve/hidden_tests.rs
+++ b/tgrep-cli/src/serve/hidden_tests.rs
@@ -267,6 +267,22 @@ fn hidden_filename_publication_is_coherent_even_when_metadata_publish_fails() {
         .collect();
     visible.sort();
     assert_eq!(visible, ["visible.png", "visible.txt"]);
+    let incomplete_sidecar = index_dir.join("incomplete-sidecar");
+    tgrep_core::path_index::write_extra_paths_with_visibility(
+        &incomplete_sidecar,
+        &[".secret.png".to_string()],
+        &Default::default(),
+        reader.file_table_id(),
+        false,
+    )
+    .unwrap();
+    let incomplete = StartupDiscovery::load(
+        &incomplete_sidecar,
+        Some(old_meta.clone()),
+        reader.file_table_id(),
+    );
+    assert!(!incomplete.hidden_complete && incomplete.filename_index_ready);
+
     let mut mismatched_meta = old_meta.clone();
     mismatched_meta.file_table_id = Some([0; 32]);
     assert!(
@@ -279,10 +295,11 @@ fn hidden_filename_publication_is_coherent_even_when_metadata_publish_fails() {
         &[".secret.png".to_string()],
         &Default::default(),
         [0; 32],
+        true,
     )
     .unwrap();
     let mismatched = StartupDiscovery::load(&bad_sidecar, Some(old_meta), reader.file_table_id());
-    assert!(mismatched.hidden_complete && !mismatched.filename_index_ready);
+    assert!(!mismatched.hidden_complete && !mismatched.filename_index_ready);
     *state.stale_refresh_hook.lock().unwrap() = None;
     assert!(background_refresh_stale(&state, &root, &index_dir, false));
     assert!(!state.filename_index_dirty.load(Ordering::SeqCst));

--- a/tgrep-cli/src/serve/hidden_tests.rs
+++ b/tgrep-cli/src/serve/hidden_tests.rs
@@ -1,0 +1,375 @@
+use super::tests::test_server_state;
+use super::*;
+
+fn matched_paths(response: &str) -> std::collections::BTreeSet<String> {
+    let response: serde_json::Value = serde_json::from_str(response).unwrap();
+    assert!(response.get("error").is_none(), "{response}");
+    response["result"]["matches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["file"].as_str().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn legacy_hidden_coverage_is_published_only_after_reconciliation() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(temporary.path()).unwrap();
+    let index_dir = root.join("custom-index");
+    std::fs::create_dir_all(root.join(".github/.nested")).unwrap();
+    for path in [
+        "visible.txt",
+        ".secret.txt",
+        ".github/settings.txt",
+        ".github/.nested/inner.txt",
+    ] {
+        std::fs::write(root.join(path), "needle\n").unwrap();
+    }
+    let state = test_server_state(&root, &index_dir);
+    builder::build_index(&root, Some(&index_dir), false, false, &[]).unwrap();
+    *state.index.write().unwrap() = HybridIndex::open(&index_dir, &root).unwrap();
+    state.hidden_complete.store(false, Ordering::SeqCst);
+    assert_eq!(state.index.read().unwrap().num_files(), 1);
+    let weak = Arc::downgrade(&state);
+    let observed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let hook_observed = Arc::clone(&observed);
+    *state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::AfterMatcherPublish) {
+            let state = weak.upgrade().unwrap();
+            assert!(!state.hidden_complete.load(Ordering::SeqCst));
+            assert!(
+                !tgrep_core::meta::IndexMeta::load(&state.index_dir)
+                    .unwrap()
+                    .hidden_complete
+            );
+            let response = handle_search(
+                None,
+                &serde_json::json!({"pattern": "needle", "hidden": true}),
+                &state,
+            );
+            assert!(
+                serde_json::from_str::<serde_json::Value>(&response)
+                    .unwrap()
+                    .get("error")
+                    .is_some()
+            );
+            hook_observed.store(true, Ordering::SeqCst);
+        }
+    }));
+    assert!(background_refresh_stale(&state, &root, &index_dir, false));
+    *state.stale_refresh_hook.lock().unwrap() = None;
+    assert!(observed.load(Ordering::SeqCst));
+    assert!(state.hidden_complete.load(Ordering::SeqCst));
+    assert!(
+        tgrep_core::meta::IndexMeta::load(&index_dir)
+            .unwrap()
+            .hidden_complete
+    );
+
+    // No hidden parameter is how older clients request ordinary visibility.
+    assert_eq!(
+        matched_paths(&handle_search(
+            None,
+            &serde_json::json!({"pattern": "needle", "max_count": 1}),
+            &state
+        )),
+        std::collections::BTreeSet::from(["visible.txt".to_string()])
+    );
+    assert_eq!(
+        matched_paths(&handle_search(
+            None,
+            &serde_json::json!({"pattern": "needle", "hidden": true}),
+            &state
+        ))
+        .len(),
+        4
+    );
+    assert_eq!(
+        matched_paths(&handle_search(
+            None,
+            &serde_json::json!({"pattern": "needle", "scope": ".github/"}),
+            &state
+        )),
+        std::collections::BTreeSet::from([".github/settings.txt".to_string()])
+    );
+    let response: serde_json::Value =
+        serde_json::from_str(&handle_files(None, &serde_json::Value::Null, &state)).unwrap();
+    assert_eq!(
+        response["result"]["files"],
+        serde_json::json!(["visible.txt"])
+    );
+
+    state.indexing.store(true, Ordering::SeqCst);
+    for response in [
+        handle_search(
+            None,
+            &serde_json::json!({"pattern": "needle", "hidden": true}),
+            &state,
+        ),
+        handle_files(None, &serde_json::json!({"hidden": true}), &state),
+    ] {
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&response)
+                .unwrap()
+                .get("error")
+                .is_some()
+        );
+    }
+}
+
+#[test]
+fn custom_storage_events_never_enter_the_overlay_or_deferred_queue() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(temporary.path()).unwrap();
+    let index_dir = root.join("custom-index");
+    let state = test_server_state(&root, &index_dir);
+    let path = index_dir.join("output.txt");
+    std::fs::write(&path, "needle\n").unwrap();
+    assert!(
+        watchable_dirs(&root, &index_dir, &[], None, &index_dir)
+            .dirs
+            .is_empty()
+    );
+    reindex_file(&state, &path, "custom-index/output.txt", true);
+    assert!(
+        !state
+            .index
+            .read()
+            .unwrap()
+            .has_active_path("custom-index/output.txt")
+    );
+    state.indexing.store(true, Ordering::SeqCst);
+    let event = Event {
+        kind: EventKind::Create(notify::event::CreateKind::File),
+        paths: vec![path],
+        attrs: Default::default(),
+    };
+    assert!(defer_events_during_build(&state, &event));
+    assert!(
+        state
+            .deferred_events
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn reload_preserves_hidden_coverage_visibility_and_storage_exclusion() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(temporary.path()).unwrap();
+    let index_dir = root.join("custom-index");
+    let state = test_server_state(&root, &index_dir);
+    std::fs::create_dir_all(root.join(".hidden")).unwrap();
+    std::fs::write(root.join(".hidden/.ignore"), "ignored.txt\n").unwrap();
+    for path in [
+        "visible.txt",
+        ".secret.txt",
+        ".hidden/open.txt",
+        ".hidden/ignored.txt",
+        "custom-index/output.txt",
+    ] {
+        std::fs::write(root.join(path), "needle\n").unwrap();
+    }
+
+    for _ in 0..2 {
+        let response = handle_reload(None, &state);
+        let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+        assert!(response.get("error").is_none(), "{response}");
+        let meta = tgrep_core::meta::IndexMeta::load(&index_dir).unwrap();
+        assert!(meta.complete && meta.hidden_complete);
+        assert_eq!(
+            matched_paths(&handle_search(
+                None,
+                &serde_json::json!({"pattern": "needle"}),
+                &state
+            )),
+            std::collections::BTreeSet::from(["visible.txt".to_string()])
+        );
+        assert_eq!(
+            matched_paths(&handle_search(
+                None,
+                &serde_json::json!({"pattern": "needle", "hidden": true}),
+                &state
+            )),
+            std::collections::BTreeSet::from([
+                "visible.txt".to_string(),
+                ".secret.txt".to_string(),
+                ".hidden/open.txt".to_string(),
+            ])
+        );
+    }
+}
+
+#[test]
+fn hidden_filename_publication_is_coherent_even_when_metadata_publish_fails() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(temporary.path()).unwrap();
+    let index_dir = root.join("custom-index");
+    let state = test_server_state(&root, &index_dir);
+    std::fs::write(root.join("visible.txt"), "needle\n").unwrap();
+    assert!(background_refresh_stale(&state, &root, &index_dir, false));
+    std::fs::write(root.join(".secret.png"), "needle\n").unwrap();
+    std::fs::write(root.join("visible.png"), "needle\n").unwrap();
+
+    let weak = Arc::downgrade(&state);
+    let observed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let hook_observed = Arc::clone(&observed);
+    *state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
+        if matches!(phase, StaleRefreshPhase::AfterFilenameSidecarPublish) {
+            let state = weak.upgrade().unwrap();
+            let response: serde_json::Value =
+                serde_json::from_str(&handle_files(None, &serde_json::Value::Null, &state))
+                    .unwrap();
+            assert_eq!(
+                response["result"]["files"],
+                serde_json::json!(["visible.png", "visible.txt"])
+            );
+            let sidecar = tgrep_core::path_index::read_filename_index(&state.index_dir)
+                .unwrap()
+                .unwrap();
+            assert!(sidecar.paths.contains(&".secret.png".to_string()));
+            let visibility = sidecar.visibility.unwrap();
+            assert!(!visibility.paths.is_visible(".secret.png", "", false));
+            let old_meta = tgrep_core::meta::IndexMeta::load(&state.index_dir).unwrap();
+            assert!(old_meta.hidden_complete);
+            assert!(old_meta.visibility.is_visible(".secret.png", "", false));
+            assert_eq!(old_meta.file_table_id, Some(visibility.file_table_id));
+            // Deterministically interrupt the second publication. The already
+            // published sidecar must remain safe with the old metadata.
+            std::fs::remove_file(
+                state
+                    .index_dir
+                    .join(".filename-index-staging")
+                    .join("meta.json"),
+            )
+            .unwrap();
+            hook_observed.store(true, Ordering::SeqCst);
+        }
+    }));
+    assert!(!background_refresh_stale(&state, &root, &index_dir, false));
+    assert!(observed.load(Ordering::SeqCst));
+    assert!(state.filename_index_dirty.load(Ordering::SeqCst));
+    let reader = tgrep_core::reader::IndexReader::open(&index_dir).unwrap();
+    let old_meta = tgrep_core::meta::IndexMeta::load(&index_dir).unwrap();
+    let restarted =
+        StartupDiscovery::load(&index_dir, Some(old_meta.clone()), reader.file_table_id());
+    assert!(restarted.hidden_complete && restarted.filename_index_ready);
+    let mut visible: Vec<_> = reader
+        .all_paths()
+        .iter()
+        .cloned()
+        .chain(restarted.filename_extra_paths)
+        .filter(|path| restarted.visibility.is_visible(path, "", false))
+        .collect();
+    visible.sort();
+    assert_eq!(visible, ["visible.png", "visible.txt"]);
+    let mut mismatched_meta = old_meta.clone();
+    mismatched_meta.file_table_id = Some([0; 32]);
+    assert!(
+        !StartupDiscovery::load(&index_dir, Some(mismatched_meta), reader.file_table_id())
+            .hidden_complete
+    );
+    let bad_sidecar = index_dir.join("bad-sidecar");
+    tgrep_core::path_index::write_extra_paths_with_visibility(
+        &bad_sidecar,
+        &[".secret.png".to_string()],
+        &Default::default(),
+        [0; 32],
+    )
+    .unwrap();
+    let mismatched = StartupDiscovery::load(&bad_sidecar, Some(old_meta), reader.file_table_id());
+    assert!(mismatched.hidden_complete && !mismatched.filename_index_ready);
+    *state.stale_refresh_hook.lock().unwrap() = None;
+    assert!(background_refresh_stale(&state, &root, &index_dir, false));
+    assert!(!state.filename_index_dirty.load(Ordering::SeqCst));
+    assert!(
+        !tgrep_core::meta::IndexMeta::load(&index_dir)
+            .unwrap()
+            .visibility
+            .is_visible(".secret.png", "", false)
+    );
+}
+
+#[test]
+fn native_hidden_directory_rename_schedules_descendant_reconciliation() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(temporary.path()).unwrap();
+    let index_dir = root.join("custom-index");
+    let state = test_server_state(&root, &index_dir);
+    std::fs::create_dir(root.join(".moving")).unwrap();
+    std::fs::write(root.join(".moving/child.txt"), "needle\n").unwrap();
+    std::fs::write(root.join(".moving/.asset.png"), "needle\n").unwrap();
+    assert!(background_refresh_stale(&state, &root, &index_dir, false));
+    state.ignore_refresh_scheduled.store(true, Ordering::SeqCst);
+    std::fs::rename(root.join(".moving"), root.join("moved")).unwrap();
+    handle_fs_event(
+        &state,
+        &root,
+        &Event::new(EventKind::Modify(notify::event::ModifyKind::Name(
+            notify::event::RenameMode::From,
+        )))
+        .add_path(root.join(".moving")),
+    );
+    assert!(state.ignore_rules_dirty.load(Ordering::SeqCst));
+    assert!(background_refresh_stale(&state, &root, &index_dir, false));
+    assert_eq!(
+        matched_paths(&handle_search(
+            None,
+            &serde_json::json!({"pattern":"needle"}),
+            &state
+        )),
+        std::collections::BTreeSet::from(["moved/child.txt".to_string()])
+    );
+    let response: serde_json::Value = serde_json::from_str(&handle_files(
+        None,
+        &serde_json::json!({"hidden":true}),
+        &state,
+    ))
+    .unwrap();
+    assert_eq!(
+        response["result"]["files"],
+        serde_json::json!(["moved/.asset.png", "moved/child.txt"])
+    );
+}
+
+#[test]
+fn filename_only_legacy_upgrade_publishes_the_core_format_boundary() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(temporary.path()).unwrap();
+    let index_dir = root.join("custom-index");
+    let state = test_server_state(&root, &index_dir);
+    std::fs::write(root.join("visible.png"), "needle\n").unwrap();
+    std::fs::write(root.join(".secret.png"), "needle\n").unwrap();
+    let mut meta = tgrep_core::meta::IndexMeta::new(&root.to_string_lossy(), 0, 0);
+    meta.version = 2;
+    meta.save(&index_dir).unwrap();
+    state.hidden_complete.store(false, Ordering::SeqCst);
+    assert!(
+        std::fs::read(index_dir.join("files.bin"))
+            .unwrap()
+            .is_empty()
+    );
+
+    assert!(background_refresh_stale(&state, &root, &index_dir, false));
+    assert!(
+        !std::fs::read(index_dir.join("files.bin"))
+            .unwrap()
+            .is_empty()
+    );
+    let meta = tgrep_core::meta::IndexMeta::load(&index_dir).unwrap();
+    assert_eq!(meta.version, tgrep_core::meta::INDEX_FORMAT_VERSION);
+    assert!(meta.hidden_complete);
+    let reader = tgrep_core::reader::IndexReader::open(&index_dir).unwrap();
+    assert_eq!(reader.num_files(), 0);
+    assert_eq!(meta.file_table_id, Some(reader.file_table_id()));
+    let response: serde_json::Value =
+        serde_json::from_str(&handle_files(None, &serde_json::Value::Null, &state)).unwrap();
+    assert_eq!(
+        response["result"]["files"],
+        serde_json::json!(["visible.png"])
+    );
+}

--- a/tgrep-cli/src/serve/poll_tests.rs
+++ b/tgrep-cli/src/serve/poll_tests.rs
@@ -104,6 +104,7 @@ impl Fixture {
             &self.root,
             &self.state.exclude_dirs,
             matcher.as_ref(),
+            &self.state.index_dir,
         )
     }
 }
@@ -359,42 +360,38 @@ fn resumed_build_binary_evidence_describes_the_read_not_the_final_walk() {
     let path = fixture.write("raced.rs", b"original_binary\n\0");
     let version = builder::file_version(&std::fs::metadata(&path).unwrap());
     let hook_root = fixture.root.clone();
+    let hook_state = Arc::downgrade(&fixture.state);
+    let observed_checkpoint = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let hook_observed = Arc::clone(&observed_checkpoint);
     *fixture.state.stale_refresh_hook.lock().unwrap() = Some(Arc::new(move |phase| {
         if matches!(phase, StaleRefreshPhase::AfterBuildBeforeStampPublish) {
             std::fs::write(&path, "fn after_classification_marker() {}\n").unwrap();
             std::fs::write(hook_root.join("late.rs"), "fn late_arrival_marker() {}\n").unwrap();
+        } else if matches!(phase, StaleRefreshPhase::BeforeCoverageReconcile) {
+            let state = hook_state.upgrade().unwrap();
+            let evidence = state.file_evidence.read().unwrap();
+            assert_eq!(evidence.version("raced.rs"), Some(&version));
+            assert!(evidence.stamp("late.rs").is_none());
+            assert!(!state.index.read().unwrap().has_active_path("raced.rs"));
+            assert!(!state.hidden_complete.load(Ordering::SeqCst));
+            assert!(
+                !tgrep_core::meta::IndexMeta::load(&state.index_dir)
+                    .unwrap()
+                    .hidden_complete
+            );
+            hook_observed.store(true, Ordering::SeqCst);
         }
     }));
     fixture.state.indexing.store(true, Ordering::SeqCst);
     background_index_build(&fixture.state, &fixture.root, &fixture.state.index_dir);
     *fixture.state.stale_refresh_hook.lock().unwrap() = None;
-    assert_eq!(
-        fixture
-            .state
-            .file_evidence
-            .read()
-            .unwrap()
-            .version("raced.rs"),
-        Some(&version)
-    );
+    assert!(observed_checkpoint.load(Ordering::SeqCst));
+    assert!(fixture.state.hidden_complete.load(Ordering::SeqCst));
     assert!(
-        fixture
-            .state
-            .file_evidence
-            .read()
+        tgrep_core::meta::IndexMeta::load(&fixture.state.index_dir)
             .unwrap()
-            .stamp("late.rs")
-            .is_none()
+            .hidden_complete
     );
-    assert!(
-        !fixture
-            .state
-            .index
-            .read()
-            .unwrap()
-            .has_active_path("raced.rs")
-    );
-    fixture.poll();
     fixture.assert_hit("after_classification_marker", "raced.rs");
     fixture.assert_hit("late_arrival_marker", "late.rs");
 }

--- a/tgrep-cli/src/status.rs
+++ b/tgrep-cli/src/status.rs
@@ -6,6 +6,8 @@ use std::path::Path;
 use anyhow::Result;
 use tgrep_core::builder;
 use tgrep_core::meta::IndexMeta;
+use tgrep_core::path_index;
+use tgrep_core::reader::IndexReader;
 
 use crate::serve::ServerInfo;
 
@@ -55,16 +57,20 @@ pub fn run(root: &Path, index_path: Option<&Path>) -> Result<()> {
     // Fall back to on-disk metadata
     match IndexMeta::load(&index_dir) {
         Ok(meta) => {
+            let hidden_complete = match local_hidden_coverage(&index_dir, &meta) {
+                Ok(complete) => complete,
+                Err(error) => {
+                    eprintln!("warning: index coverage unavailable ({error})");
+                    false
+                }
+            };
             println!("Index status for {}", root.display());
             println!("  Files:      {}", meta.num_files);
             println!("  Trigrams:   {}", meta.num_trigrams);
             println!("  Created:    {}", format_timestamp(meta.created_at));
             println!("  Updated:    {}", format_timestamp(meta.updated_at));
             println!("  Server:     not running");
-            println!(
-                "  Hidden coverage: {}",
-                coverage_label(meta.complete && meta.hidden_complete)
-            );
+            println!("  Hidden coverage: {}", coverage_label(hidden_complete));
         }
         Err(_) => {
             println!("No index found at {}", index_dir.display());
@@ -73,6 +79,17 @@ pub fn run(root: &Path, index_path: Option<&Path>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn local_hidden_coverage(index_dir: &Path, meta: &IndexMeta) -> Result<bool> {
+    let Some(index) = path_index::read_filename_index(index_dir)? else {
+        return Ok(false);
+    };
+    let Some(visibility) = index.visibility else {
+        return Ok(false);
+    };
+    let reader = IndexReader::open(index_dir)?;
+    Ok(visibility.covers_index(meta, reader.file_table_id()))
 }
 
 #[derive(serde::Deserialize)]

--- a/tgrep-cli/src/status.rs
+++ b/tgrep-cli/src/status.rs
@@ -45,6 +45,10 @@ pub fn run(root: &Path, index_path: Option<&Path>) -> Result<()> {
         } else {
             println!("  Indexing:   complete");
         }
+        println!(
+            "  Hidden coverage: {}",
+            coverage_label(status.hidden_complete.unwrap_or(false))
+        );
         return Ok(());
     }
 
@@ -57,6 +61,10 @@ pub fn run(root: &Path, index_path: Option<&Path>) -> Result<()> {
             println!("  Created:    {}", format_timestamp(meta.created_at));
             println!("  Updated:    {}", format_timestamp(meta.updated_at));
             println!("  Server:     not running");
+            println!(
+                "  Hidden coverage: {}",
+                coverage_label(meta.complete && meta.hidden_complete)
+            );
         }
         Err(_) => {
             println!("No index found at {}", index_dir.display());
@@ -92,6 +100,15 @@ struct StatusResult {
     index_progress: u64,
     #[serde(default)]
     index_total: u64,
+    hidden_complete: Option<bool>,
+}
+
+fn coverage_label(complete: bool) -> &'static str {
+    if complete {
+        "complete"
+    } else {
+        "unavailable (queries scan)"
+    }
 }
 
 fn write_refresh_status(writer: &mut impl Write, status: &StatusResult) -> std::io::Result<()> {
@@ -225,6 +242,7 @@ mod tests {
         let status: StatusResult = serde_json::from_value(legacy_status()).unwrap();
         assert!(status.watcher_active);
         assert!(!status.indexing);
+        assert!(status.hidden_complete.is_none());
         assert!(!status.reconcile_running);
         assert!(status.watch_mode_requested.is_none());
         assert!(status.watch_mode_active.is_none());

--- a/tgrep-cli/tests/indexed_hidden.rs
+++ b/tgrep-cli/tests/indexed_hidden.rs
@@ -1,0 +1,1083 @@
+//! Hidden-file coverage must not change ignore rules or ordinary query visibility.
+//! Indexed assertions also check the route, so a full scan cannot hide an
+//! incomplete index or a watcher that never delivered an update. Positive glob
+//! overrides are compared by results because they can widen the indexed corpus.
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::{NamedTempFile, TempDir};
+use tgrep_core::meta::IndexMeta;
+
+const NEEDLE: &str = "needle";
+const WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+const INNER_IGNORE: &str = "private.txt\n.private.txt\n";
+const MATCHING_FILES: &[(&str, &str)] = &[
+    (
+        "visible.txt",
+        "needle visible first\nneedle visible second\n",
+    ),
+    ("nested/visible.txt", "needle nested visible\n"),
+    (".secret.txt", "needle secret first\nneedle secret second\n"),
+    (".github/settings.txt", "needle github settings\n"),
+    (".github/.nested/deep.txt", "needle github nested\n"),
+    ("nested/.hidden/deep.txt", "needle nested hidden\n"),
+];
+
+fn path_under(root: &Path, relative: &str) -> PathBuf {
+    relative
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .fold(root.to_path_buf(), |path, part| path.join(part))
+}
+
+fn write_file(root: &Path, relative: &str, contents: &str) {
+    let path = path_under(root, relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, contents).unwrap();
+}
+
+#[cfg(windows)]
+fn set_hidden_attribute(root: &Path, relative: &str, hidden: bool) {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::fs::MetadataExt;
+    use windows_sys::Win32::Storage::FileSystem::{FILE_ATTRIBUTE_HIDDEN, SetFileAttributesW};
+
+    let path = path_under(root, relative);
+    let attributes = fs::metadata(&path).unwrap().file_attributes();
+    let attributes = if hidden {
+        attributes | FILE_ATTRIBUTE_HIDDEN
+    } else {
+        attributes & !FILE_ATTRIBUTE_HIDDEN
+    };
+    let wide: Vec<_> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    // The NUL-terminated path remains allocated throughout the call.
+    let result = unsafe { SetFileAttributesW(wide.as_ptr(), attributes) };
+    assert_ne!(
+        result,
+        0,
+        "cannot set hidden={hidden} on {}: {}",
+        path.display(),
+        std::io::Error::last_os_error()
+    );
+}
+
+struct Fixture {
+    temp: TempDir,
+    root: PathBuf,
+    index: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let target = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("target");
+        fs::create_dir_all(&target).unwrap();
+        let temp = tempfile::Builder::new()
+            .prefix("indexed-hidden-")
+            .tempdir_in(target)
+            .unwrap();
+        let root = temp.path().join("repo");
+        // The ignore crate recognizes this repository boundary without git init.
+        fs::create_dir_all(root.join(".git")).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let index = temp.path().join("index");
+        let fixture = Self { temp, root, index };
+
+        for &(path, contents) in MATCHING_FILES {
+            fixture.write(path, contents);
+        }
+        fixture.write("notes.txt", "no matching token here\n");
+        fixture.write(".notes.txt", "no matching token here either\n");
+        fixture.write(
+            ".gitignore",
+            "ignored.txt\n.ignored.txt\nignored-tree/\n.ignored-tree/\n",
+        );
+        fixture.write(".github/.gitignore", INNER_IGNORE);
+        for path in [
+            "ignored.txt",
+            ".ignored.txt",
+            "ignored-tree/visible.txt",
+            "ignored-tree/.secret.txt",
+            ".ignored-tree/visible.txt",
+            ".github/private.txt",
+            ".github/.private.txt",
+            ".git/private.txt",
+        ] {
+            fixture.write(path, "needle ignored content must not leak\n");
+        }
+        fixture
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        write_file(&self.root, relative, contents);
+    }
+
+    fn remove(&self, relative: &str) {
+        fs::remove_file(path_under(&self.root, relative)).unwrap();
+    }
+
+    fn rename(&self, old: &str, new: &str) {
+        fs::rename(path_under(&self.root, old), path_under(&self.root, new)).unwrap();
+    }
+
+    fn build(&self, force: bool) {
+        let mut command = Command::cargo_bin("tgrep").unwrap();
+        command
+            .current_dir(&self.root)
+            .timeout(WAIT_TIMEOUT)
+            .arg("index")
+            .arg(&self.root)
+            .arg("--index-path")
+            .arg(&self.index);
+        if force {
+            command.arg("--force");
+        }
+        // Deliberately never pass index --hidden.
+        command.assert().success();
+        self.assert_complete_coverage();
+    }
+
+    fn assert_complete_coverage(&self) {
+        let meta = IndexMeta::load(&self.index).unwrap();
+        assert!(meta.complete, "index publication is incomplete: {meta:?}");
+        assert!(
+            meta.hidden_complete,
+            "hidden coverage is unproven: {meta:?}"
+        );
+    }
+
+    fn query(
+        &self,
+        scope: &str,
+        pattern: &str,
+        mode: OutputMode,
+        hidden: bool,
+        no_index: bool,
+    ) -> Output {
+        let mut command = Command::cargo_bin("tgrep").unwrap();
+        command
+            .current_dir(&self.root)
+            .timeout(WAIT_TIMEOUT)
+            .arg("--index-path")
+            .arg(&self.index);
+        if let Some(flag) = mode.flag() {
+            command.arg(flag);
+        }
+        if hidden {
+            command.arg("--hidden");
+        }
+        // Preserve the Copilot argv shape, including the negative-only glob.
+        command.args(["--glob", "!.git", "--with-filename", "--stats"]);
+        if no_index {
+            command.arg("--no-index");
+        }
+        command.arg("--");
+        if mode != OutputMode::Files {
+            command.arg(pattern);
+        }
+        command
+            .arg(path_under(&self.root, scope))
+            .output()
+            .expect("failed to run tgrep query")
+    }
+
+    fn relative_output_path(&self, printed: &str) -> String {
+        let printed = printed.replace('\\', "/");
+        let root = self.root.to_string_lossy().replace('\\', "/");
+        let printed = printed.strip_prefix("//?/").unwrap_or(&printed);
+        let root = root.strip_prefix("//?/").unwrap_or(&root);
+        printed
+            .strip_prefix(&format!("{root}/"))
+            .unwrap_or_else(|| panic!("output path {printed:?} is not under {root:?}"))
+            .to_owned()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OutputMode {
+    Content,
+    FilesWithMatches,
+    FilesWithMatchesShort,
+    Count,
+    CountShort,
+    Json,
+    Files,
+}
+
+impl OutputMode {
+    fn flag(self) -> Option<&'static str> {
+        match self {
+            Self::Content => None,
+            Self::FilesWithMatches => Some("--files-with-matches"),
+            Self::FilesWithMatchesShort => Some("-l"),
+            Self::Count => Some("--count"),
+            Self::CountShort => Some("-c"),
+            Self::Json => Some("--json"),
+            Self::Files => Some("--files"),
+        }
+    }
+
+    fn paths_only(self) -> bool {
+        matches!(
+            self,
+            Self::FilesWithMatches | Self::FilesWithMatchesShort | Self::Files
+        )
+    }
+}
+
+const OUTPUT_MODES: &[OutputMode] = &[
+    OutputMode::Content,
+    OutputMode::FilesWithMatches,
+    OutputMode::FilesWithMatchesShort,
+    OutputMode::Count,
+    OutputMode::CountShort,
+    OutputMode::Json,
+    OutputMode::Files,
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Backend {
+    Local,
+    Server,
+    BruteForce,
+    // Expect a scan without requesting --no-index.
+    Fallback,
+}
+
+impl Backend {
+    fn matches(self, mode: OutputMode, output: &Output) -> bool {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if mode == OutputMode::Files {
+            let route = match self {
+                Self::Local => "(via local index)",
+                Self::Server => "(via server)",
+                Self::BruteForce | Self::Fallback => "(via filesystem walk)",
+            };
+            return stderr.contains("Filename search completed")
+                && stderr.contains(route)
+                && !stderr.contains("Brute-force search completed");
+        }
+        match self {
+            Self::Local => {
+                stderr.contains("Search completed")
+                    && stderr.contains("Query plan:")
+                    && !stderr.contains("(via server)")
+                    && !stderr.contains("Brute-force search completed")
+            }
+            Self::Server => {
+                stderr.contains("(via server)") && !stderr.contains("Brute-force search completed")
+            }
+            Self::BruteForce | Self::Fallback => {
+                stderr.contains("Brute-force search completed")
+                    && !stderr.contains("(via server)")
+                    && !stderr.contains("Query plan:")
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Corpus {
+    matches: BTreeMap<String, usize>,
+    files: BTreeSet<String>,
+    hidden_attributes: BTreeSet<String>,
+}
+
+impl Corpus {
+    fn initial() -> Self {
+        let matches: BTreeMap<_, _> = MATCHING_FILES
+            .iter()
+            .map(|&(path, contents)| {
+                (
+                    path.to_owned(),
+                    contents
+                        .lines()
+                        .filter(|line| line.contains(NEEDLE))
+                        .count(),
+                )
+            })
+            .collect();
+        let mut files: BTreeSet<_> = matches.keys().cloned().collect();
+        files.extend(
+            [
+                "notes.txt",
+                ".notes.txt",
+                ".gitignore",
+                ".github/.gitignore",
+            ]
+            .map(str::to_owned),
+        );
+        Self {
+            matches,
+            files,
+            hidden_attributes: BTreeSet::new(),
+        }
+    }
+
+    fn add(&mut self, path: &str, count: usize) {
+        self.matches.insert(path.to_owned(), count);
+        self.files.insert(path.to_owned());
+    }
+
+    fn remove(&mut self, path: &str) {
+        self.matches.remove(path);
+        self.files.remove(path);
+        self.hidden_attributes.remove(path);
+    }
+
+    fn expected(&self, scope: &str, hidden: bool, mode: OutputMode) -> BTreeMap<String, usize> {
+        let paths = if mode == OutputMode::Files {
+            self.files.iter().map(|path| (path.clone(), 1)).collect()
+        } else {
+            self.matches.clone()
+        };
+        let prefix = if scope.is_empty() {
+            String::new()
+        } else {
+            format!("{scope}/")
+        };
+        let hidden_attributes: Vec<_> = self
+            .hidden_attributes
+            .iter()
+            .filter_map(|entry| entry.strip_prefix(&prefix))
+            .collect();
+        paths
+            .into_iter()
+            .filter(|(path, _)| {
+                path.strip_prefix(&prefix).is_some_and(|relative| {
+                    hidden
+                        || (!relative.split('/').any(|part| part.starts_with('.'))
+                            && !hidden_attributes.iter().any(|entry| {
+                                relative == *entry || relative.starts_with(&format!("{entry}/"))
+                            }))
+                })
+            })
+            .map(|(path, count)| (path, if mode.paths_only() { 1 } else { count }))
+            .collect()
+    }
+}
+
+fn parsed_output(fixture: &Fixture, mode: OutputMode, output: &Output) -> BTreeMap<String, usize> {
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let mut paths = BTreeMap::new();
+    let mut summaries = 0;
+    for line in stdout.lines() {
+        let (printed, count) = match mode {
+            OutputMode::Json => {
+                let record: Value = serde_json::from_str(line).expect("invalid JSON output");
+                match record["type"].as_str().expect("missing JSON record type") {
+                    "match" => {
+                        let text = record["data"]["lines"]["text"]
+                            .as_str()
+                            .expect("missing JSON match text");
+                        assert!(text.contains(NEEDLE), "unexpected match: {record}");
+                        let path = record["data"]["path"]["text"]
+                            .as_str()
+                            .expect("missing JSON match path");
+                        let path = fixture.relative_output_path(path);
+                        *paths.entry(path).or_insert(0) += 1;
+                    }
+                    "summary" => summaries += 1,
+                    "begin" | "end" => {}
+                    kind => panic!("unexpected JSON record type {kind:?}: {record}"),
+                }
+                continue;
+            }
+            OutputMode::Content => {
+                let (path, text) = line.rsplit_once(':').expect("missing content separator");
+                assert!(text.contains(NEEDLE), "unexpected content line: {line}");
+                (path, 1)
+            }
+            OutputMode::Count | OutputMode::CountShort => {
+                let (path, count) = line.rsplit_once(':').expect("missing count separator");
+                (path, count.parse::<usize>().expect("invalid match count"))
+            }
+            _ => (line, 1),
+        };
+        let path = fixture.relative_output_path(printed);
+        if mode == OutputMode::Content {
+            *paths.entry(path).or_insert(0) += count;
+        } else {
+            assert!(
+                paths.insert(path, count).is_none(),
+                "duplicate file in {mode:?} output: {stdout}"
+            );
+        }
+    }
+    if mode == OutputMode::Json {
+        assert_eq!(summaries, 1, "missing or duplicate JSON summary: {stdout}");
+    }
+    paths
+}
+
+fn expected_exit(mode: OutputMode, expected: &BTreeMap<String, usize>) -> i32 {
+    if mode == OutputMode::Files || !expected.is_empty() {
+        0
+    } else {
+        1
+    }
+}
+
+fn assert_query(
+    fixture: &Fixture,
+    corpus: &Corpus,
+    scope: &str,
+    hidden: bool,
+    mode: OutputMode,
+    backend: Backend,
+) {
+    let output = fixture.query(scope, NEEDLE, mode, hidden, backend == Backend::BruteForce);
+    let expected = corpus.expected(scope, hidden, mode);
+    let diagnostics =
+        format!("{backend:?}, {mode:?}, scope={scope:?}, hidden={hidden}\n{output:?}");
+    assert_eq!(
+        output.status.code(),
+        Some(expected_exit(mode, &expected)),
+        "{diagnostics}"
+    );
+    assert!(backend.matches(mode, &output), "{diagnostics}");
+    assert_eq!(
+        parsed_output(fixture, mode, &output),
+        expected,
+        "{diagnostics}"
+    );
+}
+
+fn assert_modes(fixture: &Fixture, corpus: &Corpus, scope: &str, backend: Backend) {
+    for hidden in [false, true] {
+        for &mode in OUTPUT_MODES {
+            assert_query(fixture, corpus, scope, hidden, mode, backend);
+        }
+    }
+}
+
+fn assert_snapshot(fixture: &Fixture, corpus: &Corpus, backend: Backend) {
+    for hidden in [false, true] {
+        for mode in [OutputMode::FilesWithMatches, OutputMode::Files] {
+            assert_query(fixture, corpus, "", hidden, mode, backend);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WatchMode {
+    Disabled,
+    Native,
+    Poll,
+}
+
+impl WatchMode {
+    fn active_name(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Native => "native",
+            Self::Poll => "poll",
+        }
+    }
+}
+
+struct ServerGuard {
+    child: Option<Child>,
+    log: NamedTempFile,
+    port: Option<u16>,
+    mode: WatchMode,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl ServerGuard {
+    fn start(fixture: &Fixture, corpus: &Corpus, mode: WatchMode, hidden: bool) -> Self {
+        let warm_start = fixture.index.join("meta.json").exists()
+            && IndexMeta::load(&fixture.index).unwrap().complete;
+        let log = NamedTempFile::new_in(fixture.temp.path()).unwrap();
+        let mut command = std::process::Command::new(assert_cmd::cargo::cargo_bin("tgrep"));
+        command
+            .current_dir(&fixture.root)
+            .arg("serve")
+            .arg("--index-path")
+            .arg(&fixture.index);
+        match mode {
+            WatchMode::Disabled => command.arg("--no-watch"),
+            WatchMode::Native => command.args(["--watch-mode", "auto"]),
+            WatchMode::Poll => command.args(["--watch-mode", "poll", "--poll-interval", "1"]),
+        };
+        if hidden {
+            command.arg("--hidden");
+        }
+        let child = command
+            .arg(&fixture.root)
+            .stdout(Stdio::null())
+            .stderr(log.as_file().try_clone().unwrap())
+            .spawn()
+            .expect("failed to start tgrep serve");
+        let pid = u64::from(child.id());
+        let mut server = Self {
+            child: Some(child),
+            log,
+            port: None,
+            mode,
+        };
+        let started = Instant::now();
+        let serve_json = fixture.index.join("serve.json");
+        loop {
+            server.assert_running();
+            let observation = match fs::read_to_string(&serve_json) {
+                Ok(data) => {
+                    if let Ok(info) = serde_json::from_str::<Value>(&data)
+                        && info["pid"].as_u64() == Some(pid)
+                        && let Some(port) = info["port"].as_u64()
+                        && let Ok(port) = u16::try_from(port)
+                        && TcpStream::connect(("127.0.0.1", port)).is_ok()
+                    {
+                        server.port = Some(port);
+                        break;
+                    }
+                    data
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => error.to_string(),
+                Err(error) => panic!("cannot read {}: {error}", serve_json.display()),
+            };
+            assert!(
+                started.elapsed() < WAIT_TIMEOUT,
+                "server discovery timed out: {observation}\n{}",
+                server.logs()
+            );
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        loop {
+            server.assert_running();
+            let status = server.rpc("status");
+            let refresh_ready = (!warm_start && mode == WatchMode::Disabled)
+                || (status["last_reconcile_at"].is_u64() && status["reconcile_running"] == false);
+            if has_complete_coverage(&status)
+                && status["watch_mode_active"] == mode.active_name()
+                && refresh_ready
+            {
+                server.assert_mode(&status);
+                break;
+            }
+            assert!(
+                started.elapsed() < WAIT_TIMEOUT,
+                "server bootstrap timed out: {status}\n{}",
+                server.logs()
+            );
+            thread::sleep(Duration::from_millis(100));
+        }
+        wait_for_snapshot(fixture, &mut server, corpus);
+        server
+    }
+
+    fn logs(&self) -> String {
+        fs::read_to_string(self.log.path())
+            .unwrap()
+            .lines()
+            .filter(|line| !line.starts_with("[trace] search:"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn assert_running(&mut self) {
+        let status = self.child.as_mut().unwrap().try_wait().unwrap();
+        assert!(
+            status.is_none(),
+            "server exited unexpectedly: {status:?}\n{}",
+            self.logs()
+        );
+    }
+
+    fn rpc(&self, method: &str) -> Value {
+        let mut stream = TcpStream::connect(("127.0.0.1", self.port.unwrap())).unwrap();
+        stream.set_read_timeout(Some(WAIT_TIMEOUT)).unwrap();
+        stream.set_write_timeout(Some(WAIT_TIMEOUT)).unwrap();
+        let request = serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": method});
+        writeln!(stream, "{request}").unwrap();
+        stream.flush().unwrap();
+        let mut response = String::new();
+        BufReader::new(stream).read_line(&mut response).unwrap();
+        let response: Value = serde_json::from_str(&response).unwrap();
+        assert!(
+            response.get("error").is_none(),
+            "{method} RPC failed: {response}\n{}",
+            self.logs()
+        );
+        response.get("result").expect("missing RPC result").clone()
+    }
+
+    fn assert_mode(&self, status: &Value) {
+        assert_eq!(
+            status["watch_mode_active"],
+            self.mode.active_name(),
+            "{status}"
+        );
+        assert_eq!(
+            status["watcher_active"],
+            self.mode == WatchMode::Native,
+            "{status}"
+        );
+        assert!(status["last_reconcile_error"].is_null(), "{status}");
+    }
+
+    fn stop(mut self) {
+        let child = self.child.as_mut().unwrap();
+        child.kill().expect("failed to stop owned server process");
+        child.wait().expect("failed to reap owned server process");
+        self.child = None;
+    }
+}
+
+fn has_complete_coverage(status: &Value) -> bool {
+    let indexing = status["indexing"]
+        .as_bool()
+        .expect("missing indexing status");
+    let hidden_complete = status["hidden_complete"]
+        .as_bool()
+        .expect("missing hidden coverage status");
+    assert!(
+        !indexing || !hidden_complete,
+        "partial server advertised complete hidden coverage: {status}"
+    );
+    !indexing && hidden_complete
+}
+
+fn wait_for_snapshot(fixture: &Fixture, server: &mut ServerGuard, corpus: &Corpus) {
+    let started = Instant::now();
+    loop {
+        server.assert_running();
+        let mut failures = Vec::new();
+        for hidden in [false, true] {
+            for mode in [OutputMode::FilesWithMatches, OutputMode::Files] {
+                let output = fixture.query("", NEEDLE, mode, hidden, false);
+                let actual = parsed_output(fixture, mode, &output);
+                let expected = corpus.expected("", hidden, mode);
+                if output.status.code() != Some(expected_exit(mode, &expected))
+                    || !Backend::Server.matches(mode, &output)
+                    || actual != expected
+                {
+                    failures.push(format!(
+                        "{mode:?}, hidden={hidden}: expected {expected:?}, got {actual:?}\n\
+                         status={:?}, stderr={}",
+                        output.status.code(),
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
+            }
+        }
+        let status = server.rpc("status");
+        if !has_complete_coverage(&status) {
+            failures.push(format!("server coverage is not ready: {status}"));
+        }
+        if failures.is_empty() {
+            server.assert_mode(&status);
+            return;
+        }
+        assert!(
+            started.elapsed() < WAIT_TIMEOUT,
+            "server did not reach expected snapshot:\n{}\n{}",
+            failures.join("\n"),
+            server.logs()
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn wait_for_pattern(
+    fixture: &Fixture,
+    server: &mut ServerGuard,
+    pattern: &str,
+    expected_paths: &[&str],
+) {
+    let expected: BTreeMap<_, _> = expected_paths
+        .iter()
+        .map(|path| ((*path).to_owned(), 1))
+        .collect();
+    let mode = OutputMode::FilesWithMatches;
+    let started = Instant::now();
+    loop {
+        server.assert_running();
+        let output = fixture.query("", pattern, mode, true, false);
+        if output.status.code() == Some(expected_exit(mode, &expected))
+            && Backend::Server.matches(mode, &output)
+            && parsed_output(fixture, mode, &output) == expected
+        {
+            return;
+        }
+        assert!(
+            started.elapsed() < WAIT_TIMEOUT,
+            "pattern {pattern:?} did not reach {expected:?} via server:\n{output:?}\n{}",
+            server.logs()
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn default_index_serves_hidden_copilot_formats_without_disabling_ignores() {
+    let fixture = Fixture::new();
+    let corpus = Corpus::initial();
+    fixture.build(false);
+    assert_modes(&fixture, &corpus, "", Backend::Local);
+    assert_modes(&fixture, &corpus, "", Backend::BruteForce);
+}
+
+#[test]
+fn ready_server_serves_hidden_formats_and_accepts_redundant_hidden_flag() {
+    for hidden in [false, true] {
+        let fixture = Fixture::new();
+        let corpus = Corpus::initial();
+        // Start without an index: serve, not a preceding index command, owns
+        // the initial hidden-inclusive build in both variants.
+        let server = ServerGuard::start(&fixture, &corpus, WatchMode::Disabled, hidden);
+        assert_modes(&fixture, &corpus, "", Backend::Server);
+        for mode in [OutputMode::Content, OutputMode::Files] {
+            assert_query(&fixture, &corpus, "", true, mode, Backend::BruteForce);
+        }
+        server.stop();
+        fixture.assert_complete_coverage();
+        assert_snapshot(&fixture, &corpus, Backend::Local);
+    }
+}
+
+#[test]
+fn unproven_indexes_scan_scoped_hidden_roots_until_server_upgrade() {
+    let fixture = Fixture::new();
+    let mut corpus = Corpus::initial();
+    fixture.build(false);
+    let meta_path = fixture.index.join("meta.json");
+    let original: Value = serde_json::from_slice(&fs::read(&meta_path).unwrap()).unwrap();
+
+    let late_paths = [
+        ".github/late-visible.txt",
+        ".github/.late-hidden.txt",
+        ".github/.late-directory/child.txt",
+        "late-outside.txt",
+        ".late-outside.txt",
+    ];
+    for path in late_paths {
+        fixture.write(path, "needle added_after_the_index\n");
+    }
+    for mode in [OutputMode::FilesWithMatches, OutputMode::Files] {
+        assert_query(&fixture, &corpus, ".github", true, mode, Backend::Local);
+    }
+    for path in late_paths {
+        corpus.add(path, 1);
+    }
+
+    for (coverage, complete, hidden_complete) in [
+        ("incomplete", false, Some(true)),
+        ("false", true, Some(false)),
+        ("missing", true, None),
+    ] {
+        let mut meta = original.clone();
+        meta["complete"] = Value::Bool(complete);
+        if let Some(hidden_complete) = hidden_complete {
+            meta["hidden_complete"] = Value::Bool(hidden_complete);
+        } else {
+            let fields = meta.as_object_mut().unwrap();
+            fields.remove("hidden_complete");
+            fields.remove("visibility");
+        }
+        fs::write(&meta_path, serde_json::to_vec(&meta).unwrap()).unwrap();
+        let loaded = IndexMeta::load(&fixture.index).unwrap();
+        assert!(
+            !loaded.complete || !loaded.hidden_complete,
+            "{coverage}: capability must remain unproven"
+        );
+        eprintln!("scoped fallback coverage: {coverage}");
+        for hidden in [false, true] {
+            for mode in [
+                OutputMode::Content,
+                OutputMode::FilesWithMatches,
+                OutputMode::Files,
+            ] {
+                assert_query(
+                    &fixture,
+                    &corpus,
+                    ".github",
+                    hidden,
+                    mode,
+                    Backend::Fallback,
+                );
+            }
+        }
+    }
+
+    // The final variant is complete but lacks both hidden capability and
+    // visibility evidence. Startup must reconcile, not merely flip a flag.
+    let assert_scope = |backend| {
+        for hidden in [false, true] {
+            for mode in [
+                OutputMode::Content,
+                OutputMode::FilesWithMatches,
+                OutputMode::Files,
+            ] {
+                assert_query(&fixture, &corpus, ".github", hidden, mode, backend);
+            }
+        }
+    };
+    let server = ServerGuard::start(&fixture, &corpus, WatchMode::Disabled, false);
+    assert_scope(Backend::Server);
+    server.stop();
+    fixture.assert_complete_coverage();
+    assert_scope(Backend::Local);
+}
+
+#[test]
+fn explicitly_named_hidden_root_uses_the_parent_custom_index() {
+    let fixture = Fixture::new();
+    let corpus = Corpus::initial();
+    fixture.build(false);
+    for backend in [Backend::Local, Backend::Server] {
+        let _server = (backend == Backend::Server)
+            .then(|| ServerGuard::start(&fixture, &corpus, WatchMode::Disabled, false));
+        // settings.txt is visible relative to .github; .nested/deep.txt and
+        // .gitignore still require --hidden. Siblings must never escape scope.
+        assert_modes(&fixture, &corpus, ".github", backend);
+        for mode in [OutputMode::FilesWithMatches, OutputMode::Files] {
+            assert_query(&fixture, &corpus, "nested/.hidden", false, mode, backend);
+        }
+        assert_snapshot(&fixture, &corpus, backend);
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_hidden_attributes_retain_visibility_and_respect_explicit_roots() {
+    let fixture = Fixture::new();
+    let mut corpus = Corpus::initial();
+    for path in [
+        "attribute-secret.txt",
+        "attribute-directory/visible.txt",
+        "attribute-directory/secret.txt",
+        "attribute-directory/.dot.txt",
+    ] {
+        fixture.write(path, "needle native_hidden_attribute\n");
+        corpus.add(path, 1);
+    }
+    let hidden_entries = [
+        "attribute-secret.txt",
+        "attribute-directory",
+        "attribute-directory/secret.txt",
+    ];
+    for path in hidden_entries {
+        set_hidden_attribute(&fixture.root, path, true);
+        corpus.hidden_attributes.insert(path.to_owned());
+    }
+    fixture.build(false);
+
+    let assert_scopes = |corpus: &Corpus, backend| {
+        for scope in ["", "attribute-directory"] {
+            for hidden in [false, true] {
+                for mode in [OutputMode::FilesWithMatches, OutputMode::Files] {
+                    assert_query(&fixture, corpus, scope, hidden, mode, backend);
+                }
+            }
+        }
+    };
+    assert_scopes(&corpus, Backend::Local);
+    assert_scopes(&corpus, Backend::BruteForce);
+    let server = ServerGuard::start(&fixture, &corpus, WatchMode::Disabled, false);
+    assert_scopes(&corpus, Backend::Server);
+
+    for path in hidden_entries {
+        set_hidden_attribute(&fixture.root, path, false);
+    }
+    let mut live_corpus = corpus.clone();
+    live_corpus.hidden_attributes.clear();
+    // Attribute changes after a no-watch startup must not cause per-query
+    // stat-based visibility changes. Only a fresh scan sees the live attributes.
+    assert_scopes(&corpus, Backend::Server);
+    assert_scopes(&live_corpus, Backend::BruteForce);
+    server.stop();
+    assert_scopes(&corpus, Backend::Local);
+
+    fixture.build(true);
+    assert_scopes(&live_corpus, Backend::Local);
+}
+
+fn exercise_hidden_updates(mode: WatchMode) {
+    let fixture = Fixture::new();
+    let mut corpus = Corpus::initial();
+    fixture.build(false);
+    let mut server = ServerGuard::start(&fixture, &corpus, mode, false);
+
+    for (path, contents) in [
+        (".created.txt", "needle hidden_create_before\n"),
+        (".github/live.txt", "needle github_live\n"),
+        (".github/.live.txt", "needle github_dot_live\n"),
+        ("nested/.moving/child.txt", "needle moving_visible_child\n"),
+        ("nested/.moving/.child.txt", "needle moving_hidden_child\n"),
+    ] {
+        fixture.write(path, contents);
+        corpus.add(path, 1);
+    }
+    fixture.write(".github/private.txt", "needle ignored_edit_must_not_leak\n");
+    fixture.write(
+        ".ignored-tree/new.txt",
+        "needle ignored_create_must_not_leak\n",
+    );
+    wait_for_snapshot(&fixture, &mut server, &corpus);
+    wait_for_pattern(
+        &fixture,
+        &mut server,
+        "hidden_create_before",
+        &[".created.txt"],
+    );
+
+    fixture.write(
+        ".created.txt",
+        "needle hidden_edit_after_with_a_different_size\n",
+    );
+    fixture.remove(".secret.txt");
+    corpus.remove(".secret.txt");
+    fixture.rename("nested/.moving", "nested/moved");
+    for name in ["child.txt", ".child.txt"] {
+        corpus.remove(&format!("nested/.moving/{name}"));
+        corpus.add(&format!("nested/moved/{name}"), 1);
+    }
+    // Filename membership proves deletion and rename, not merely that search
+    // skipped a path which no longer exists on disk.
+    wait_for_snapshot(&fixture, &mut server, &corpus);
+    wait_for_pattern(
+        &fixture,
+        &mut server,
+        "hidden_edit_after_with_a_different_size",
+        &[".created.txt"],
+    );
+    wait_for_pattern(&fixture, &mut server, "hidden_create_before", &[]);
+
+    fixture.write(
+        ".github/.gitignore",
+        &format!("{INNER_IGNORE}live.txt\n.pending/\n"),
+    );
+    fixture.write(".github/.ignore", ".live.txt\n");
+    corpus.remove(".github/live.txt");
+    corpus.remove(".github/.live.txt");
+    corpus.files.insert(".github/.ignore".to_owned());
+    wait_for_snapshot(&fixture, &mut server, &corpus);
+
+    fixture.write(".github/live.txt", "needle changed_while_gitignored\n");
+    fixture.write(".github/.live.txt", "needle changed_while_dot_ignored\n");
+    fixture.write(
+        ".github/.pending/new.txt",
+        "needle hidden_created_while_ignored\n",
+    );
+    fixture.write(
+        ".created.txt",
+        "needle ignore_event_positive_control_longer\n",
+    );
+    wait_for_pattern(
+        &fixture,
+        &mut server,
+        "ignore_event_positive_control_longer",
+        &[".created.txt"],
+    );
+    wait_for_snapshot(&fixture, &mut server, &corpus);
+
+    fixture.write(".github/.gitignore", INNER_IGNORE);
+    fixture.remove(".github/.ignore");
+    corpus.files.remove(".github/.ignore");
+    for path in [
+        ".github/live.txt",
+        ".github/.live.txt",
+        ".github/.pending/new.txt",
+    ] {
+        corpus.add(path, 1);
+    }
+    wait_for_snapshot(&fixture, &mut server, &corpus);
+    wait_for_pattern(
+        &fixture,
+        &mut server,
+        "hidden_created_while_ignored",
+        &[".github/.pending/new.txt"],
+    );
+
+    // A synchronous reload establishes a durable pre-stop snapshot. Offline
+    // mutations below can only be learned by the restarted server.
+    server.rpc("reload");
+    wait_for_snapshot(&fixture, &mut server, &corpus);
+    server.stop();
+
+    fixture.remove(".created.txt");
+    corpus.remove(".created.txt");
+    fixture.write(".offline.txt", "needle offline_hidden_create\n");
+    corpus.add(".offline.txt", 1);
+    fixture.write(
+        ".github/settings.txt",
+        "needle offline_hidden_edit_with_different_size\n",
+    );
+    fixture.rename("nested/moved", "nested/.returned");
+    for name in ["child.txt", ".child.txt"] {
+        corpus.remove(&format!("nested/moved/{name}"));
+        corpus.add(&format!("nested/.returned/{name}"), 1);
+    }
+    fixture.write(".github/.gitignore", &format!("{INNER_IGNORE}live.txt\n"));
+    corpus.remove(".github/live.txt");
+
+    let mut server = ServerGuard::start(&fixture, &corpus, mode, false);
+    wait_for_pattern(
+        &fixture,
+        &mut server,
+        "offline_hidden_edit_with_different_size",
+        &[".github/settings.txt"],
+    );
+    wait_for_pattern(
+        &fixture,
+        &mut server,
+        "ignore_event_positive_control_longer",
+        &[],
+    );
+}
+
+#[test]
+fn native_watcher_tracks_hidden_updates_ignore_transitions_and_restart() {
+    exercise_hidden_updates(WatchMode::Native);
+}
+
+#[test]
+fn polling_tracks_hidden_updates_ignore_transitions_and_restart() {
+    exercise_hidden_updates(WatchMode::Poll);
+}
+
+#[test]
+fn custom_index_inside_source_is_excluded_from_build_rebuild_and_reload() {
+    for name in ["custom-index", ".custom-index"] {
+        let mut fixture = Fixture::new();
+        fixture.index = fixture.root.join(name);
+        let corpus = Corpus::initial();
+
+        for force in [false, true] {
+            for path in ["visible.txt", ".secret.txt", ".nested/child.txt"] {
+                write_file(&fixture.index, path, "needle index_output_must_not_leak\n");
+            }
+            fixture.build(force);
+            assert_snapshot(&fixture, &corpus, Backend::Local);
+        }
+
+        for path in ["visible.txt", ".secret.txt", ".nested/child.txt"] {
+            write_file(&fixture.index, path, "needle index_output_must_not_leak\n");
+        }
+        let mut server = ServerGuard::start(&fixture, &corpus, WatchMode::Disabled, false);
+        server.rpc("reload");
+        wait_for_snapshot(&fixture, &mut server, &corpus);
+        server.stop();
+        assert_snapshot(&fixture, &corpus, Backend::Local);
+    }
+}

--- a/tgrep-cli/tests/indexed_hidden.rs
+++ b/tgrep-cli/tests/indexed_hidden.rs
@@ -15,6 +15,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::{NamedTempFile, TempDir};
 use tgrep_core::meta::IndexMeta;
+use tgrep_core::path_index::{self, EXTRA_PATHS_FILENAME};
 
 const NEEDLE: &str = "needle";
 const WAIT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -1079,5 +1080,210 @@ fn custom_index_inside_source_is_excluded_from_build_rebuild_and_reload() {
         wait_for_snapshot(&fixture, &mut server, &corpus);
         server.stop();
         assert_snapshot(&fixture, &corpus, Backend::Local);
+    }
+}
+
+#[test]
+fn hidden_fallback_walks_exclude_custom_index_storage() {
+    for name in ["custom-index", ".custom-index"] {
+        let mut fixture = Fixture::new();
+        fixture.index = fixture.root.join(name);
+        fixture.write(&format!("{name}-sibling/visible.txt"), "needle sibling\n");
+        let query = |mode: OutputMode, hidden: bool, args: &[&str]| {
+            let mut command = Command::cargo_bin("tgrep").unwrap();
+            command
+                .current_dir(&fixture.root)
+                .timeout(WAIT_TIMEOUT)
+                .arg("--index-path")
+                .arg(Path::new("nested").join("..").join(name))
+                .args(["--with-filename", "--stats"])
+                .arg(mode.flag().unwrap())
+                .args(args);
+            if hidden {
+                command.arg("--hidden");
+            }
+            command.arg("--");
+            if mode != OutputMode::Files {
+                command.arg(NEEDLE);
+            }
+            command.arg(&fixture.root).output().unwrap()
+        };
+
+        // Capture the eligible source corpus before any storage exists, including
+        // the ignored files that a positive glob can explicitly reinclude.
+        let mut baselines = Vec::new();
+        for args in [&[][..], &["--no-index"][..], &["--glob", "*.txt"][..]] {
+            for hidden in [false, true] {
+                for mode in [OutputMode::FilesWithMatches, OutputMode::Files] {
+                    let output = query(mode, hidden, args);
+                    assert!(output.status.success(), "{output:?}");
+                    let paths = parsed_output(&fixture, mode, &output);
+                    assert!(paths.contains_key("visible.txt"), "{paths:?}");
+                    baselines.push((args, hidden, mode, paths));
+                }
+            }
+        }
+
+        fixture.build(false);
+        for path in [
+            "visible.txt",
+            ".secret.txt",
+            ".staging/visible.txt",
+            ".retired/generation/visible.txt",
+        ] {
+            write_file(&fixture.index, path, "needle index_output_must_not_leak\n");
+        }
+        let sidecar_path = fixture.index.join(EXTRA_PATHS_FILENAME);
+        let original_sidecar = fs::read(&sidecar_path).unwrap();
+        let filename_index = path_index::read_filename_index(&fixture.index)
+            .unwrap()
+            .unwrap();
+        let visibility = filename_index.visibility.unwrap();
+        for coverage in ["complete", "missing", "mismatched"] {
+            fs::write(&sidecar_path, &original_sidecar).unwrap();
+            match coverage {
+                "missing" => fs::remove_file(&sidecar_path).unwrap(),
+                "mismatched" => path_index::write_extra_paths_with_visibility(
+                    &fixture.index,
+                    &filename_index.paths,
+                    &visibility.paths,
+                    [0; 32],
+                    true,
+                )
+                .unwrap(),
+                _ => {}
+            }
+            for (args, hidden, mode, expected) in &baselines {
+                let output = query(*mode, *hidden, args);
+                let diagnostic =
+                    format!("{name}, {coverage}, {args:?}, hidden={hidden}: {output:?}");
+                assert!(output.status.success(), "{diagnostic}");
+                let backend = if coverage == "complete" && args.is_empty() {
+                    Backend::Local
+                } else {
+                    Backend::Fallback
+                };
+                assert!(backend.matches(*mode, &output), "{diagnostic}");
+                assert_eq!(
+                    parsed_output(&fixture, *mode, &output),
+                    *expected,
+                    "{diagnostic}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn hidden_local_status_requires_coherent_index_coverage() {
+    let fixture = Fixture::new();
+    fixture.build(false);
+    let original_meta = IndexMeta::load(&fixture.index).unwrap();
+    let sidecar_path = fixture.index.join(EXTRA_PATHS_FILENAME);
+    let original_sidecar = fs::read(&sidecar_path).unwrap();
+    let file_table_path = fixture.index.join("files.bin");
+    let original_file_table = fs::read(&file_table_path).unwrap();
+    let filename_index = path_index::read_filename_index(&fixture.index)
+        .unwrap()
+        .unwrap();
+    let visibility = filename_index.visibility.unwrap();
+    let indexed_corpus = Corpus::initial();
+    let mut live_corpus = Corpus::initial();
+    fixture.write(".late.txt", "needle added_after_the_index\n");
+    live_corpus.add(".late.txt", 1);
+
+    for coverage in [
+        "complete",
+        "partial",
+        "hidden-incomplete",
+        "legacy-format",
+        "missing-metadata-id",
+        "mismatched-metadata-id",
+        "missing-sidecar",
+        "legacy-sidecar",
+        "malformed-sidecar",
+        "incomplete-sidecar",
+        "mismatched-sidecar",
+        "missing-file-table",
+        "malformed-file-table",
+        "restored",
+    ] {
+        let mut meta = original_meta.clone();
+        fs::write(&sidecar_path, &original_sidecar).unwrap();
+        fs::write(&file_table_path, &original_file_table).unwrap();
+        match coverage {
+            "partial" => meta.complete = false,
+            "hidden-incomplete" => meta.hidden_complete = false,
+            "legacy-format" => meta.version -= 1,
+            "missing-metadata-id" => meta.file_table_id = None,
+            "mismatched-metadata-id" => meta.file_table_id = Some([0; 32]),
+            "missing-sidecar" => fs::remove_file(&sidecar_path).unwrap(),
+            "legacy-sidecar" => {
+                path_index::write_extra_paths(&fixture.index, &filename_index.paths).unwrap();
+            }
+            "malformed-sidecar" => fs::write(&sidecar_path, b"invalid sidecar").unwrap(),
+            "incomplete-sidecar" | "mismatched-sidecar" => {
+                path_index::write_extra_paths_with_visibility(
+                    &fixture.index,
+                    &filename_index.paths,
+                    &visibility.paths,
+                    if coverage == "mismatched-sidecar" {
+                        [0; 32]
+                    } else {
+                        visibility.file_table_id
+                    },
+                    coverage != "incomplete-sidecar",
+                )
+                .unwrap();
+            }
+            "missing-file-table" => fs::remove_file(&file_table_path).unwrap(),
+            "malformed-file-table" => {
+                fs::write(&file_table_path, b"invalid file table").unwrap();
+            }
+            _ => {}
+        }
+        meta.save(&fixture.index).unwrap();
+        let complete = matches!(coverage, "complete" | "restored");
+        let expected_label = if complete {
+            "Hidden coverage: complete"
+        } else {
+            "Hidden coverage: unavailable (queries scan)"
+        };
+        let output = Command::cargo_bin("tgrep")
+            .unwrap()
+            .timeout(WAIT_TIMEOUT)
+            .arg("status")
+            .arg(&fixture.root)
+            .arg("--index-path")
+            .arg(&fixture.index)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{coverage}: {output:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains(expected_label),
+            "{coverage}: {output:?}"
+        );
+        // A damaged core index is an error, not a coverage-driven scan fallback.
+        if matches!(coverage, "missing-file-table" | "malformed-file-table") {
+            continue;
+        }
+        for mode in [OutputMode::FilesWithMatches, OutputMode::Files] {
+            assert_query(
+                &fixture,
+                if complete {
+                    &indexed_corpus
+                } else {
+                    &live_corpus
+                },
+                "",
+                true,
+                mode,
+                if complete {
+                    Backend::Local
+                } else {
+                    Backend::Fallback
+                },
+            );
+        }
     }
 }

--- a/tgrep-cli/tests/ripgrep_compat.rs
+++ b/tgrep-cli/tests/ripgrep_compat.rs
@@ -264,6 +264,248 @@ fn with_stats_backends(
     check(&["--index-path", index], "(via server)");
 }
 
+#[test]
+fn indexed_hidden_copilot_modes_keep_visibility_and_ignore_parity() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("testdata");
+    let prefix = format!("{}/", root.to_string_lossy().replace('\\', "/"));
+    let normalize = |path: &str| {
+        let path = path.replace('\\', "/");
+        path.strip_prefix(&prefix).unwrap().to_string()
+    };
+    for path in [".git", ".github/.nested", "ignored-dir"] {
+        fs::create_dir_all(root.join(path)).unwrap();
+    }
+    fs::write(
+        root.join(".gitignore"),
+        "ignored.txt\n.ignored.txt\nignored-dir/\n",
+    )
+    .unwrap();
+    let included = [
+        "visible.txt",
+        ".secret.txt",
+        ".github/settings.txt",
+        ".github/.nested/inner.txt",
+    ];
+    for path in
+        included
+            .iter()
+            .copied()
+            .chain(["ignored.txt", ".ignored.txt", "ignored-dir/child.txt"])
+    {
+        fs::write(root.join(path), "needle\n").unwrap();
+    }
+
+    with_stats_backends(&root, &dir.path().join("idx"), |backend, marker| {
+        for hidden in [false, true] {
+            for mode in [
+                "content",
+                "--files-with-matches",
+                "--count",
+                "--json",
+                "--files",
+            ] {
+                let mut cmd = tgrep();
+                cmd.current_dir(&root).args(backend).args([
+                    "--stats",
+                    "--glob",
+                    "!.git",
+                    "--with-filename",
+                    "--no-heading",
+                    "--color",
+                    "never",
+                ]);
+                if hidden {
+                    cmd.arg("--hidden");
+                }
+                if mode != "content" {
+                    cmd.arg(mode);
+                }
+                cmd.arg("--");
+                if mode != "--files" {
+                    cmd.arg("needle");
+                }
+                let output = cmd.arg(&root).assert().success().get_output().clone();
+                let diagnostic = if mode == "--files" {
+                    match marker {
+                        "Search completed" => "(via local index)",
+                        "(via server)" => "(via server)",
+                        _ => "(via filesystem walk)",
+                    }
+                } else {
+                    marker
+                };
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                assert!(stderr.contains(diagnostic), "{backend:?} {mode}: {stderr}");
+                if marker == "Search completed" && mode != "--files" {
+                    assert!(stderr.contains("Query plan:"), "{stderr}");
+                }
+
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let mut actual: Vec<String> = if mode == "--json" {
+                    stdout
+                        .lines()
+                        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+                        .filter(|row| row["type"] == "match")
+                        .map(|row| normalize(row["data"]["path"]["text"].as_str().unwrap()))
+                        .collect()
+                } else {
+                    stdout.lines().map(normalize).collect()
+                };
+                let mut expected: Vec<String> = included
+                    .iter()
+                    .filter(|path| hidden || **path == "visible.txt")
+                    .map(|path| match mode {
+                        "content" => format!("{path}:needle"),
+                        "--count" => format!("{path}:1"),
+                        _ => path.to_string(),
+                    })
+                    .collect();
+                if hidden && mode == "--files" {
+                    expected.push(".gitignore".to_string());
+                }
+                actual.sort();
+                expected.sort();
+                assert_eq!(actual, expected, "{backend:?} {mode}, hidden={hidden}");
+            }
+        }
+    });
+}
+
+#[test]
+fn indexed_hidden_legacy_and_partial_coverage_scan_until_server_upgrade() {
+    let dir = setup_fixture();
+    let root = dir.path().join("testdata");
+    let prefix = format!("{}/", root.to_string_lossy().replace('\\', "/"));
+    let normalize = |path: &str| {
+        let path = path.replace('\\', "/");
+        path.strip_prefix(&prefix).unwrap().to_string()
+    };
+    let index = dir.path().join("idx");
+    fs::write(root.join("visible.txt"), "needle\n").unwrap();
+    tgrep()
+        .args([
+            "index",
+            root.to_str().unwrap(),
+            "--index-path",
+            index.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let meta_path = index.join("meta.json");
+    let original: serde_json::Value =
+        serde_json::from_slice(&fs::read(&meta_path).unwrap()).unwrap();
+    assert_eq!(original["hidden_complete"], true);
+    fs::write(root.join(".late.txt"), "needle\n").unwrap();
+
+    for coverage in ["mismatched", "missing", "false", "partial"] {
+        let mut meta = original.clone();
+        match coverage {
+            "mismatched" => {
+                meta["file_table_id"] = serde_json::to_value([0u8; 32]).unwrap();
+            }
+            "missing" => {
+                meta.as_object_mut().unwrap().remove("hidden_complete");
+                meta.as_object_mut().unwrap().remove("visibility");
+            }
+            "false" => meta["hidden_complete"] = serde_json::json!(false),
+            _ => meta["complete"] = serde_json::json!(false),
+        }
+        fs::write(&meta_path, serde_json::to_vec(&meta).unwrap()).unwrap();
+        let output = tgrep()
+            .args(["--index-path", index.to_str().unwrap()])
+            .args([
+                "--files-with-matches",
+                "--hidden",
+                "--glob",
+                "!.git",
+                "--with-filename",
+                "--stats",
+                "--",
+                "needle",
+            ])
+            .arg(&root)
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Brute-force search completed"))
+            .get_output()
+            .clone();
+        let mut paths: Vec<_> = String::from_utf8(output.stdout)
+            .unwrap()
+            .lines()
+            .map(normalize)
+            .collect();
+        paths.sort();
+        assert_eq!(paths, [".late.txt", "visible.txt"], "{coverage}");
+        tgrep()
+            .args(["--index-path", index.to_str().unwrap()])
+            .args(["--files", "--hidden", "--glob", "!.git", "--stats", "--"])
+            .arg(&root)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(".late.txt"))
+            .stderr(predicate::str::contains("(via filesystem walk)"));
+    }
+
+    let server = start_passthru_server(&root, &index);
+    let info: serde_json::Value =
+        serde_json::from_slice(&fs::read(index.join("serve.json")).unwrap()).unwrap();
+    let port = info["port"].as_u64().unwrap() as u16;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let response =
+            send_rpc_request(port, r#"{"jsonrpc":"2.0","method":"status","id":0}"#).unwrap();
+        let status: serde_json::Value = serde_json::from_str(&response).unwrap();
+        if status["result"]["hidden_complete"] == true {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "coverage did not upgrade: {status}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let mut server = Some(server);
+    for marker in ["(via server)", "Query plan:"] {
+        if marker == "Query plan:" {
+            drop(server.take());
+        }
+        let output = tgrep()
+            .args(["--index-path", index.to_str().unwrap()])
+            .args([
+                "--files-with-matches",
+                "--hidden",
+                "--glob",
+                "!.git",
+                "--with-filename",
+                "--sort",
+                "path",
+                "--stats",
+                "--",
+                "needle",
+            ])
+            .arg(&root)
+            .assert()
+            .success()
+            .stderr(predicate::str::contains(marker))
+            .stderr(predicate::str::contains("Brute-force search completed").not())
+            .get_output()
+            .clone();
+        assert_eq!(
+            String::from_utf8(output.stdout)
+                .unwrap()
+                .lines()
+                .map(normalize)
+                .collect::<Vec<_>>(),
+            [".late.txt", "visible.txt"]
+        );
+    }
+    let upgraded: serde_json::Value =
+        serde_json::from_slice(&fs::read(meta_path).unwrap()).unwrap();
+    assert_eq!(upgraded["complete"], true);
+    assert_eq!(upgraded["hidden_complete"], true);
+}
+
 fn stats_totals(stderr: &[u8]) -> Vec<(u64, u64)> {
     let stderr = String::from_utf8_lossy(stderr);
     regex::Regex::new(r"(\d+) matches \((\d+) matched lines\)")
@@ -605,8 +847,33 @@ fn stats_scope_depth_filters_and_quiet_early_exit_apply_to_server_totals() {
         for (flags, expected) in [
             (vec!["--max-depth", "1"], (4, 3)),
             (vec!["--max-depth", "1", "-q"], (2, 1)),
-            (vec!["-g", "a.txt", "--stop-on-nonmatch"], (2, 1)),
-            (vec!["-g", "zero.txt"], (0, 0)),
+            (
+                vec![
+                    "-g",
+                    "!b.txt",
+                    "-g",
+                    "!zero.txt",
+                    "-g",
+                    "!nested",
+                    "-g",
+                    "!binary.txt",
+                    "--stop-on-nonmatch",
+                ],
+                (2, 1),
+            ),
+            (
+                vec![
+                    "-g",
+                    "!a.txt",
+                    "-g",
+                    "!b.txt",
+                    "-g",
+                    "!nested",
+                    "-g",
+                    "!binary.txt",
+                ],
+                (0, 0),
+            ),
         ] {
             let output = tgrep()
                 .args(backend)
@@ -3146,7 +3413,11 @@ fn indexed_passthru_prints_no_match_and_exits_one() {
             "--passthru",
             "--stats",
             "-g",
-            "hello.rs",
+            "!lib.rs",
+            "-g",
+            "!*.toml",
+            "-g",
+            "!*.txt",
             "does-not-exist",
             &indexed_fixture_path(&dir),
         ])
@@ -3313,7 +3584,11 @@ fn passthru_max_count_zero_matches_ripgrep_across_search_paths() {
             "--passthru",
             "--stats",
             "-g",
-            "hello.rs",
+            "!lib.rs",
+            "-g",
+            "!*.toml",
+            "-g",
+            "!*.txt",
             "-m",
             "0",
             pattern,
@@ -5975,9 +6250,8 @@ fn index_is_git_gated_by_default_like_ripgrep() {
     let dir = non_git_enlistment();
     let idx = dir.path().join("idx");
     let n = indexed_file_count(&indexed_fixture_path(&dir), idx.to_str().unwrap(), &[]);
-    // src/main.rs + build/gen.rs + out.log. `.gitignore` is dot-prefixed and so
-    // is filtered by the walk's hidden rule regardless of the git gate.
-    assert_eq!(n, 3, "no `.git`, so `.gitignore` must not apply by default");
+    // src/main.rs + build/gen.rs + out.log + the nonignored .gitignore source.
+    assert_eq!(n, 4, "no `.git`, so `.gitignore` must not apply by default");
 }
 
 #[test]
@@ -5989,9 +6263,9 @@ fn index_honours_no_require_git() {
         idx.to_str().unwrap(),
         &["--no-require-git"],
     );
-    // Only src/main.rs survives; `.gitignore` is dot-prefixed and hidden anyway.
+    // src/main.rs and the nonignored .gitignore source survive.
     assert_eq!(
-        n, 1,
+        n, 2,
         "`--no-require-git` must reach the indexing walk, not just search"
     );
 }

--- a/tgrep-cli/tests/ripgrep_parity.rs
+++ b/tgrep-cli/tests/ripgrep_parity.rs
@@ -447,16 +447,20 @@ fn indexed_search_honors_max_depth() {
 }
 
 // ---------------------------------------------------------------------------
-// 7. --hidden / --no-ignore must bypass the index
+// 7. Legacy hidden coverage / --no-ignore must bypass the index
 //
-// The index is built skipping hidden and ignored files, so answering these
-// flags from the index would silently under-report.
+// Missing coverage metadata cannot prove an old index contains hidden files.
+// Ignored files remain outside the default index.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn hidden_flag_bypasses_the_index() {
+fn hidden_flag_bypasses_an_index_without_coverage_metadata() {
     let (dir, idx) = indexed_fixture();
-    // Written after indexing, and hidden, so only a bypassing search sees it.
+    let meta_path = std::path::Path::new(&idx).join("meta.json");
+    let mut meta: serde_json::Value =
+        serde_json::from_slice(&fs::read(&meta_path).unwrap()).unwrap();
+    meta.as_object_mut().unwrap().remove("hidden_complete");
+    fs::write(&meta_path, serde_json::to_vec(&meta).unwrap()).unwrap();
     fs::write(dir.path().join(".secret.txt"), "needle hidden\n").unwrap();
 
     let out = stdout_of(tgrep().current_dir(dir.path()).args([
@@ -469,7 +473,7 @@ fn hidden_flag_bypasses_the_index() {
     ]));
     assert!(
         out.contains("needle hidden"),
-        "--hidden must bypass the index: {out:?}"
+        "--hidden must bypass an index with unknown coverage: {out:?}"
     );
 }
 

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -826,16 +826,18 @@ pub fn build_index_with_options_and_ignorecase(
     let file_table_id = meta
         .file_table_id
         .ok_or_else(|| Error::IndexCorrupted("built index has no file-table identity".into()))?;
+    let hidden_complete =
+        include_hidden && walk.skipped_error == 0 && read_errors.into_inner() == 0;
     path_index::write_extra_paths_with_visibility(
         &index_dir,
         &extra_paths,
         &walk.visibility,
         file_table_id,
+        hidden_complete,
     )?;
     meta::write_file_evidence(&evidence, &index_dir)?;
     // `meta.json` remains the final publication marker for in-place builds.
-    meta.hidden_complete =
-        include_hidden && walk.skipped_error == 0 && read_errors.into_inner() == 0;
+    meta.hidden_complete = hidden_complete;
     meta.visibility = walk.visibility;
     meta.save(&index_dir)?;
 

--- a/tgrep-core/src/builder.rs
+++ b/tgrep-core/src/builder.rs
@@ -82,17 +82,10 @@ pub struct BuildOptions {
     /// output. This opts out of that gate.
     pub no_require_git: bool,
     pub exclude_dirs: Vec<String>,
-    /// Apply leading-dot ("hidden") filtering in the walk instead of the
-    /// platform's native hidden check, and treat `.gitignore` files as
-    /// hidden.
-    ///
-    /// The two differ on Windows, where the native check reads the
-    /// `FILE_ATTRIBUTE_HIDDEN` bit that git does not set on dotfiles, so a
-    /// default walk indexes `.gitignore`, `.mailmap`, and friends there but
-    /// not on Unix. `tgrep serve` walks with leading-dot semantics on every
-    /// platform, and its file watcher skips dot-prefixed paths outright, so a
-    /// build destined for a server must opt in — otherwise the server would
-    /// index dotfiles it can never afterwards update or remove.
+    /// Additional storage paths to exclude when building into a staging
+    /// directory. The output directory itself is always excluded.
+    pub exclude_paths: Vec<std::path::PathBuf>,
+    /// Return ignore-file paths for the server's watcher matcher.
     pub collect_gitignore_files: bool,
     pub strategy: IndexStrategy,
     /// Arena budget in bytes for [`IndexStrategy::External`]. Ignored by
@@ -105,10 +98,11 @@ pub struct BuildOptions {
 impl Default for BuildOptions {
     fn default() -> Self {
         Self {
-            include_hidden: false,
+            include_hidden: true,
             no_ignore: false,
             no_require_git: false,
             exclude_dirs: Vec::new(),
+            exclude_paths: Vec::new(),
             collect_gitignore_files: false,
             strategy: IndexStrategy::default(),
             buffer_bytes: external::DEFAULT_BUFFER_BYTES,
@@ -650,6 +644,19 @@ pub fn build_index_with_options_and_ignorecase(
         None => root.join(INDEX_DIR_NAME),
     };
     std::fs::create_dir_all(&index_dir)?;
+    let storage_path = std::fs::canonicalize(&index_dir)?;
+    if root.starts_with(&storage_path) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "index directory must not contain the source root",
+        )
+        .into());
+    }
+    let mut exclude_paths = opts.exclude_paths.clone();
+    exclude_paths.push(storage_path);
+    let mut building_meta = IndexMeta::new(&root.to_string_lossy(), 0, 0);
+    building_meta.complete = false;
+    building_meta.save(&index_dir)?;
     // Evidence belongs to the complete core generation. Invalidate it before
     // an in-place writer can truncate any core file.
     meta::remove_file_evidence(&index_dir)?;
@@ -667,8 +674,11 @@ pub fn build_index_with_options_and_ignorecase(
             include_hidden,
             no_ignore,
             no_require_git: opts.no_require_git,
-            collect_gitignore_files: opts.collect_gitignore_files,
+            // Visibility must retain hidden entries admitted by ignore-file
+            // whitelists, even for a build without a watcher.
+            collect_gitignore_files: true,
             exclude_dirs: exclude_dirs.to_vec(),
+            exclude_paths,
             max_file_size: opts.max_file_size,
             ..Default::default()
         },
@@ -689,6 +699,7 @@ pub fn build_index_with_options_and_ignorecase(
     // 8KB read per file — we're already reading the full file anyway.
     eprintln!("Extracting trigrams...");
     let binary_skipped = std::sync::atomic::AtomicUsize::new(0);
+    let read_errors = std::sync::atomic::AtomicUsize::new(0);
 
     // Assign file IDs and collect posting entries. Batching avoids
     // retaining every file's per-trigram HashMap at once for large repos, and
@@ -723,6 +734,8 @@ pub fn build_index_with_options_and_ignorecase(
                     Err(error) => {
                         if error.kind() == std::io::ErrorKind::InvalidData {
                             raced_too_large.lock().unwrap().insert(path.clone());
+                        } else {
+                            read_errors.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         }
                         return None;
                     }
@@ -809,17 +822,37 @@ pub fn build_index_with_options_and_ignorecase(
         .filter(|path| !indexed_paths.contains(path.as_str()))
         .collect();
     extra_paths.sort_unstable();
-    path_index::write_extra_paths(&index_dir, &extra_paths)?;
+    let mut meta = IndexMeta::load(&index_dir)?;
+    let file_table_id = meta
+        .file_table_id
+        .ok_or_else(|| Error::IndexCorrupted("built index has no file-table identity".into()))?;
+    path_index::write_extra_paths_with_visibility(
+        &index_dir,
+        &extra_paths,
+        &walk.visibility,
+        file_table_id,
+    )?;
     meta::write_file_evidence(&evidence, &index_dir)?;
     // `meta.json` remains the final publication marker for in-place builds.
-    IndexMeta::load(&index_dir)?.save(&index_dir)?;
+    meta.hidden_complete =
+        include_hidden && walk.skipped_error == 0 && read_errors.into_inner() == 0;
+    meta.visibility = walk.visibility;
+    meta.save(&index_dir)?;
 
     eprintln!("Index built successfully at {}", index_dir.display());
     Ok(BuildOutcome {
         num_files: file_id_map.len(),
         versions: evidence.versions,
-        gitignore_files,
-        ignore_files,
+        gitignore_files: if opts.collect_gitignore_files {
+            gitignore_files
+        } else {
+            Vec::new()
+        },
+        ignore_files: if opts.collect_gitignore_files {
+            ignore_files
+        } else {
+            Vec::new()
+        },
     })
 }
 
@@ -1116,6 +1149,7 @@ fn write_files_and_meta<'a>(
 ) -> Result<()> {
     let mut files_file =
         std::io::BufWriter::new(std::fs::File::create(index_dir.join("files.bin"))?);
+    ondisk::write_file_table_header(&mut files_file)?;
     for (id, path) in paths.into_iter().enumerate() {
         ondisk::write_file_entry(&mut files_file, id as u32, path)?;
     }
@@ -1130,9 +1164,32 @@ fn write_files_and_meta<'a>(
     if let Some(c) = complete {
         meta.complete = c;
     }
+    meta.file_table_id = Some(meta::read_file_table_id(index_dir)?);
     meta.save(index_dir)?;
 
     Ok(())
+}
+
+/// Stage only the format boundary when a legacy index needs no content merge.
+/// The table is streamed, preserving IDs and avoiding a copy of its path set.
+pub fn stage_file_table_upgrade(index_dir: &Path, staging_dir: &Path) -> Result<bool> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut source = std::fs::File::open(index_dir.join("files.bin"))?;
+    let mut header = Vec::with_capacity(ondisk::FILE_TABLE_HEADER_LEN);
+    (&mut source)
+        .take(ondisk::FILE_TABLE_HEADER_LEN as u64)
+        .read_to_end(&mut header)?;
+    if ondisk::file_table_body(&header)?.len() != header.len() {
+        return Ok(false);
+    }
+    source.seek(SeekFrom::Start(0))?;
+    std::fs::create_dir_all(staging_dir)?;
+    let mut target = std::io::BufWriter::new(std::fs::File::create(staging_dir.join("files.bin"))?);
+    ondisk::write_file_table_header(&mut target)?;
+    std::io::copy(&mut source, &mut target)?;
+    target.flush()?;
+    Ok(true)
 }
 
 /// Preserves mask data (loc_mask/next_mask) from the snapshot so Bloom-filter
@@ -2133,13 +2190,8 @@ mod tests {
         assert_eq!(BuildOptions::default().strategy, IndexStrategy::External);
     }
 
-    // `tgrep serve` walks with leading-dot hidden semantics and its watcher
-    // skips dot-prefixed paths, so a build that feeds a server must exclude
-    // dotfiles. On Windows the default walk keeps them (the native hidden
-    // check reads an attribute git never sets), which would leave the server
-    // holding entries it can never update or delete.
     #[test]
-    fn collect_gitignore_files_excludes_dotfiles_from_the_index() {
+    fn default_build_includes_dotfiles_and_records_query_visibility() {
         let repo = tempfile::tempdir().unwrap();
         let root = repo.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -2163,13 +2215,60 @@ mod tests {
         .unwrap();
 
         let reader = IndexReader::open(for_serve.path()).unwrap();
-        let indexed: Vec<String> = (0..reader.num_files() as u32)
+        let mut indexed: Vec<String> = (0..reader.num_files() as u32)
             .filter_map(|id| reader.file_path(id).map(|p| p.to_string()))
             .collect();
+        indexed.sort();
         assert_eq!(
             indexed,
-            vec!["src/main.rs".to_string()],
-            "a build destined for the server must skip dot-prefixed files"
+            vec![".gitignore", ".mailmap", "src/main.rs"],
+            "index and serve must cover nonignored hidden files by default"
+        );
+        let meta = IndexMeta::load(for_serve.path()).unwrap();
+        assert!(meta.complete && meta.hidden_complete);
+        assert!(!meta.visibility.is_visible(".mailmap", "", false));
+        assert!(meta.visibility.is_visible("src/main.rs", "", false));
+    }
+
+    #[test]
+    fn default_build_never_indexes_its_custom_storage() {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path();
+        std::fs::write(root.join("visible.txt"), "needle visible").unwrap();
+        std::fs::write(root.join(".secret"), "needle hidden").unwrap();
+        let storage = root.join("custom-index");
+        std::fs::create_dir_all(storage.join(".retired/generation-1")).unwrap();
+        std::fs::write(
+            storage.join(".retired/generation-1/source.txt"),
+            "needle storage",
+        )
+        .unwrap();
+        for _ in 0..2 {
+            build_index_with_options(root, Some(&storage), &BuildOptions::default()).unwrap();
+            let reader = IndexReader::open(&storage).unwrap();
+            let mut paths = reader.all_paths().to_vec();
+            paths.sort();
+            assert_eq!(paths, [".secret", "visible.txt"]);
+            assert!(IndexMeta::load(&storage).unwrap().hidden_complete);
+        }
+    }
+
+    #[test]
+    fn storage_cannot_cover_the_source_root() {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path();
+        std::fs::write(root.join("visible.txt"), "needle").unwrap();
+        let error =
+            build_index_with_options(root, Some(root), &BuildOptions::default()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("index directory must not contain the source root")
+        );
+        assert!(!root.join("meta.json").exists());
+        assert_eq!(
+            std::fs::read_to_string(root.join("visible.txt")).unwrap(),
+            "needle"
         );
     }
 

--- a/tgrep-core/src/gitignore.rs
+++ b/tgrep-core/src/gitignore.rs
@@ -197,6 +197,45 @@ impl IgnoreMatcher {
     }
 
     pub fn is_ignored(&self, path: &Path, is_dir: bool) -> bool {
+        if self.standard_decision(path, is_dir, true) == Some(true) {
+            return true;
+        }
+        if self.local_is_filter
+            && self
+                .local
+                .matched_path_or_any_parents(path, is_dir)
+                .is_ignore()
+        {
+            return true;
+        }
+        // The walk applies this narrowing even to whitelisted paths.
+        self.ignorecase.as_ref().is_some_and(|ignorecase| {
+            let relative = path.to_string_lossy().replace('\\', "/");
+            let relative = relative.trim_start_matches("./").trim_start_matches('/');
+            ignorecase.excludes(&self.root.join(relative), is_dir)
+        })
+    }
+
+    /// Whether an explicit standard ignore-file whitelist admits this entry
+    /// through the walker's hidden filter. Parent-directory matches are not
+    /// inherited here: the walker makes the hidden decision for each entry.
+    pub fn is_whitelisted(&self, path: &Path, is_dir: bool) -> bool {
+        self.standard_decision(path, is_dir, false) == Some(false)
+    }
+
+    fn standard_decision(&self, path: &Path, is_dir: bool, parents: bool) -> Option<bool> {
+        let matched = |matcher: &Gitignore, path: &Path| {
+            let result = if parents {
+                matcher.matched_path_or_any_parents(path, is_dir)
+            } else {
+                matcher.matched(path, is_dir)
+            };
+            match result {
+                Match::Ignore(_) => Some(true),
+                Match::Whitelist(_) => Some(false),
+                Match::None => None,
+            }
+        };
         let rel = path.to_string_lossy().replace('\\', "/");
         let rel = rel.trim_start_matches("./").trim_start_matches('/');
 
@@ -211,19 +250,9 @@ impl IgnoreMatcher {
                 let Some(under) = strip_dir_prefix(rel, &entry.dir) else {
                     continue;
                 };
-                match entry
-                    .matcher
-                    .matched_path_or_any_parents(Path::new(under), is_dir)
-                {
-                    Match::Ignore(_) => {
-                        standard_decision = Some(true);
-                        break;
-                    }
-                    Match::Whitelist(_) => {
-                        standard_decision = Some(false);
-                        break;
-                    }
-                    Match::None => {}
+                if let Some(decision) = matched(&entry.matcher, Path::new(under)) {
+                    standard_decision = Some(decision);
+                    break;
                 }
             }
             if standard_decision.is_some() {
@@ -236,19 +265,9 @@ impl IgnoreMatcher {
                 } else {
                     format!("{}/{rel}", entry.prefix)
                 };
-                match entry
-                    .matcher
-                    .matched_path_or_any_parents(Path::new(&path), is_dir)
-                {
-                    Match::Ignore(_) => {
-                        standard_decision = Some(true);
-                        break;
-                    }
-                    Match::Whitelist(_) => {
-                        standard_decision = Some(false);
-                        break;
-                    }
-                    Match::None => {}
+                if let Some(decision) = matched(&entry.matcher, Path::new(&path)) {
+                    standard_decision = Some(decision);
+                    break;
                 }
             }
             if standard_decision.is_some() {
@@ -259,11 +278,7 @@ impl IgnoreMatcher {
         // `with_nested` historically takes an already-combined root matcher;
         // nested files must retain their deeper-path precedence over it.
         if standard_decision.is_none() && !self.local_is_filter {
-            standard_decision = match self.local.matched_path_or_any_parents(path, is_dir) {
-                Match::Ignore(_) => Some(true),
-                Match::Whitelist(_) => Some(false),
-                Match::None => None,
-            };
+            standard_decision = matched(&self.local, path);
         }
 
         if standard_decision.is_none()
@@ -274,39 +289,13 @@ impl IgnoreMatcher {
             } else {
                 format!("{prefix}/{rel}")
             };
-            match matcher.matched_path_or_any_parents(Path::new(&path), is_dir) {
-                Match::Ignore(_) => standard_decision = Some(true),
-                Match::Whitelist(_) => standard_decision = Some(false),
-                Match::None => {}
-            }
+            standard_decision = matched(matcher, Path::new(&path));
         }
 
         if standard_decision.is_none() {
-            standard_decision = match self.global.matched_path_or_any_parents(path, is_dir) {
-                Match::Ignore(_) => Some(true),
-                Match::Whitelist(_) => Some(false),
-                Match::None => None,
-            };
+            standard_decision = matched(&self.global, path);
         }
-
-        if standard_decision == Some(true) {
-            return true;
-        }
-        if self.local_is_filter
-            && self
-                .local
-                .matched_path_or_any_parents(path, is_dir)
-                .is_ignore()
-        {
-            return true;
-        }
-        // Applied last, and to whitelisted paths too, because that is where the
-        // indexing walk applies it: a `filter_entry` rejection is not undone by
-        // a whitelist rule. Both passes must agree on what the tree contains,
-        // or the watcher indexes a file the stale check immediately evicts.
-        self.ignorecase
-            .as_ref()
-            .is_some_and(|ignorecase| ignorecase.excludes(&self.root.join(rel), is_dir))
+        standard_decision
     }
 
     /// Fingerprint of the tracked paths behind the tracked-file exemption.
@@ -951,27 +940,16 @@ pub fn build_matcher(root: &Path) -> Option<IgnoreMatcher> {
     let p4ignore = build_p4ignore_matcher(root).map(std::sync::Arc::new);
     let match_root = root.to_path_buf();
 
-    // Walk to find every `.gitignore` file. We can't use `hidden(true)`
-    // because `.gitignore` itself starts with `.` and would be filtered.
-    // Instead, walk with hidden=false and use `filter_entry` to skip
-    // all dot-prefixed *directories* (`.git`, `.tgrep`, `.vscode`, …) —
-    // this avoids unnecessary I/O into hidden subtrees while still
-    // letting dot-prefixed *files* like `.gitignore` through, since
-    // `filter_entry` only controls directory descent for directories.
+    let index_dir = crate::builder::default_index_dir(root);
+    // Hidden subtrees carry ordinary ignore rules too. Prune storage, not
+    // arbitrary dot-prefixed directories.
     let walker = WalkBuilder::new(root)
         .hidden(false)
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
         .filter_entry(move |entry| {
-            // Allow files (we only care about .gitignore among them).
-            // For directories, skip any that start with '.'.
-            if entry.file_type().is_some_and(|ft| ft.is_dir())
-                && entry
-                    .file_name()
-                    .to_str()
-                    .is_some_and(|n| n.starts_with('.'))
-            {
+            if entry.path().starts_with(&index_dir) {
                 return false;
             }
             if entry.file_name() == ".gitignore" || entry.file_name() == ".ignore" {

--- a/tgrep-core/src/lib.rs
+++ b/tgrep-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod path_index;
 pub mod query;
 pub mod reader;
 pub mod trigram;
+pub mod visibility;
 pub mod walker;
 
 pub use error::{Error, Result};

--- a/tgrep-core/src/meta.rs
+++ b/tgrep-core/src/meta.rs
@@ -7,6 +7,8 @@ use crate::Result;
 
 const META_FILENAME: &str = "meta.json";
 const FILESTAMPS_FILENAME: &str = "filestamps.json";
+pub const INDEX_FORMAT_VERSION: u32 = crate::ondisk::INDEX_FORMAT_VERSION;
+pub type FileTableId = [u8; 32];
 const CONTENT_ID_DOMAIN: &[u8] =
     b"tgrep/content-id/v1\0decode_for_index-output\0binary-and-posting-semantics-v2";
 
@@ -22,6 +24,15 @@ pub struct IndexMeta {
     /// stopped during background indexing and the index is partial.
     #[serde(default = "default_complete")]
     pub complete: bool,
+    /// Proven coverage of otherwise eligible hidden files. Missing on legacy
+    /// indexes; neither `complete` alone nor a partial build proves coverage.
+    #[serde(default)]
+    pub hidden_complete: bool,
+    #[serde(default)]
+    pub visibility: crate::visibility::PathVisibility,
+    /// Binds visibility to the exact path table across multi-file publication.
+    #[serde(default)]
+    pub file_table_id: Option<FileTableId>,
 }
 
 fn default_complete() -> bool {
@@ -35,13 +46,16 @@ impl IndexMeta {
             .unwrap_or_default()
             .as_secs();
         Self {
-            version: 2,
+            version: INDEX_FORMAT_VERSION,
             num_files,
             num_trigrams,
             created_at: now,
             updated_at: now,
             root_path: root_path.to_string(),
             complete: true,
+            hidden_complete: false,
+            visibility: Default::default(),
+            file_table_id: None,
         }
     }
 
@@ -60,6 +74,25 @@ impl IndexMeta {
         let data = std::fs::read_to_string(path)?;
         let meta: Self = serde_json::from_str(&data)?;
         Ok(meta)
+    }
+}
+
+pub fn file_table_id(data: &[u8]) -> FileTableId {
+    *blake3::hash(data).as_bytes()
+}
+
+pub fn read_file_table_id(index_dir: &Path) -> Result<FileTableId> {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(index_dir.join("files.bin"))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(*hasher.finalize().as_bytes());
+        }
+        hasher.update(&buffer[..read]);
     }
 }
 
@@ -526,6 +559,16 @@ pub fn collect_filestamps(root: &Path, paths: &[String]) -> HashMap<String, File
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn legacy_metadata_does_not_prove_hidden_coverage() {
+        let mut value = serde_json::to_value(super::IndexMeta::new("root", 1, 2)).unwrap();
+        value.as_object_mut().unwrap().remove("hidden_complete");
+        value.as_object_mut().unwrap().remove("visibility");
+        let meta: super::IndexMeta = serde_json::from_value(value).unwrap();
+        assert!(meta.complete);
+        assert!(!meta.hidden_complete);
+    }
+
     use super::*;
 
     #[test]

--- a/tgrep-core/src/ondisk.rs
+++ b/tgrep-core/src/ondisk.rs
@@ -17,11 +17,39 @@
 /// Each entry is 6 bytes: `file_id(u32) + loc_mask(u8) + next_mask(u8)`.
 ///
 /// ## `files.bin` — file ID → path mapping
-/// Variable-length records: `file_id(u32 LE) + path_len(u16 LE) + path_bytes`.
+/// A versioned header followed by variable-length records:
+/// `file_id(u32 LE) + path_len(u16 LE) + path_bytes`.
 pub(crate) const LOOKUP_ENTRY_SIZE: usize = 16; // 4 + 8 + 4
 pub(crate) const POSTING_ENTRY_SIZE: usize = 6; // 4 + 1 + 1
 pub(crate) const POSTING_WRITE_CHUNK_ENTRIES: usize = 8192;
 pub(crate) const LOOKUP_WRITE_CHUNK_ENTRIES: usize = 4096;
+pub(crate) const INDEX_FORMAT_VERSION: u32 = 3;
+// Two duplicate reserved IDs make old dense-ID readers reject the table,
+// rather than exposing a hidden-inclusive corpus without visibility filtering.
+const FILE_TABLE_MAGIC: &[u8; 12] = b"\xff\xff\xff\xff\0\0\xff\xff\xff\xff\0\0";
+pub(crate) const FILE_TABLE_HEADER_LEN: usize = FILE_TABLE_MAGIC.len() + size_of::<u32>();
+
+pub(crate) fn write_file_table_header(writer: &mut impl std::io::Write) -> crate::Result<()> {
+    writer.write_all(FILE_TABLE_MAGIC)?;
+    writer.write_all(&INDEX_FORMAT_VERSION.to_le_bytes())?;
+    Ok(())
+}
+
+pub(crate) fn file_table_body(data: &[u8]) -> crate::Result<&[u8]> {
+    if !data.starts_with(FILE_TABLE_MAGIC) {
+        return Ok(data);
+    }
+    let version = data
+        .get(FILE_TABLE_MAGIC.len()..FILE_TABLE_HEADER_LEN)
+        .ok_or_else(|| crate::Error::IndexCorrupted("files.bin header is truncated".into()))?;
+    let version = u32::from_le_bytes(version.try_into().unwrap());
+    if version != INDEX_FORMAT_VERSION {
+        return Err(crate::Error::IndexCorrupted(format!(
+            "unsupported files.bin format version {version}"
+        )));
+    }
+    Ok(&data[FILE_TABLE_HEADER_LEN..])
+}
 
 /// A single entry in `lookup.bin`.
 #[derive(Debug, Clone, Copy)]
@@ -216,6 +244,28 @@ pub(crate) fn decode_file_entries(data: &[u8]) -> crate::Result<Vec<(u32, String
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn versioned_file_table_rejects_legacy_readers() {
+        let mut bytes = Vec::new();
+        write_file_table_header(&mut bytes).unwrap();
+        write_file_entry(&mut bytes, 0, ".secret.txt").unwrap();
+        let entries = decode_file_entries(file_table_body(&bytes).unwrap()).unwrap();
+        assert_eq!(entries, [(0, ".secret.txt".to_string())]);
+
+        // The v1/v2 parser either rejects the header as malformed or reaches
+        // the unchanged dense/unique-ID validation with duplicate reserved IDs.
+        if let Ok(legacy) = decode_file_entries(&bytes) {
+            let mut ids = std::collections::HashSet::new();
+            assert!(
+                legacy
+                    .iter()
+                    .any(|(id, _)| *id as usize >= legacy.len() || !ids.insert(*id))
+            );
+        }
+        bytes[FILE_TABLE_MAGIC.len()..FILE_TABLE_HEADER_LEN].copy_from_slice(&99u32.to_le_bytes());
+        assert!(file_table_body(&bytes).is_err());
+    }
 
     #[test]
     fn test_lookup_roundtrip() {

--- a/tgrep-core/src/path_index.rs
+++ b/tgrep-core/src/path_index.rs
@@ -32,6 +32,22 @@ pub struct FilenameVisibility {
     pub hidden_complete: bool,
 }
 
+impl FilenameVisibility {
+    /// Whether metadata and this atomic snapshot prove coverage of the opened index.
+    pub fn covers_index(
+        &self,
+        meta: &crate::meta::IndexMeta,
+        file_table_id: crate::meta::FileTableId,
+    ) -> bool {
+        meta.complete
+            && meta.hidden_complete
+            && meta.version == crate::meta::INDEX_FORMAT_VERSION
+            && meta.file_table_id == Some(file_table_id)
+            && self.hidden_complete
+            && self.file_table_id == file_table_id
+    }
+}
+
 /// Write a legacy filename-only path set without visibility evidence.
 pub fn write_extra_paths(index_dir: &Path, paths: &[String]) -> Result<()> {
     write_paths(index_dir, paths, None)

--- a/tgrep-core/src/path_index.rs
+++ b/tgrep-core/src/path_index.rs
@@ -29,6 +29,7 @@ pub struct FilenameIndex {
 pub struct FilenameVisibility {
     pub paths: PathVisibility,
     pub file_table_id: crate::meta::FileTableId,
+    pub hidden_complete: bool,
 }
 
 /// Write a legacy filename-only path set without visibility evidence.
@@ -42,6 +43,7 @@ pub fn write_extra_paths_with_visibility(
     paths: &[String],
     visibility: &PathVisibility,
     file_table_id: crate::meta::FileTableId,
+    hidden_complete: bool,
 ) -> Result<()> {
     write_paths(
         index_dir,
@@ -49,6 +51,7 @@ pub fn write_extra_paths_with_visibility(
         Some(&FilenameVisibility {
             paths: visibility.clone(),
             file_table_id,
+            hidden_complete,
         }),
     )
 }
@@ -208,14 +211,15 @@ mod tests {
         let paths = vec![".secret.png".to_string(), "visible.png".to_string()];
         let mut visibility = PathVisibility::default();
         visibility.record(".secret.png", false, None, None);
-        write_extra_paths_with_visibility(dir.path(), &paths, &visibility, [7; 32]).unwrap();
+        write_extra_paths_with_visibility(dir.path(), &paths, &visibility, [7; 32], true).unwrap();
         let decoded = read_filename_index(dir.path()).unwrap().unwrap();
         assert_eq!(decoded.paths, paths);
         assert_eq!(
             decoded.visibility,
             Some(FilenameVisibility {
                 paths: visibility,
-                file_table_id: [7; 32]
+                file_table_id: [7; 32],
+                hidden_complete: true,
             })
         );
         let data = std::fs::read(dir.path().join(EXTRA_PATHS_FILENAME)).unwrap();

--- a/tgrep-core/src/path_index.rs
+++ b/tgrep-core/src/path_index.rs
@@ -8,20 +8,69 @@
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
+use crate::visibility::PathVisibility;
 use crate::{Error, Result};
 
 pub const EXTRA_PATHS_FILENAME: &str = "files-extra.bin";
 
 const MAGIC: &[u8; 8] = b"TGRPXP01";
+const VISIBILITY_MAGIC: &[u8; 8] = b"TGRPXP02";
 const HEADER_LEN: usize = MAGIC.len() + size_of::<u64>();
 const PATH_LEN_SIZE: usize = size_of::<u32>();
 
-/// Write a complete filename-only path set.
+pub struct FilenameIndex {
+    pub paths: Vec<String>,
+    /// Missing for a legacy sidecar, whose membership cannot be safely paired
+    /// with visibility from a separately published metadata file.
+    pub visibility: Option<FilenameVisibility>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FilenameVisibility {
+    pub paths: PathVisibility,
+    pub file_table_id: crate::meta::FileTableId,
+}
+
+/// Write a legacy filename-only path set without visibility evidence.
 pub fn write_extra_paths(index_dir: &Path, paths: &[String]) -> Result<()> {
+    write_paths(index_dir, paths, None)
+}
+
+/// Publishable filename membership and its visibility in one atomic file.
+pub fn write_extra_paths_with_visibility(
+    index_dir: &Path,
+    paths: &[String],
+    visibility: &PathVisibility,
+    file_table_id: crate::meta::FileTableId,
+) -> Result<()> {
+    write_paths(
+        index_dir,
+        paths,
+        Some(&FilenameVisibility {
+            paths: visibility.clone(),
+            file_table_id,
+        }),
+    )
+}
+
+fn write_paths(
+    index_dir: &Path,
+    paths: &[String],
+    visibility: Option<&FilenameVisibility>,
+) -> Result<()> {
     std::fs::create_dir_all(index_dir)?;
     let mut writer = BufWriter::new(std::fs::File::create(index_dir.join(EXTRA_PATHS_FILENAME))?);
-    writer.write_all(MAGIC)?;
+    writer.write_all(if visibility.is_some() {
+        VISIBILITY_MAGIC
+    } else {
+        MAGIC
+    })?;
     writer.write_all(&(paths.len() as u64).to_le_bytes())?;
+    if let Some(visibility) = visibility {
+        let data = serde_json::to_vec(visibility)?;
+        writer.write_all(&(data.len() as u64).to_le_bytes())?;
+        writer.write_all(&data)?;
+    }
 
     for path in paths {
         let bytes = path.as_bytes();
@@ -43,6 +92,10 @@ pub fn write_extra_paths(index_dir: &Path, paths: &[String]) -> Result<()> {
 /// `Ok(None)` identifies a legacy index that predates the sidecar. Callers can
 /// then preserve correctness by falling back to a filesystem walk.
 pub fn read_extra_paths(index_dir: &Path) -> Result<Option<Vec<String>>> {
+    Ok(read_filename_index(index_dir)?.map(|index| index.paths))
+}
+
+pub fn read_filename_index(index_dir: &Path) -> Result<Option<FilenameIndex>> {
     let path = index_dir.join(EXTRA_PATHS_FILENAME);
     if !path.exists() {
         return Ok(None);
@@ -55,12 +108,31 @@ pub fn read_extra_paths(index_dir: &Path) -> Result<Option<Vec<String>>> {
             data.len()
         )));
     }
-    if &data[..MAGIC.len()] != MAGIC {
+    let has_visibility = &data[..MAGIC.len()] == VISIBILITY_MAGIC;
+    if !has_visibility && &data[..MAGIC.len()] != MAGIC {
         return Err(corrupted("invalid header".to_string()));
     }
 
     let count = u64::from_le_bytes(data[MAGIC.len()..HEADER_LEN].try_into().unwrap());
-    let max_records = (data.len() - HEADER_LEN) / PATH_LEN_SIZE;
+    let mut pos = HEADER_LEN;
+    let visibility = if has_visibility {
+        let length = data
+            .get(pos..pos + size_of::<u64>())
+            .ok_or_else(|| corrupted("visibility length is truncated".into()))?;
+        let length = usize::try_from(u64::from_le_bytes(length.try_into().unwrap()))
+            .map_err(|_| corrupted("visibility length does not fit in usize".into()))?;
+        pos += size_of::<u64>();
+        let end = pos
+            .checked_add(length)
+            .filter(|end| *end <= data.len())
+            .ok_or_else(|| corrupted("visibility exceeds the file bounds".into()))?;
+        let visibility = serde_json::from_slice(&data[pos..end])?;
+        pos = end;
+        Some(visibility)
+    } else {
+        None
+    };
+    let max_records = (data.len() - pos) / PATH_LEN_SIZE;
     if count > max_records as u64 {
         return Err(corrupted(format!(
             "declares {count} paths but the file can contain at most {max_records}"
@@ -68,7 +140,6 @@ pub fn read_extra_paths(index_dir: &Path) -> Result<Option<Vec<String>>> {
     }
 
     let mut paths = Vec::with_capacity(count as usize);
-    let mut pos = HEADER_LEN;
     for index in 0..count {
         if pos + PATH_LEN_SIZE > data.len() {
             return Err(corrupted(format!("path {index} has a truncated length")));
@@ -91,7 +162,7 @@ pub fn read_extra_paths(index_dir: &Path) -> Result<Option<Vec<String>>> {
             data.len() - pos
         )));
     }
-    Ok(Some(paths))
+    Ok(Some(FilenameIndex { paths, visibility }))
 }
 
 /// Remove a previous sidecar before rebuilding in place.
@@ -129,6 +200,39 @@ mod tests {
         ];
         write_extra_paths(dir.path(), &paths).unwrap();
         assert_eq!(read_extra_paths(dir.path()).unwrap(), Some(paths));
+    }
+
+    #[test]
+    fn visibility_and_filename_membership_round_trip_together() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = vec![".secret.png".to_string(), "visible.png".to_string()];
+        let mut visibility = PathVisibility::default();
+        visibility.record(".secret.png", false, None, None);
+        write_extra_paths_with_visibility(dir.path(), &paths, &visibility, [7; 32]).unwrap();
+        let decoded = read_filename_index(dir.path()).unwrap().unwrap();
+        assert_eq!(decoded.paths, paths);
+        assert_eq!(
+            decoded.visibility,
+            Some(FilenameVisibility {
+                paths: visibility,
+                file_table_id: [7; 32]
+            })
+        );
+        let data = std::fs::read(dir.path().join(EXTRA_PATHS_FILENAME)).unwrap();
+        assert_ne!(
+            &data[..MAGIC.len()],
+            MAGIC,
+            "old sidecar readers must reject it"
+        );
+
+        write_extra_paths(dir.path(), &paths).unwrap();
+        assert!(
+            read_filename_index(dir.path())
+                .unwrap()
+                .unwrap()
+                .visibility
+                .is_none()
+        );
     }
 
     #[test]

--- a/tgrep-core/src/reader.rs
+++ b/tgrep-core/src/reader.rs
@@ -14,6 +14,7 @@ pub struct IndexReader {
     lookup: Option<Mmap>,
     postings: Option<Mmap>,
     file_paths: Vec<String>,
+    file_table_id: crate::meta::FileTableId,
     /// File IDs sorted by path, for exact membership checks without duplicating
     /// every path string in a second collection.
     path_order: Vec<usize>,
@@ -94,7 +95,8 @@ impl IndexReader {
         // Load file paths. A truncated files.bin used to be silently accepted,
         // resulting in queries that returned empty file paths for high IDs.
         let files_data = std::fs::read(&files_path)?;
-        let file_entries = ondisk::decode_file_entries(&files_data)?;
+        let file_table_id = crate::meta::file_table_id(&files_data);
+        let file_entries = ondisk::decode_file_entries(ondisk::file_table_body(&files_data)?)?;
 
         // Validate that file IDs are dense (0..N) with no duplicates.
         // Without this, a corrupted files.bin declaring an id like
@@ -130,6 +132,7 @@ impl IndexReader {
             lookup,
             postings,
             file_paths,
+            file_table_id,
             path_order,
             num_entries,
         })
@@ -143,6 +146,7 @@ impl IndexReader {
             lookup: None,
             postings: None,
             file_paths: Vec::new(),
+            file_table_id: crate::meta::file_table_id(&[]),
             path_order: Vec::new(),
             num_entries: 0,
         }
@@ -221,6 +225,10 @@ impl IndexReader {
     /// Total number of indexed files.
     pub fn num_files(&self) -> usize {
         self.file_paths.len()
+    }
+
+    pub fn file_table_id(&self) -> crate::meta::FileTableId {
+        self.file_table_id
     }
 
     /// Total number of unique trigrams.
@@ -609,6 +617,7 @@ mod tests {
             lookup: opened.lookup,
             postings: opened.postings,
             file_paths: opened.file_paths,
+            file_table_id: opened.file_table_id,
             path_order: opened.path_order,
             num_entries: 0,
         };

--- a/tgrep-core/src/visibility.rs
+++ b/tgrep-core/src/visibility.rs
@@ -1,0 +1,104 @@
+//! Query-time visibility for a hidden-inclusive index.
+
+use std::collections::BTreeMap;
+use std::fs::Metadata;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::gitignore::IgnoreMatcher;
+
+/// Hidden file/directory entries, relative to the index root. Retaining the
+/// directory barriers (rather than marking all descendants) lets an explicitly
+/// named hidden search root expose its otherwise visible children.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PathVisibility {
+    hidden: BTreeMap<String, bool>,
+}
+
+impl PathVisibility {
+    pub fn is_empty(&self) -> bool {
+        self.hidden.is_empty()
+    }
+
+    /// Record an entry using metadata already obtained by a walk or watcher.
+    /// On Windows the walker caches directory-entry attributes, so this adds no
+    /// per-candidate filesystem queries to an indexed search.
+    pub fn record(
+        &mut self,
+        relative: &str,
+        is_dir: bool,
+        metadata: Option<&Metadata>,
+        ignore: Option<&IgnoreMatcher>,
+    ) -> bool {
+        if relative.is_empty() {
+            return false;
+        }
+        let path = Path::new(relative);
+        let hidden = is_hidden(path, metadata)
+            && !ignore.is_some_and(|matcher| matcher.is_whitelisted(path, is_dir));
+        if hidden {
+            self.hidden.insert(relative.to_string(), is_dir) != Some(is_dir)
+        } else {
+            self.hidden.remove(relative).is_some()
+        }
+    }
+
+    /// Ignore-file whitelists can admit a hidden entry even without --hidden.
+    pub fn apply_ignore_rules(&mut self, ignore: Option<&IgnoreMatcher>) {
+        if let Some(ignore) = ignore {
+            self.hidden
+                .retain(|path, is_dir| !ignore.is_whitelisted(Path::new(path), *is_dir));
+        }
+    }
+
+    /// `prefix` is the search-root-relative slice of the index root, with a
+    /// trailing slash (or empty for the whole index).
+    pub fn is_visible(&self, indexed: &str, prefix: &str, include_hidden: bool) -> bool {
+        let Some(relative) = indexed.strip_prefix(prefix) else {
+            return false;
+        };
+        if include_hidden {
+            return true;
+        }
+        relative
+            .match_indices('/')
+            .map(|(offset, _)| prefix.len() + offset)
+            .chain(std::iter::once(indexed.len()))
+            .all(|end| !self.hidden.contains_key(&indexed[..end]))
+    }
+}
+
+pub fn is_hidden(path: &Path, metadata: Option<&Metadata>) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        if metadata.is_some_and(|meta| meta.file_attributes() & 0x2 != 0) {
+            return true;
+        }
+    }
+    #[cfg(not(windows))]
+    let _ = metadata;
+    path.file_name()
+        .is_some_and(|name| name.as_encoded_bytes().starts_with(b"."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_hidden_root_does_not_hide_visible_descendants() {
+        let mut visibility = PathVisibility::default();
+        visibility.record(".github", true, None, None);
+        visibility.record(".github/.nested", true, None, None);
+        visibility.record(".secret", false, None, None);
+        assert!(!visibility.is_visible(".github/settings.txt", "", false));
+        assert!(visibility.is_visible(".github/settings.txt", ".github/", false));
+        assert!(!visibility.is_visible(".github/.nested/file", ".github/", false));
+        assert!(visibility.is_visible(".github/.nested/file", "", true));
+        assert!(visibility.is_visible("visible.txt", "", false));
+        assert!(!visibility.is_visible(".secret", "", false));
+        assert!(!visibility.is_visible("outside/file", ".github/", true));
+    }
+}

--- a/tgrep-core/src/walker.rs
+++ b/tgrep-core/src/walker.rs
@@ -2,6 +2,8 @@
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
+pub use ignore::overrides::{Override, OverrideBuilder};
+
 /// The size limit a walk applies when the caller does not name one.
 ///
 /// 64 MiB, which is a deliberate divergence from ripgrep's "no limit". The
@@ -90,6 +92,7 @@ pub struct WalkResult {
     /// `gitignore_files` so a matcher can apply them last, giving them
     /// precedence over `.gitignore` — the `ignore` crate's own ordering.
     pub ignore_files: Vec<PathBuf>,
+    pub visibility: crate::visibility::PathVisibility,
     pub skipped_binary: usize,
     pub skipped_error: usize,
     /// Files rejected only because they exceeded `WalkOptions::max_file_size`.
@@ -114,6 +117,10 @@ pub struct WalkOptions {
     pub collect_gitignore_files: bool,
     /// Directory names to exclude from walking (e.g., "vendor", "third_party").
     pub exclude_dirs: Vec<String>,
+    /// Absolute storage paths to prune, including custom index directories.
+    pub exclude_paths: Vec<PathBuf>,
+    /// Explicit search globs, which override ignore and hidden-file rules.
+    pub overrides: Option<Override>,
     /// `--max-depth`: descend at most this many directories below each root.
     pub max_depth: Option<usize>,
     /// `--one-file-system`: don't cross file system boundaries.
@@ -154,6 +161,8 @@ impl Default for WalkOptions {
             max_file_size: DEFAULT_MAX_FILE_SIZE,
             collect_gitignore_files: false,
             exclude_dirs: Vec::new(),
+            exclude_paths: Vec::new(),
+            overrides: None,
             max_depth: None,
             same_file_system: false,
             ignore_files: Vec::new(),
@@ -273,6 +282,8 @@ pub fn walk_dir_with_ignorecase(
     let listed_files = std::sync::Mutex::new(Vec::new());
     let gitignore_files = std::sync::Mutex::new(Vec::new());
     let ignore_files = std::sync::Mutex::new(Vec::new());
+    let visibility = std::sync::Mutex::new(crate::visibility::PathVisibility::default());
+    let visibility_ignorecase = ignorecase.clone();
     let skipped_binary = std::sync::atomic::AtomicUsize::new(0);
     let skipped_error = std::sync::atomic::AtomicUsize::new(0);
     let skipped_too_large = std::sync::atomic::AtomicUsize::new(0);
@@ -288,6 +299,8 @@ pub fn walk_dir_with_ignorecase(
         .flatten()
         .map(std::sync::Arc::new);
     let p4ignore_root = root.clone();
+    let exclude_paths = opts.exclude_paths.clone();
+    let overrides = opts.overrides.clone();
     let mut builder = WalkBuilder::new(&root);
     builder
         .hidden(!include_hidden)
@@ -302,10 +315,22 @@ pub fn walk_dir_with_ignorecase(
         .git_exclude(!opts.no_ignore && !opts.no_ignore_exclude)
         .ignore_case_insensitive(opts.ignore_files_case_insensitive)
         .filter_entry(move |entry| {
+            if exclude_paths
+                .iter()
+                .any(|path| entry.path().starts_with(path))
+            {
+                return false;
+            }
             if entry.file_name() == ".gitignore" {
                 return true;
             }
             let is_dir = entry.file_type().is_some_and(|kind| kind.is_dir());
+            if overrides
+                .as_ref()
+                .is_some_and(|overrides| overrides.matched(entry.path(), is_dir).is_whitelist())
+            {
+                return true;
+            }
             if let Some(ignorecase) = &ignorecase
                 && ignorecase.excludes(entry.path(), is_dir)
             {
@@ -320,6 +345,9 @@ pub fn walk_dir_with_ignorecase(
             !matcher.is_ignored(relative, is_dir)
         })
         .threads(opts.threads.unwrap_or_else(walker_thread_count).max(1));
+    if let Some(overrides) = &opts.overrides {
+        builder.overrides(overrides.clone());
+    }
     // `--ignore-file` is applied even under `--no-ignore`: the user asked for
     // these rules explicitly, so only `--no-ignore-files` turns them off.
     for path in &opts.ignore_files {
@@ -339,6 +367,7 @@ pub fn walk_dir_with_ignorecase(
         let listed_files = &listed_files;
         let gitignore_files = &gitignore_files;
         let ignore_files = &ignore_files;
+        let visibility = &visibility;
         let skipped_binary = &skipped_binary;
         let skipped_error = &skipped_error;
         let skipped_too_large = &skipped_too_large;
@@ -370,6 +399,7 @@ pub fn walk_dir_with_ignorecase(
                 // any ignore file matched by its own rules. See
                 // `gitignore::ignore_files_in`.
                 if collect_gitignore_files {
+                    record_visibility(visibility, walk_root, &entry);
                     let (gitignore, dot_ignore) = crate::gitignore::ignore_files_in(entry.path());
                     if let Some(path) = gitignore {
                         gitignore_files.lock().unwrap().push(path);
@@ -386,6 +416,9 @@ pub fn walk_dir_with_ignorecase(
             }
 
             let path = entry.path();
+            if collect_gitignore_files {
+                record_visibility(visibility, walk_root, &entry);
+            }
 
             let binary_extension = !search_binary && is_binary_extension(path);
             let too_large =
@@ -419,15 +452,71 @@ pub fn walk_dir_with_ignorecase(
         })
     });
 
+    let gitignore_files = gitignore_files.into_inner().unwrap();
+    let ignore_files = ignore_files.into_inner().unwrap();
+    let visibility = finish_visibility(
+        &root,
+        opts.no_ignore,
+        opts.no_require_git,
+        &gitignore_files,
+        &ignore_files,
+        visibility.into_inner().unwrap(),
+        visibility_ignorecase,
+    );
     WalkResult {
         files: files.into_inner().unwrap(),
         listed_files: listed_files.into_inner().unwrap(),
-        gitignore_files: gitignore_files.into_inner().unwrap(),
-        ignore_files: ignore_files.into_inner().unwrap(),
+        gitignore_files,
+        ignore_files,
+        visibility,
         skipped_binary: skipped_binary.into_inner(),
         skipped_error: skipped_error.into_inner(),
         skipped_too_large: skipped_too_large.into_inner(),
     }
+}
+
+fn record_visibility(
+    visibility: &std::sync::Mutex<crate::visibility::PathVisibility>,
+    root: &Path,
+    entry: &ignore::DirEntry,
+) {
+    #[cfg(windows)]
+    let metadata = entry.metadata().ok();
+    #[cfg(not(windows))]
+    let metadata = None;
+    if !crate::visibility::is_hidden(entry.path(), metadata.as_ref()) {
+        return;
+    }
+    if let Ok(relative) = entry.path().strip_prefix(root) {
+        visibility.lock().unwrap().record(
+            &relative.to_string_lossy().replace('\\', "/"),
+            entry.file_type().is_some_and(|kind| kind.is_dir()),
+            metadata.as_ref(),
+            None,
+        );
+    }
+}
+
+fn finish_visibility(
+    root: &Path,
+    no_ignore: bool,
+    no_require_git: bool,
+    gitignore_files: &[PathBuf],
+    ignore_files: &[PathBuf],
+    mut visibility: crate::visibility::PathVisibility,
+    ignorecase: Option<std::sync::Arc<crate::gitignore::CaseInsensitiveIgnore>>,
+) -> crate::visibility::PathVisibility {
+    if !no_ignore && !visibility.is_empty() {
+        let matcher = build_gitignore_matcher_from_files_with_ignorecase(
+            root,
+            gitignore_files,
+            ignore_files,
+            no_require_git,
+            ignorecase,
+        );
+        visibility.apply_ignore_rules(matcher.as_ref());
+    }
+    visibility
 }
 
 /// Build a point-query ignore matcher from `.gitignore` and `.ignore` files
@@ -487,6 +576,7 @@ pub struct MetaWalkResult {
     pub listed_files: Vec<String>,
     pub gitignore_files: Vec<PathBuf>,
     pub ignore_files: Vec<PathBuf>,
+    pub visibility: crate::visibility::PathVisibility,
     /// Entries or metadata reads the walk could not inspect.
     pub skipped_error: usize,
 }
@@ -500,6 +590,7 @@ pub struct MetaWalkResult {
 pub struct MetaWalkOptions {
     /// Directory names to prune from the walk.
     pub exclude_dirs: Vec<String>,
+    pub exclude_paths: Vec<PathBuf>,
     /// `--no-ignore`: don't respect any ignore files.
     pub no_ignore: bool,
     /// `--no-require-git`: respect gitignore rules outside a git repository.
@@ -525,6 +616,7 @@ impl Default for MetaWalkOptions {
     fn default() -> Self {
         Self {
             exclude_dirs: Vec::new(),
+            exclude_paths: Vec::new(),
             no_ignore: false,
             no_require_git: false,
             max_file_size: DEFAULT_MAX_FILE_SIZE,
@@ -536,8 +628,8 @@ impl Default for MetaWalkOptions {
 /// `.gitignore` / `.ignore` files encountered. No file content is read — this
 /// is used for stale file detection on startup.
 ///
-/// Hidden entries are skipped, matching the indexing walk. Ignore files are
-/// still found because every directory the walk descends into is probed
+/// Hidden entries are included, matching the indexing walk. Ignore files are
+/// found because every directory the walk descends into is probed
 /// explicitly via [`crate::gitignore::ignore_files_in`], which also catches
 /// ignore files that their own rules would have filtered out of the walk.
 pub fn walk_file_metadata(root: &Path, opts: &MetaWalkOptions) -> MetaWalkResult {
@@ -558,6 +650,8 @@ pub fn walk_file_metadata_with_ignorecase(
     let listed_files = std::sync::Mutex::new(Vec::new());
     let gitignore_files = std::sync::Mutex::new(Vec::new());
     let ignore_files = std::sync::Mutex::new(Vec::new());
+    let visibility = std::sync::Mutex::new(crate::visibility::PathVisibility::default());
+    let visibility_ignorecase = ignorecase.clone();
     let skipped_error = std::sync::atomic::AtomicUsize::new(0);
     let exclude: std::sync::Arc<Vec<String>> = std::sync::Arc::new(opts.exclude_dirs.clone());
     let p4ignore = (!no_ignore)
@@ -566,14 +660,23 @@ pub fn walk_file_metadata_with_ignorecase(
         .map(std::sync::Arc::new);
     let match_root = root.to_path_buf();
     let root = root.to_path_buf();
+    let exclude_paths = opts.exclude_paths.clone();
 
     let walker = WalkBuilder::new(&root)
-        .hidden(true)
+        .hidden(false)
+        .ignore(!no_ignore)
+        .parents(!no_ignore)
         .require_git(!opts.no_require_git)
         .git_ignore(!no_ignore)
         .git_global(!no_ignore)
         .git_exclude(!no_ignore)
         .filter_entry(move |entry| {
+            if exclude_paths
+                .iter()
+                .any(|path| entry.path().starts_with(path))
+            {
+                return false;
+            }
             let is_dir = entry.file_type().is_some_and(|kind| kind.is_dir());
             if let Some(ignorecase) = &ignorecase
                 && ignorecase.excludes(entry.path(), is_dir)
@@ -598,6 +701,7 @@ pub fn walk_file_metadata_with_ignorecase(
         let listed_files = &listed_files;
         let gitignore_files = &gitignore_files;
         let ignore_files = &ignore_files;
+        let visibility = &visibility;
         let skipped_error = &skipped_error;
         Box::new(move |entry| {
             let entry = match entry {
@@ -612,9 +716,9 @@ pub fn walk_file_metadata_with_ignorecase(
                 if should_skip_dir(&entry, &exclude) {
                     return ignore::WalkState::Skip;
                 }
+                record_visibility(visibility, &root, &entry);
                 // Probing each descended directory finds ignore files the walk
-                // itself filters out; see `gitignore::ignore_files_in`. It also
-                // keeps `hidden(true)` intact, so the metadata set is unchanged.
+                // itself filters out; see `gitignore::ignore_files_in`.
                 let (gitignore, dot_ignore) = crate::gitignore::ignore_files_in(entry.path());
                 if let Some(path) = gitignore {
                     gitignore_files.lock().unwrap().push(path);
@@ -630,6 +734,7 @@ pub fn walk_file_metadata_with_ignorecase(
             }
 
             let path = entry.path();
+            record_visibility(visibility, &root, &entry);
             let rel_path = match path.strip_prefix(&root) {
                 Ok(p) => p.to_string_lossy().replace('\\', "/"),
                 Err(_) => return ignore::WalkState::Continue,
@@ -675,11 +780,23 @@ pub fn walk_file_metadata_with_ignorecase(
         })
     });
 
+    let gitignore_files = gitignore_files.into_inner().unwrap();
+    let ignore_files = ignore_files.into_inner().unwrap();
+    let visibility = finish_visibility(
+        &root,
+        opts.no_ignore,
+        opts.no_require_git,
+        &gitignore_files,
+        &ignore_files,
+        visibility.into_inner().unwrap(),
+        visibility_ignorecase,
+    );
     MetaWalkResult {
         files: results.into_inner().unwrap(),
         listed_files: listed_files.into_inner().unwrap(),
-        gitignore_files: gitignore_files.into_inner().unwrap(),
-        ignore_files: ignore_files.into_inner().unwrap(),
+        gitignore_files,
+        ignore_files,
+        visibility,
         skipped_error: skipped_error.into_inner(),
     }
 }
@@ -1174,7 +1291,7 @@ mod tests {
     }
 
     #[test]
-    fn walk_file_metadata_collects_ignore_files_but_omits_them_from_metadata() {
+    fn walk_file_metadata_includes_nonignored_ignore_sources() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path().join("testdata");
         fs::create_dir_all(root.join("src")).unwrap();
@@ -1185,14 +1302,17 @@ mod tests {
 
         let result = walk_file_metadata(&root, &MetaWalkOptions::default());
 
-        // The dot-files themselves stay out of the metadata set, exactly as
-        // they did under the previous `hidden(true)` walk.
-        let names: Vec<_> = result
+        let mut names: Vec<_> = result
             .files
             .iter()
             .map(|f| f.relative_path.as_str())
             .collect();
-        assert_eq!(names, vec!["src/main.rs"]);
+        names.sort();
+        assert_eq!(
+            names,
+            vec![".gitignore", ".ignore", "src/.ignore", "src/main.rs"]
+        );
+        assert!(!result.visibility.is_visible(".ignore", "", false));
 
         let rel = |v: &[PathBuf]| {
             let mut out: Vec<_> = v
@@ -1377,7 +1497,7 @@ mod tests {
             "default stays git-gated: {gated:?}"
         );
 
-        let lifted: Vec<_> = walk_file_metadata(
+        let mut lifted: Vec<_> = walk_file_metadata(
             root,
             &MetaWalkOptions {
                 no_require_git: true,
@@ -1388,7 +1508,8 @@ mod tests {
         .into_iter()
         .map(|f| f.relative_path)
         .collect();
-        assert_eq!(lifted, vec!["src/main.rs".to_string()]);
+        lifted.sort();
+        assert_eq!(lifted, vec![".gitignore", "src/main.rs"]);
     }
 
     #[test]
@@ -1862,7 +1983,19 @@ mod tests {
         // walk decides what is missing from it. If they disagree, every build
         // indexes a file the next stale check evicts.
         let dir = ignorecase_fixture(true, &["src/main.rs", "src/Kept.TXT"]);
-        let indexed = sorted_filenames(&walk_dir(dir.path(), &WalkOptions::default()), dir.path());
+        let indexed = sorted_filenames(
+            &walk_dir(
+                dir.path(),
+                &WalkOptions {
+                    include_hidden: true,
+                    ..Default::default()
+                },
+            ),
+            dir.path(),
+        )
+        .into_iter()
+        .filter(|p| !p.starts_with(".git/"))
+        .collect::<Vec<_>>();
         let mut seen: Vec<String> = walk_file_metadata(dir.path(), &MetaWalkOptions::default())
             .files
             .iter()
@@ -1871,5 +2004,64 @@ mod tests {
             .collect();
         seen.sort();
         assert_eq!(indexed, seen);
+    }
+
+    #[test]
+    fn hidden_visibility_matches_walks_with_ignore_whitelists_and_scoped_roots() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::create_dir_all(root.join(".github/.nested")).unwrap();
+        fs::create_dir_all(root.join(".public-dir")).unwrap();
+        fs::write(
+            root.join(".gitignore"),
+            "!.public.txt\n!.public-dir/\nignored.txt\n.ignored\n",
+        )
+        .unwrap();
+        fs::write(root.join(".github/.ignore"), "blocked.txt\n").unwrap();
+        for name in [
+            "visible.txt",
+            ".secret.txt",
+            ".public.txt",
+            ".public-dir/visible.txt",
+            ".public-dir/.secret",
+            ".github/open.txt",
+            ".github/blocked.txt",
+            ".github/.nested/visible.txt",
+            "ignored.txt",
+            ".ignored",
+        ] {
+            fs::write(root.join(name), "needle").unwrap();
+        }
+        let broad = walk_dir(
+            root,
+            &WalkOptions {
+                include_hidden: true,
+                collect_gitignore_files: true,
+                ..Default::default()
+            },
+        );
+        let indexed = sorted_filenames(&broad, root);
+        assert!(indexed.contains(&".secret.txt".to_string()));
+        assert!(indexed.contains(&".github/open.txt".to_string()));
+        for excluded in ["ignored.txt", ".ignored", ".github/blocked.txt"] {
+            assert!(
+                !indexed.iter().any(|path| path == excluded),
+                "{excluded}: {indexed:?}"
+            );
+        }
+        for prefix in ["", ".github/"] {
+            let scoped_root = root.join(prefix);
+            let expected = sorted_filenames(
+                &walk_dir(&scoped_root, &WalkOptions::default()),
+                &scoped_root,
+            );
+            let actual: Vec<_> = indexed
+                .iter()
+                .filter(|path| broad.visibility.is_visible(path, prefix, false))
+                .filter_map(|path| path.strip_prefix(prefix).map(str::to_string))
+                .collect();
+            assert_eq!(actual, expected, "scope {prefix:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Make `index` and `serve` include hidden, **non-ignored** files by default, while ordinary searches continue to apply ripgrep-compatible hidden-file filtering. `serve --hidden` is accepted as a redundant flag; no new server startup flag is required.

This fixes the indexed-search performance regression for Copilot's existing arguments, including `--index-path <index> --files-with-matches --hidden --glob !.git --with-filename -- needle <root>`. Content, filename-only, count, JSON, and `--files` queries can use compatible local indexes or the server without dropping hidden matches or disabling ignore rules.

- Apply shared visibility before candidate limits/counts/output selection, respecting explicitly requested hidden roots and Windows hidden attributes without per-candidate filesystem probes.
- Carry the broader corpus through builds, resumed checkpoints, reloads, incremental publication, native watching, polling, and startup reconciliation. Discover and update ignore rules inside hidden directories; preserve `.gitignore`/`.ignore` and other existing ignore semantics.
- Exclude the actual configured index directory and its staging/retired generations, including custom storage inside the source tree. Preserve existing Windows generation retirement and rollback handling.
- Reconcile descendants when a native directory rename/removal reports only the directory, so old content/cache and filename entries do not survive.

## Compatibility and migration

Legacy, incomplete, or mismatched coverage metadata falls back to a filesystem scan. A current server reconciles older indexes and publishes hidden coverage only when it has established the eligible corpus; older servers must explicitly confirm support before a new client renders indexed results.

The new file-table format prevents older local readers from silently exposing hidden results by ignoring visibility metadata. Filename-only membership is published atomically with its visibility and file-table identity, including coherent startup hydration after interrupted publication. New readers retain legacy-format migration support. **Downgrading to an older binary requires rebuilding its index**, preferably at a separate `--index-path`.

`--hidden` never implies `--no-ignore`. Positive glob overrides intentionally scan because they can reinclude ignored files absent from the default index; negative-only globs such as `!.git` remain indexed. Other unsupported corpus-widening flags retain their scan fallback. README and agent guidance document these boundaries.

No package version bump, runtime-repository change, tag, or release is included.

## Validation

- Workspace unit tests: **261 CLI passed, 1 existing ignored; 257 core passed**.
- Related integration tests: **362 passed** — `ripgrep_compat` 230, `ripgrep_parity` 102, `indexed_hidden` 8, `indexed_files` 4, `concurrent_search` 7, `memory_cap` 1, `watcher_dot_ignore` 2, `watcher_watch_registration` 6, `warm_start_gitignore` 1, and `serve_max_filesize` 1. The final committed eight-test `indexed_hidden` target was rerun successfully.
- Focused regressions cover real Copilot arguments and backend diagnostics, ordinary visibility, ignored hidden files, legacy/incomplete coverage and migration, custom storage, Windows attributes, hidden updates/ignore transitions/restarts, interrupted filename publication/startup hydration, native directory rename, and retained publication rollback assertions.
- `cargo clippy --workspace --benches --locked --quiet -- -D warnings`, `cargo build --workspace --benches --locked --quiet`, `cargo fmt --all -- --check`, and Git whitespace checks passed.
- Independent acceptance against the frozen binary: **82 parity/lifecycle cases** (including native directory creation/rename/deletion with an active watcher) and **10 exact v1.0.8 reverse-client local/server cases**, all passed. Parent acceptance checked content/`-l`/`-c` routing and `--files` parity; Rust regressions separately assert filename backend diagnostics.